### PR TITLE
[CSM Portal] fix case-tabs pre-auth crash from PR #1628

### DIFF
--- a/apps/csm-portal/webapp/src/layouts/AppLayout.test.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppLayout.test.tsx
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// AppLayout pulls in a lot of chrome (header, sidebar, banners, the idle
+// timeout provider) that isn't relevant to the `showCaseTabs` gating under
+// test here, and a couple of those (useAppShell, useAsgardeo) need real
+// return shapes to avoid destructuring crashes unrelated to this test.
+vi.mock("@wso2/oxygen-ui", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@wso2/oxygen-ui")>()),
+  useAppShell: () => ({
+    state: { sidebarCollapsed: false, expandedMenus: [] },
+    actions: { toggleSidebar: vi.fn(), setActiveMenuItem: vi.fn(), toggleMenu: vi.fn() },
+  }),
+}));
+
+vi.mock("@asgardeo/react", () => ({
+  useAsgardeo: () => ({ isLoading: false, isSignedIn: true }),
+}));
+
+vi.mock("@context/linear-loader/LoaderContext", () => ({
+  useLoader: () => ({ isVisible: false }),
+}));
+
+vi.mock("@context/error-page/ErrorPageContext", () => ({
+  useErrorPageContext: () => ({ isErrorPageDisplayed: false }),
+}));
+
+vi.mock("@providers/IdleTimeoutProvider", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@context/case-tabs/CaseTabsContext", () => ({
+  CaseTabsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// The component under test for the actual bug: renders a marker (real
+// `CaseTabsContentHost` would instead mount a restored case tab's page,
+// which is what called `useCurrentUser` outside its provider and crashed).
+// Standing in for it here isolates the assertion to exactly what
+// `AppLayout`'s `showCaseTabs` prop controls: whether this renders at all.
+vi.mock("@features/case-tabs/components/CaseTabsWorkspace", () => ({
+  CaseTabsContentHost: () => <div data-testid="case-tabs-content-host" />,
+  CaseTabStripBar: () => null,
+}));
+
+vi.mock("@features/csm-recent/hooks/useRecentViews", () => ({
+  useSyncRecentViewsIdentity: () => undefined,
+}));
+
+vi.mock("@components/notification-banner/GlobalNotificationBanner", () => ({
+  default: () => null,
+}));
+vi.mock("@components/announcement-banner/HtmlAnnouncementBanner", () => ({
+  default: () => null,
+}));
+vi.mock("@components/mobile-app-banner/MobileAppBanner", () => ({ default: () => null }));
+vi.mock("@components/top-banner/TopBanner", () => ({ default: () => null }));
+vi.mock("@components/header/Header", () => ({ default: () => <div data-testid="header" /> }));
+vi.mock("@components/side-nav-bar/CsmSideBar", () => ({ default: () => null }));
+
+const { default: AppLayout } = await import("./AppLayout");
+
+function renderAppLayout(props: { showCaseTabs?: boolean } = {}) {
+  return render(
+    <MemoryRouter initialEntries={["/cases/abc123"]}>
+      <AppLayout {...props}>
+        <div data-testid="routed-page" />
+      </AppLayout>
+    </MemoryRouter>,
+  );
+}
+
+describe("AppLayout showCaseTabs gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders CaseTabsContentHost by default (CurrentUserProvider is always an ancestor on this path)", () => {
+    renderAppLayout();
+
+    expect(screen.getByTestId("case-tabs-content-host")).toBeInTheDocument();
+    expect(screen.getByTestId("routed-page")).toBeInTheDocument();
+  });
+
+  it("does not render CaseTabsContentHost when showCaseTabs=false, the setting AuthGuard's AuthPendingShell uses because it has no CurrentUserProvider ancestor", () => {
+    renderAppLayout({ showCaseTabs: false });
+
+    expect(screen.queryByTestId("case-tabs-content-host")).not.toBeInTheDocument();
+    // The routed page (here: AuthPendingShell's own RouteSuspenseFallback
+    // stand-in) still renders — only the case-tabs host is suppressed.
+    expect(screen.getByTestId("routed-page")).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
@@ -73,11 +73,22 @@ interface AppLayoutProps {
    * the sidebar from flashing on screen for one frame before that context
    * update lands. */
   minimalHeader?: boolean;
+  /** Gates whether `<CaseTabsContentHost />` (below) renders at all. Defaults
+   * to `true` — every normal, signed-in render path has a
+   * `CurrentUserProvider` ancestor and case tabs are safe to mount
+   * immediately. Must be `false` wherever `AppLayout` is rendered WITHOUT
+   * that ancestor (see `AuthGuard.tsx`'s `AuthPendingShell`): a restored
+   * open case tab renders `CsmCaseDetailPage`, which calls `useCurrentUser`
+   * via `useFindMyOngoingCases`, and that throws outside the provider. Like
+   * `minimalHeader`, applied in the same render as `children`, not a render
+   * later via an effect. */
+  showCaseTabs?: boolean;
 }
 
 export default function AppLayout({
   children,
   minimalHeader = false,
+  showCaseTabs = true,
 }: AppLayoutProps): JSX.Element {
   const location = useLocation();
   const mainContentRef = useRef<HTMLDivElement>(null);
@@ -251,7 +262,7 @@ export default function AppLayout({
                         own element now renders nothing itself once its tab
                         is open (see CaseDetailRouteSync), so there's no
                         double-render. */}
-                    <CaseTabsContentHost />
+                    {showCaseTabs && <CaseTabsContentHost />}
                     {children || <Outlet />}
                   </Suspense>
                 )}

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.test.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.test.tsx
@@ -67,11 +67,13 @@ vi.mock("@layouts/AppLayout", () => ({
   default: ({
     children,
     minimalHeader = false,
+    showCaseTabs = true,
   }: {
     children?: React.ReactNode;
     minimalHeader?: boolean;
+    showCaseTabs?: boolean;
   }) => {
-    appLayoutPropsMock({ minimalHeader });
+    appLayoutPropsMock({ minimalHeader, showCaseTabs });
     return <>{children}</>;
   },
 }));
@@ -295,7 +297,7 @@ describe("AuthGuard's response to a /users/me failure once signed in", () => {
     // synchronously from the same render as `children`, not settled a render
     // later via an effect, so the sidebar never flashes on screen first.
     for (const call of appLayoutPropsMock.mock.calls) {
-      expect(call[0]).toEqual({ minimalHeader: true });
+      expect(call[0]).toEqual({ minimalHeader: true, showCaseTabs: true });
     }
     expect(appLayoutPropsMock).toHaveBeenCalled();
   });
@@ -342,7 +344,13 @@ describe("AuthGuard's response to a /users/me failure once signed in", () => {
     ).not.toBeInTheDocument();
     // minimalHeader true here too: the routed page (and its sidebar) has no
     // business being reachable before we know this caller is authorized.
-    expect(appLayoutPropsMock).toHaveBeenCalledWith({ minimalHeader: true });
+    // showCaseTabs stays true (the default): CurrentUserProvider is still an
+    // ancestor here, just its data hasn't resolved yet, and useCurrentUser
+    // only throws with no provider at all, not while it's loading.
+    expect(appLayoutPropsMock).toHaveBeenCalledWith({
+      minimalHeader: true,
+      showCaseTabs: true,
+    });
   });
 
   it("does not show the not-authorized page for an unrelated /users/me failure (e.g. 500)", async () => {
@@ -364,6 +372,35 @@ describe("AuthGuard's response to a /users/me failure once signed in", () => {
     expect(
       screen.queryByText("You don't have access to this portal yet"),
     ).not.toBeInTheDocument();
-    expect(appLayoutPropsMock).toHaveBeenCalledWith({ minimalHeader: false });
+    expect(appLayoutPropsMock).toHaveBeenCalledWith({
+      minimalHeader: false,
+      showCaseTabs: true,
+    });
+  });
+});
+
+describe("AuthGuard's AppLayout showCaseTabs wiring while auth itself hasn't resolved", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    asgardeoState.isSignedIn = false;
+    currentUserState.isLoading = false;
+    currentUserState.isError = false;
+    currentUserState.error = null;
+    signInMock.mockResolvedValue(undefined);
+  });
+
+  it("passes showCaseTabs=false to AppLayout while signed out (no CurrentUserProvider ancestor), so a restored case tab can't crash on a cold reload", async () => {
+    signInSilentlyMock.mockResolvedValue(false);
+
+    await act(async () => {
+      renderAuthGuard();
+    });
+
+    await waitFor(() => expect(signInMock).toHaveBeenCalledTimes(1));
+    expect(appLayoutPropsMock).toHaveBeenCalled();
+    for (const call of appLayoutPropsMock.mock.calls) {
+      expect(call[0]).toMatchObject({ showCaseTabs: false });
+    }
   });
 });

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
@@ -46,7 +46,13 @@ import { isForbiddenError, isUnauthorizedError } from "@utils/ApiError";
  */
 function AuthPendingShell(): JSX.Element {
   return (
-    <AppLayout>
+    // showCaseTabs={false}: there is no CurrentUserProvider in scope here, and
+    // AppLayout's own CaseTabsContentHost renders a restored open case tab's
+    // page unconditionally (alongside, not instead of, these children) —
+    // that page calls useCurrentUser too (via useFindMyOngoingCases), which
+    // throws outside the provider. Same crash the children-suppression above
+    // already guards against, just via a different render path.
+    <AppLayout showCaseTabs={false}>
       <RouteSuspenseFallback />
     </AppLayout>
   );

--- a/apps/csm-portal/webapp/vite.config.ts
+++ b/apps/csm-portal/webapp/vite.config.ts
@@ -132,6 +132,15 @@ const viteConfig = defineConfig({
     },
   },
   envPrefix: ["CSM_PORTAL_"],
+  // TEMPORARY debug measure: emit referenced (non-hidden) sourcemaps so a
+  // staging deploy shows de-minified stack traces in the browser devtools
+  // console while root-causing a live bug. There is no error-tracking
+  // service in this stack to receive uploaded maps, so "hidden" sourcemaps
+  // would be useless here -- referenced maps are what a browser's devtools
+  // auto-fetches and resolves against. Revert once the bug is diagnosed.
+  build: {
+    sourcemap: true,
+  },
   server: {
     port: 3001,
     strictPort: true,

--- a/apps/csm-portal/webapp/vite.config.ts
+++ b/apps/csm-portal/webapp/vite.config.ts
@@ -132,15 +132,6 @@ const viteConfig = defineConfig({
     },
   },
   envPrefix: ["CSM_PORTAL_"],
-  // TEMPORARY debug measure: emit referenced (non-hidden) sourcemaps so a
-  // staging deploy shows de-minified stack traces in the browser devtools
-  // console while root-causing a live bug. There is no error-tracking
-  // service in this stack to receive uploaded maps, so "hidden" sourcemaps
-  // would be useless here -- referenced maps are what a browser's devtools
-  // auto-fetches and resolves against. Revert once the bug is diagnosed.
-  build: {
-    sourcemap: true,
-  },
   server: {
     port: 3001,
     strictPort: true,


### PR DESCRIPTION
## Purpose

PR #1628 (merged) shipped the CSM webapp as a single JS bundle to eliminate mid-session
route-chunk-fetch freezes. Immediately after that deploy, a real crash surfaced:
`useCurrentUser must be used within a CurrentUserProvider`, thrown on a cold reload of a
browser tab that had a case detail page open.

That fix was pushed to this same branch, but landed on the fork *after* #1628 had already
merged, so it never made it into `main`. This PR carries just the follow-up commits.

## Root cause

`AppLayout.tsx` rendered the open-case-tabs host (`CaseTabsContentHost`) unconditionally,
regardless of whether auth had resolved yet. `AuthPendingShell` (shown while sign-in is
still in flight, with no `CurrentUserProvider` ancestor) already suppressed the routed page
for exactly this reason, but the case-tabs host bypassed that suppression. On a cold
reload with a case tab restored from before the deploy, it tried to render that tab's page
immediately, which calls `useCurrentUser()` and throws.

This is a pre-existing architectural gap, not something #1628 introduced directly — but
#1628's static imports removed the chunk-fetch delay that used to give auth time to resolve
first, so the race went from rare to essentially guaranteed.

## Goals

- Stop the crash on cold reload with an open case tab.
- No change to case-tab behavior once auth has resolved normally.

## Approach

Added a `showCaseTabs?: boolean` prop to `AppLayout` (default `true`), following the same
pattern already used for the existing `minimalHeader` prop — applied synchronously in the
same render as `children`, not a flag settled a render later via an effect.
`AuthPendingShell` now passes `showCaseTabs={false}`. Chose unmount over hide: the case-tabs
host has no side effects that must keep running regardless of visibility, and a tab can't
have meaningful in-progress state to lose on a cold reload before auth even resolves.

Also reverts a temporary sourcemap-enabling change from the same branch, used only for a
one-off offline debugging session to demangle the crash's stack trace — never actually
deployed, and must not ship on a publicly-reachable staging site.

## Release note

Fixes a crash when reloading a browser tab that had a case page open, immediately after a
new deploy.

## Documentation

N/A — internal bug fix, no user-facing behavior or docs change beyond the crash no longer
happening.

## Security checks

- Secure coding standards followed: yes
- FindSecurityBugs: N/A (TypeScript/JS, not Go/Java) — `eslint` ran clean (0 errors, 2
  pre-existing warnings unrelated to this change)
- No secrets committed: yes

## Related PRs

Follow-up to #1628 (merged) — carries commits that were pushed to the same branch after
that PR had already merged, so they never landed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented restored case tabs from loading during authentication states where user information is unavailable.
  * Improved cold-start behavior for signed-out users, avoiding errors while authentication is pending.

* **Enhancements**
  * Added control over whether case tabs appear in the application layout, with tabs shown by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->