### PR TITLE
[CSM Portal] CSM BFF: outages, incident handoff, verify CR/SR-metadata pass through free

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -93,6 +93,7 @@ func main() {
 	problemHandler := handler.NewProblemHandler(customerEntityClient)
 	incidentTaskHandler := handler.NewIncidentTaskHandler(customerEntityClient)
 	alertHandler := handler.NewAlertHandler(customerEntityClient)
+	outageHandler := handler.NewOutageHandler(customerEntityClient)
 
 	// Google Chat is not yet configured for every deployment, so its spaces
 	// are read with os.Getenv (never mustEnv) — a missing or malformed value
@@ -233,6 +234,7 @@ func main() {
 	mux.HandleFunc("POST /incidents/{id}/comments", incidentHandler.CreateIncidentComment)
 	mux.HandleFunc("POST /incidents/{id}/comments/search", incidentHandler.SearchIncidentComments)
 	mux.HandleFunc("POST /incidents/{id}/activities/search", incidentHandler.SearchIncidentActivities)
+	mux.HandleFunc("POST /incidents/{id}/specialist-handoffs", incidentHandler.HandOffIncidentToSpecialist)
 	mux.HandleFunc("GET /alerts/{id}", alertHandler.GetAlert)
 	mux.HandleFunc("GET /smart-alerts/{id}", alertHandler.GetSmartAlert)
 	mux.HandleFunc("POST /change-requests/{id}/comments", changeRequestHandler.CreateChangeRequestComment)
@@ -245,6 +247,16 @@ func main() {
 	mux.HandleFunc("GET /incident-tasks/{id}", incidentTaskHandler.GetIncidentTask)
 	mux.HandleFunc("POST /incident-tasks/search", incidentTaskHandler.SearchIncidentTasks)
 	mux.HandleFunc("POST /incident-tasks/aggregate", incidentTaskHandler.AggregateIncidentTasks)
+	mux.HandleFunc("POST /outages", outageHandler.CreateOutage)
+	mux.HandleFunc("POST /outages/search", outageHandler.SearchOutages)
+	// Registered before the {id} wildcard purely for readability — net/http's
+	// ServeMux resolves by specificity, not registration order, so this
+	// literal path wins over the wildcard regardless.
+	mux.HandleFunc("GET /outages/metadata", outageHandler.GetOutageMetadata)
+	mux.HandleFunc("GET /outages/{id}", outageHandler.GetOutage)
+	mux.HandleFunc("PATCH /outages/{id}", outageHandler.PatchOutage)
+	mux.HandleFunc("POST /outages/{id}/communications", outageHandler.AddOutageCommunication)
+	mux.HandleFunc("POST /outages/{id}/communications/search", outageHandler.SearchOutageCommunications)
 	// Called manually today; not yet wired into real incident/case creation.
 	mux.HandleFunc("POST /notifications/google-chat/alerts", notificationHandler.PostGoogleChatAlert)
 

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -222,6 +222,13 @@ func (c *CustomerEntityClient) SearchIncidentActivities(ctx context.Context, id 
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/incidents/%s/activities/search", url.PathEscape(id)), body)
 }
 
+// HandOffIncidentToSpecialist calls POST /incidents/{id}/specialist-handoffs on the entity
+// service: hands the incident off to its specialist group in one atomic call. Response is
+// returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) HandOffIncidentToSpecialist(ctx context.Context, id string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/incidents/%s/specialist-handoffs", url.PathEscape(id)), body)
+}
+
 // SearchProblems calls POST /problems/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
 func (c *CustomerEntityClient) SearchProblems(ctx context.Context, body []byte) ([]byte, error) {
@@ -581,4 +588,46 @@ func (c *CustomerEntityClient) GetAlert(ctx context.Context, id string) ([]byte,
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *CustomerEntityClient) GetSmartAlert(ctx context.Context, id string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/smart-alerts/%s", url.PathEscape(id)), nil)
+}
+
+// CreateOutage calls POST /outages on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) CreateOutage(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/outages", body)
+}
+
+// SearchOutages calls POST /outages/search on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) SearchOutages(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/outages/search", body)
+}
+
+// GetOutage calls GET /outages/{id} on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) GetOutage(ctx context.Context, id string) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/outages/%s", url.PathEscape(id)), nil)
+}
+
+// PatchOutage calls PATCH /outages/{id} on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) PatchOutage(ctx context.Context, id string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/outages/%s", url.PathEscape(id)), body)
+}
+
+// AddOutageCommunication calls POST /outages/{id}/communications on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) AddOutageCommunication(ctx context.Context, id string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/outages/%s/communications", url.PathEscape(id)), body)
+}
+
+// SearchOutageCommunications calls POST /outages/{id}/communications/search on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) SearchOutageCommunications(ctx context.Context, id string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/outages/%s/communications/search", url.PathEscape(id)), body)
+}
+
+// GetOutageMetadata calls GET /outages/metadata on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) GetOutageMetadata(ctx context.Context) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, "/outages/metadata", nil)
 }

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -524,6 +524,7 @@ type mockEntityIncidentClient struct {
 	createCommentFn            func(ctx context.Context, body []byte) ([]byte, error)
 	searchCommentsFn           func(ctx context.Context, body []byte) ([]byte, error)
 	searchIncidentActivitiesFn func(ctx context.Context, id string, body []byte) ([]byte, error)
+	handOffIncidentFn          func(ctx context.Context, id string, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityIncidentClient) SearchIncidents(ctx context.Context, body []byte) ([]byte, error) {
@@ -580,6 +581,13 @@ func (m *mockEntityIncidentClient) SearchIncidentActivities(ctx context.Context,
 		return m.searchIncidentActivitiesFn(ctx, id, body)
 	}
 	return []byte(`{"activity":[],"total":0,"limit":20,"offset":0,"hasMore":false}`), nil
+}
+
+func (m *mockEntityIncidentClient) HandOffIncidentToSpecialist(ctx context.Context, id string, body []byte) ([]byte, error) {
+	if m.handOffIncidentFn != nil {
+		return m.handOffIncidentFn(ctx, id, body)
+	}
+	return []byte(`{"message":"Incident handed off to specialist group","handoff":{"assignmentGroup":{"id":"11111111-1111-1111-1111-111111111111","name":"Specialist Group"},"previousAssignmentGroup":null,"reasonCode":"no-runbook","reasonDescription":"Runbook is not available","escalationTeam":null,"task":{"id":"22222222-2222-2222-2222-222222222222","number":"TASK0000001","subject":"[Runbook Task] test"},"githubIssue":{"url":"https://github.com/example/repo/issues/1","number":1,"repo":"repo"},"githubIssueError":null,"incident":{}}}`), nil
 }
 
 // ----- mock entity problem client -----
@@ -752,6 +760,67 @@ func (m *mockEntityChangeRequestClient) DecideChangeRequestApproval(ctx context.
 		return m.decideChangeRequestApprovalFn(ctx, id, body)
 	}
 	return []byte(`{"id":"11111111-1111-1111-1111-111111111111","state":"approved"}`), nil
+}
+
+// ----- mock entity outage client -----
+
+type mockEntityOutageClient struct {
+	createOutageFn               func(ctx context.Context, body []byte) ([]byte, error)
+	searchOutagesFn              func(ctx context.Context, body []byte) ([]byte, error)
+	getOutageFn                  func(ctx context.Context, id string) ([]byte, error)
+	patchOutageFn                func(ctx context.Context, id string, body []byte) ([]byte, error)
+	addOutageCommunicationFn     func(ctx context.Context, id string, body []byte) ([]byte, error)
+	searchOutageCommunicationsFn func(ctx context.Context, id string, body []byte) ([]byte, error)
+	getOutageMetadataFn          func(ctx context.Context) ([]byte, error)
+}
+
+func (m *mockEntityOutageClient) CreateOutage(ctx context.Context, body []byte) ([]byte, error) {
+	if m.createOutageFn != nil {
+		return m.createOutageFn(ctx, body)
+	}
+	return []byte(`{"message":"Outage created successfully","outage":{"id":"11111111-1111-1111-1111-111111111111","number":"OUT0001881"}}`), nil
+}
+
+func (m *mockEntityOutageClient) SearchOutages(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchOutagesFn != nil {
+		return m.searchOutagesFn(ctx, body)
+	}
+	return []byte(`{"outages":[],"total":0,"limit":20,"offset":0,"appliedBeginFrom":"","beginFromDefaulted":false}`), nil
+}
+
+func (m *mockEntityOutageClient) GetOutage(ctx context.Context, id string) ([]byte, error) {
+	if m.getOutageFn != nil {
+		return m.getOutageFn(ctx, id)
+	}
+	return []byte(`{"id":"` + id + `"}`), nil
+}
+
+func (m *mockEntityOutageClient) PatchOutage(ctx context.Context, id string, body []byte) ([]byte, error) {
+	if m.patchOutageFn != nil {
+		return m.patchOutageFn(ctx, id, body)
+	}
+	return []byte(`{"message":"Outage updated successfully","outage":{"id":"` + id + `"}}`), nil
+}
+
+func (m *mockEntityOutageClient) AddOutageCommunication(ctx context.Context, id string, body []byte) ([]byte, error) {
+	if m.addOutageCommunicationFn != nil {
+		return m.addOutageCommunicationFn(ctx, id, body)
+	}
+	return []byte(`{"message":"Communication added successfully","communication":{"id":"11111111-1111-1111-1111-111111111111"}}`), nil
+}
+
+func (m *mockEntityOutageClient) SearchOutageCommunications(ctx context.Context, id string, body []byte) ([]byte, error) {
+	if m.searchOutageCommunicationsFn != nil {
+		return m.searchOutageCommunicationsFn(ctx, id, body)
+	}
+	return []byte(`{"communications":[],"total":0,"limit":20,"offset":0}`), nil
+}
+
+func (m *mockEntityOutageClient) GetOutageMetadata(ctx context.Context) ([]byte, error) {
+	if m.getOutageMetadataFn != nil {
+		return m.getOutageMetadataFn(ctx)
+	}
+	return []byte(`{"types":[],"statuses":[],"communicationChannels":[],"statusPageClouds":[]}`), nil
 }
 
 // ----- mock entity IT service client -----

--- a/apps/csm-portal/backend/internal/handler/incidents.go
+++ b/apps/csm-portal/backend/internal/handler/incidents.go
@@ -37,6 +37,7 @@ type entityIncidentClient interface {
 	CreateComment(ctx context.Context, body []byte) ([]byte, error)
 	SearchComments(ctx context.Context, body []byte) ([]byte, error)
 	SearchIncidentActivities(ctx context.Context, id string, body []byte) ([]byte, error)
+	HandOffIncidentToSpecialist(ctx context.Context, id string, body []byte) ([]byte, error)
 }
 
 // searchIncidentsRequest mirrors the enum/format-constrained fields of the documented
@@ -87,6 +88,9 @@ var (
 	validIncidentStates = map[string]bool{
 		"NEW": true, "IN_PROGRESS": true, "ON_HOLD": true, "RESOLVED": true, "CLOSED": true, "CANCELLED": true,
 	}
+
+	validHandoffReasonCodes     = map[string]bool{"no-runbook": true, "runbook-not-working": true}
+	validHandoffEscalationTeams = map[string]bool{"choreo-runtime-team": true, "choreo-apim-team": true}
 )
 
 // createIncidentRequest mirrors the enum/format-constrained fields of the documented
@@ -310,6 +314,33 @@ func validateSearchIncidentsBody(body []byte) bool {
 		return false
 	}
 	if req.SortBy.Order != "" && !validIncidentSortOrders[req.SortBy.Order] {
+		return false
+	}
+	return true
+}
+
+// handOffIncidentRequest mirrors the enum-constrained fields of the documented
+// HandOffIncidentToSpecialistRequest schema. It is decoded only to validate those
+// fields at the boundary; the original raw body is still forwarded to the entity
+// service unchanged.
+type handOffIncidentRequest struct {
+	ReasonCode     string  `json:"reasonCode"`
+	EscalationTeam *string `json:"escalationTeam"`
+}
+
+// validateHandOffIncidentBody checks the required reasonCode enum and, when present,
+// the escalationTeam enum, so obviously invalid requests are rejected before reaching
+// the entity service. createGithubIssue is a plain boolean with no enum to check; an
+// invalid type there is caught by json.Unmarshal.
+func validateHandOffIncidentBody(body []byte) bool {
+	var req handOffIncidentRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	if !validHandoffReasonCodes[req.ReasonCode] {
+		return false
+	}
+	if req.EscalationTeam != nil && *req.EscalationTeam != "" && !validHandoffEscalationTeams[*req.EscalationTeam] {
 		return false
 	}
 	return true
@@ -660,6 +691,77 @@ func (h *IncidentHandler) SearchIncidentComments(w http.ResponseWriter, r *http.
 		slog.ErrorContext(r.Context(), "entity SearchComments failed", "userID", user.UserID, "incidentID", id, "err", err)
 		mapUpstreamErrorGeneric(w, err, "Failed to search incident comments.")
 		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// handOffIncidentResponseEnvelope is the subset of HandOffIncidentToSpecialistResponse
+// this handler decodes for observability only. It is never re-marshalled or used to
+// build the caller's response -- the raw upstream body is forwarded verbatim so
+// githubIssueError (and every other field) reaches the caller unchanged.
+type handOffIncidentResponseEnvelope struct {
+	Handoff struct {
+		GithubIssueError *string `json:"githubIssueError"`
+	} `json:"handoff"`
+}
+
+// HandOffIncidentToSpecialist handles POST /incidents/{id}/specialist-handoffs.
+// The handoff itself can succeed (ServiceNow state committed) while the internal
+// GitHub issue creation fails -- the entity service reports that as a non-nil
+// handoff.githubIssueError on an otherwise-200 response rather than an error status.
+// This is surfaced explicitly in the server log rather than left to a caller who
+// might not inspect the nested field, so a silent partial failure is still visible
+// operator-side even if a webapp caller ever missed it. The response body itself is
+// forwarded unchanged, so the caller always has the field to check too.
+func (h *IncidentHandler) HandOffIncidentToSpecialist(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	if !validateHandOffIncidentBody(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.HandOffIncidentToSpecialist(r.Context(), id, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity HandOffIncidentToSpecialist failed", "userID", user.UserID, "incidentID", id, "err", err)
+		mapUpstreamError(w, err, "Failed to hand off incident to specialist group.")
+		return
+	}
+
+	var envelope handOffIncidentResponseEnvelope
+	if err := json.Unmarshal(result, &envelope); err != nil {
+		slog.WarnContext(r.Context(), "entity HandOffIncidentToSpecialist: decode response for githubIssueError check failed", "userID", user.UserID, "incidentID", id, "err", err)
+	} else if envelope.Handoff.GithubIssueError != nil {
+		slog.WarnContext(r.Context(), "incident handed off to specialist group but internal issue creation failed",
+			"userID", user.UserID, "incidentID", id, "githubIssueError", *envelope.Handoff.GithubIssueError)
 	}
 
 	writeJSON(w, http.StatusOK, result)

--- a/apps/csm-portal/backend/internal/handler/incidents_test.go
+++ b/apps/csm-portal/backend/internal/handler/incidents_test.go
@@ -691,3 +691,183 @@ func TestAggregateIncidents(t *testing.T) {
 		}
 	})
 }
+
+func TestHandOffIncidentToSpecialist(t *testing.T) {
+	const incidentID = "11111111-1111-1111-1111-111111111111"
+	const validBody = `{"reasonCode":"no-runbook","escalationTeam":"choreo-apim-team","createGithubIssue":true}`
+
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := httptest.NewRequest(http.MethodPost, "/incidents/"+incidentID+"/specialist-handoffs", strings.NewReader(validBody))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.HandOffIncidentToSpecialist(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty incident ID", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents//specialist-handoffs", strings.NewReader(validBody)))
+		w := httptest.NewRecorder()
+		h.HandOffIncidentToSpecialist(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID incident ID", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/inc-42/specialist-handoffs", strings.NewReader(validBody)))
+		r.SetPathValue("id", "inc-42")
+		w := httptest.NewRecorder()
+		h.HandOffIncidentToSpecialist(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/"+incidentID+"/specialist-handoffs", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.HandOffIncidentToSpecialist(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/"+incidentID+"/specialist-handoffs", strings.NewReader(`not-json`)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.HandOffIncidentToSpecialist(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects missing reasonCode", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/"+incidentID+"/specialist-handoffs", strings.NewReader(`{}`)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.HandOffIncidentToSpecialist(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects unknown reasonCode", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/"+incidentID+"/specialist-handoffs", strings.NewReader(`{"reasonCode":"give-up"}`)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.HandOffIncidentToSpecialist(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects unknown escalationTeam", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/"+incidentID+"/specialist-handoffs", strings.NewReader(`{"reasonCode":"no-runbook","escalationTeam":"some-other-team"}`)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.HandOffIncidentToSpecialist(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("accepts a body with reasonCode only", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/"+incidentID+"/specialist-handoffs", strings.NewReader(`{"reasonCode":"runbook-not-working"}`)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.HandOffIncidentToSpecialist(w, r)
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards ID and body to upstream and returns 200 with response", func(t *testing.T) {
+		var capturedID string
+		var capturedBody []byte
+		client := &mockEntityIncidentClient{
+			handOffIncidentFn: func(_ context.Context, id string, body []byte) ([]byte, error) {
+				capturedID = id
+				capturedBody = body
+				return []byte(`{"message":"Incident handed off to specialist group","handoff":{"assignmentGroup":{"id":"33333333-3333-3333-3333-333333333333","name":"Choreo APIM Special Ops"},"previousAssignmentGroup":null,"reasonCode":"no-runbook","reasonDescription":"Runbook is not available","escalationTeam":"choreo-apim-team","task":{"id":"44444444-4444-4444-4444-444444444444","number":"TASK0000123","subject":"[Runbook Task] test"},"githubIssue":{"url":"https://github.com/example/repo/issues/1","number":1,"repo":"repo"},"githubIssueError":null,"incident":{"id":"` + incidentID + `"}}}`), nil
+			},
+		}
+		h := NewIncidentHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/"+incidentID+"/specialist-handoffs", strings.NewReader(validBody)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.HandOffIncidentToSpecialist(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedID != incidentID {
+			t.Errorf("upstream received id %q, want %q", capturedID, incidentID)
+		}
+		if string(capturedBody) != validBody {
+			t.Errorf("upstream received body %q, want %q", capturedBody, validBody)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["message"] != "Incident handed off to specialist group" {
+			t.Errorf("message = %v, want %q", resp["message"], "Incident handed off to specialist group")
+		}
+	})
+
+	// A handoff can succeed (ServiceNow state committed) with the internal GitHub
+	// issue missing -- the upstream response is still 200 with a non-nil
+	// handoff.githubIssueError. This must reach the caller unchanged rather than
+	// being swallowed or reported as a clean success with the field stripped.
+	t.Run("passes through a non-nil githubIssueError on an otherwise-successful handoff", func(t *testing.T) {
+		client := &mockEntityIncidentClient{
+			handOffIncidentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				return []byte(`{"message":"Incident handed off to specialist group","handoff":{"assignmentGroup":{"id":"33333333-3333-3333-3333-333333333333","name":"Choreo APIM Special Ops"},"previousAssignmentGroup":null,"reasonCode":"no-runbook","reasonDescription":"Runbook is not available","escalationTeam":null,"task":{"id":"44444444-4444-4444-4444-444444444444","number":"TASK0000123","subject":"[Runbook Task] test"},"githubIssue":null,"githubIssueError":"GitHub issue creation failed (401)","incident":{"id":"` + incidentID + `"}}}`), nil
+			},
+		}
+		h := NewIncidentHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/"+incidentID+"/specialist-handoffs", strings.NewReader(validBody)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.HandOffIncidentToSpecialist(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		resp := decodeJSON[map[string]any](t, w)
+		handoff, ok := resp["handoff"].(map[string]any)
+		if !ok {
+			t.Fatalf("response has no handoff object: %v", resp)
+		}
+		if handoff["githubIssueError"] != "GitHub issue creation failed (401)" {
+			t.Errorf("githubIssueError = %v, want %q", handoff["githubIssueError"], "GitHub issue creation failed (401)")
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to hand off incident to specialist group.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityIncidentClient{
+					handOffIncidentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewIncidentHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/"+incidentID+"/specialist-handoffs", strings.NewReader(validBody)))
+				r.SetPathValue("id", incidentID)
+				w := httptest.NewRecorder()
+				h.HandOffIncidentToSpecialist(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/internal/handler/outages.go
+++ b/apps/csm-portal/backend/internal/handler/outages.go
@@ -1,0 +1,403 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+)
+
+// entityOutageClient abstracts the entity service outage operations used by OutageHandler.
+type entityOutageClient interface {
+	CreateOutage(ctx context.Context, body []byte) ([]byte, error)
+	SearchOutages(ctx context.Context, body []byte) ([]byte, error)
+	GetOutage(ctx context.Context, id string) ([]byte, error)
+	PatchOutage(ctx context.Context, id string, body []byte) ([]byte, error)
+	AddOutageCommunication(ctx context.Context, id string, body []byte) ([]byte, error)
+	SearchOutageCommunications(ctx context.Context, id string, body []byte) ([]byte, error)
+	GetOutageMetadata(ctx context.Context) ([]byte, error)
+}
+
+var validOutageTypes = map[string]bool{"outage": true, "degradation": true, "planned": true}
+
+var validOutageCommunicationChannels = map[string]bool{"external": true, "internal": true, "additional": true}
+
+// createOutageRequest mirrors the enum/format-constrained fields of the documented
+// CreateOutageRequest schema. It is decoded only to validate those fields at the
+// boundary; the original raw body is still forwarded to the entity service unchanged.
+type createOutageRequest struct {
+	Type                string  `json:"type"`
+	Begin               string  `json:"begin"`
+	ShortDescription    string  `json:"shortDescription"`
+	ConfigurationItemID *string `json:"configurationItemId"`
+	IncidentID          *string `json:"incidentId"`
+}
+
+// validateCreateOutageBody checks the required fields (type, begin, shortDescription),
+// the type enum, and any UUID-formatted linking fields, so obviously invalid requests
+// are rejected before reaching the entity service.
+func validateCreateOutageBody(body []byte) bool {
+	var req createOutageRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	if !validOutageTypes[req.Type] {
+		return false
+	}
+	if req.Begin == "" {
+		return false
+	}
+	if req.ShortDescription == "" {
+		return false
+	}
+	if req.ConfigurationItemID != nil && *req.ConfigurationItemID != "" && !uuidRe.MatchString(*req.ConfigurationItemID) {
+		return false
+	}
+	if req.IncidentID != nil && *req.IncidentID != "" && !uuidRe.MatchString(*req.IncidentID) {
+		return false
+	}
+	return true
+}
+
+// patchOutageRequest mirrors the enum/format-constrained fields of the documented
+// PatchOutageRequest schema. It is decoded only to validate those fields at the
+// boundary; the original raw body is still forwarded to the entity service unchanged.
+type patchOutageRequest struct {
+	Type                string  `json:"type"`
+	ConfigurationItemID *string `json:"configurationItemId"`
+	IncidentID          *string `json:"incidentId"`
+}
+
+// validatePatchOutageBody rejects an empty JSON object (a PATCH must change at least
+// one field), and checks the type enum and any UUID-formatted linking fields when
+// present. end is intentionally left unvalidated beyond JSON decoding: it is a
+// tri-state field (absent/null/value) that the entity service interprets itself
+// (see domain.PatchOutageRequest), so no closed check belongs here.
+func validatePatchOutageBody(body []byte) bool {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return false
+	}
+	if len(fields) == 0 {
+		return false
+	}
+
+	var req patchOutageRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	if req.Type != "" && !validOutageTypes[req.Type] {
+		return false
+	}
+	if req.ConfigurationItemID != nil && *req.ConfigurationItemID != "" && !uuidRe.MatchString(*req.ConfigurationItemID) {
+		return false
+	}
+	if req.IncidentID != nil && *req.IncidentID != "" && !uuidRe.MatchString(*req.IncidentID) {
+		return false
+	}
+	return true
+}
+
+// addOutageCommunicationRequest mirrors the enum-constrained fields of the documented
+// AddOutageCommunicationRequest schema. It is decoded only to validate those fields at
+// the boundary; the original raw body is still forwarded to the entity service unchanged.
+type addOutageCommunicationRequest struct {
+	Channel string `json:"channel"`
+	Body    string `json:"body"`
+}
+
+// validateAddOutageCommunicationBody checks the channel enum and that body is non-blank.
+func validateAddOutageCommunicationBody(body []byte) bool {
+	var req addOutageCommunicationRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	if !validOutageCommunicationChannels[req.Channel] {
+		return false
+	}
+	if req.Body == "" {
+		return false
+	}
+	return true
+}
+
+// OutageHandler handles HTTP requests for outage operations, delegating to the
+// entity service for data access.
+type OutageHandler struct {
+	entity entityOutageClient
+}
+
+// NewOutageHandler creates an OutageHandler backed by the given entity client.
+func NewOutageHandler(entity entityOutageClient) *OutageHandler {
+	return &OutageHandler{entity: entity}
+}
+
+// CreateOutage handles POST /outages.
+func (h *OutageHandler) CreateOutage(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	if !validateCreateOutageBody(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateOutage(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateOutage failed", "userID", user.UserID, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to create outage.")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, result)
+}
+
+// SearchOutages handles POST /outages/search.
+func (h *OutageHandler) SearchOutages(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchOutages(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchOutages failed", "userID", user.UserID, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to search outages.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// GetOutage handles GET /outages/{id}.
+func (h *OutageHandler) GetOutage(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetOutage(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetOutage failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to retrieve outage.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// PatchOutage handles PATCH /outages/{id}.
+func (h *OutageHandler) PatchOutage(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	if !validatePatchOutageBody(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.PatchOutage(r.Context(), id, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity PatchOutage failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamError(w, err, "Failed to update outage.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// AddOutageCommunication handles POST /outages/{id}/communications.
+func (h *OutageHandler) AddOutageCommunication(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxCommentBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	if !validateAddOutageCommunicationBody(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.AddOutageCommunication(r.Context(), id, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity AddOutageCommunication failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to add outage communication.")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, result)
+}
+
+// SearchOutageCommunications handles POST /outages/{id}/communications/search.
+func (h *OutageHandler) SearchOutageCommunications(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchOutageCommunications(r.Context(), id, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchOutageCommunications failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to search outage communications.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// GetOutageMetadata handles GET /outages/metadata.
+func (h *OutageHandler) GetOutageMetadata(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	result, err := h.entity.GetOutageMetadata(r.Context())
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetOutageMetadata failed", "userID", user.UserID, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to retrieve outage metadata.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}

--- a/apps/csm-portal/backend/internal/handler/outages_test.go
+++ b/apps/csm-portal/backend/internal/handler/outages_test.go
@@ -1,0 +1,535 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const testOutageID = "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff"
+
+func TestCreateOutage(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := httptest.NewRequest(http.MethodPost, "/outages", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.CreateOutage(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.CreateOutage(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.CreateOutage(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects unknown type", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		body := `{"type":"catastrophe","begin":"2026-08-18 09:00:00","shortDescription":"test"}`
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages", strings.NewReader(body)))
+		w := httptest.NewRecorder()
+		h.CreateOutage(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+	})
+
+	t.Run("rejects missing shortDescription", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		body := `{"type":"outage","begin":"2026-08-18 09:00:00"}`
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages", strings.NewReader(body)))
+		w := httptest.NewRecorder()
+		h.CreateOutage(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+	})
+
+	t.Run("rejects malformed configurationItemId", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		body := `{"type":"outage","begin":"2026-08-18 09:00:00","shortDescription":"test","configurationItemId":"not-a-uuid"}`
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages", strings.NewReader(body)))
+		w := httptest.NewRecorder()
+		h.CreateOutage(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+	})
+
+	t.Run("forwards body to upstream and returns 201 with response", func(t *testing.T) {
+		const reqPayload = `{"type":"degradation","begin":"2026-08-18 09:00:00","shortDescription":"TEST RECORD"}`
+		var capturedBody []byte
+		client := &mockEntityOutageClient{
+			createOutageFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"message":"Outage created successfully","outage":{"id":"` + testOutageID + `","number":"OUT0001881"}}`), nil
+			},
+		}
+		h := NewOutageHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.CreateOutage(w, r)
+
+		assertStatus(t, w, http.StatusCreated)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		outage, _ := resp["outage"].(map[string]any)
+		if outage["number"] != "OUT0001881" {
+			t.Errorf("response outage.number = %v, want OUT0001881", outage["number"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to create outage.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityOutageClient{
+					createOutageFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewOutageHandler(client)
+				body := `{"type":"outage","begin":"2026-08-18 09:00:00","shortDescription":"test"}`
+				r := withUser(httptest.NewRequest(http.MethodPost, "/outages", strings.NewReader(body)))
+				w := httptest.NewRecorder()
+				h.CreateOutage(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
+func TestSearchOutages(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := httptest.NewRequest(http.MethodPost, "/outages/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchOutages(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchOutages(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+	})
+
+	t.Run("forwards body and returns 200", func(t *testing.T) {
+		var capturedBody []byte
+		client := &mockEntityOutageClient{
+			searchOutagesFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"outages":[],"total":0,"limit":2,"offset":0,"appliedBeginFrom":"2026-02-18","beginFromDefaulted":true}`), nil
+			},
+		}
+		h := NewOutageHandler(client)
+		reqPayload := `{"pagination":{"limit":2}}`
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages/search", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.SearchOutages(w, r)
+		assertStatus(t, w, http.StatusOK)
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to search outages.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityOutageClient{
+					searchOutagesFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewOutageHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/outages/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchOutages(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+			})
+		}
+	})
+}
+
+func TestGetOutage(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := httptest.NewRequest(http.MethodGet, "/outages/"+testOutageID, nil)
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.GetOutage(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/outages/not-a-uuid", nil))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.GetOutage(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+	})
+
+	t.Run("returns 200 with the upstream result", func(t *testing.T) {
+		client := &mockEntityOutageClient{
+			getOutageFn: func(_ context.Context, id string) ([]byte, error) {
+				return []byte(`{"id":"` + id + `","number":"OUT0001875"}`), nil
+			},
+		}
+		h := NewOutageHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/outages/"+testOutageID, nil))
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.GetOutage(w, r)
+		assertStatus(t, w, http.StatusOK)
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["number"] != "OUT0001875" {
+			t.Errorf("response number = %v, want OUT0001875", resp["number"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to retrieve outage.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityOutageClient{
+					getOutageFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewOutageHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/outages/"+testOutageID, nil))
+				r.SetPathValue("id", testOutageID)
+				w := httptest.NewRecorder()
+				h.GetOutage(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+			})
+		}
+	})
+}
+
+func TestPatchOutage(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := httptest.NewRequest(http.MethodPatch, "/outages/"+testOutageID, strings.NewReader(`{"end":null}`))
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.PatchOutage(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/outages/not-a-uuid", strings.NewReader(`{"end":null}`)))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.PatchOutage(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+	})
+
+	t.Run("rejects empty body", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/outages/"+testOutageID, strings.NewReader(`{}`)))
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.PatchOutage(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+	})
+
+	t.Run("rejects unknown type", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/outages/"+testOutageID, strings.NewReader(`{"type":"catastrophe"}`)))
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.PatchOutage(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+	})
+
+	t.Run("accepts explicit null end (reopen)", func(t *testing.T) {
+		var capturedBody []byte
+		client := &mockEntityOutageClient{
+			patchOutageFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"message":"Outage updated successfully","outage":{"id":"` + testOutageID + `"}}`), nil
+			},
+		}
+		h := NewOutageHandler(client)
+		reqPayload := `{"end":null}`
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/outages/"+testOutageID, strings.NewReader(reqPayload)))
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.PatchOutage(w, r)
+		assertStatus(t, w, http.StatusOK)
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to update outage.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityOutageClient{
+					patchOutageFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewOutageHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPatch, "/outages/"+testOutageID, strings.NewReader(`{"end":null}`)))
+				r.SetPathValue("id", testOutageID)
+				w := httptest.NewRecorder()
+				h.PatchOutage(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+			})
+		}
+	})
+}
+
+func TestAddOutageCommunication(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := httptest.NewRequest(http.MethodPost, "/outages/"+testOutageID+"/communications", strings.NewReader(`{}`))
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.AddOutageCommunication(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages/not-a-uuid/communications", strings.NewReader(`{}`)))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.AddOutageCommunication(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+	})
+
+	t.Run("rejects unknown channel", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		body := `{"channel":"twitter","body":"hello"}`
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages/"+testOutageID+"/communications", strings.NewReader(body)))
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.AddOutageCommunication(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+	})
+
+	t.Run("rejects empty body text", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		body := `{"channel":"external","body":""}`
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages/"+testOutageID+"/communications", strings.NewReader(body)))
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.AddOutageCommunication(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+	})
+
+	t.Run("forwards body and returns 201", func(t *testing.T) {
+		var capturedID string
+		var capturedBody []byte
+		client := &mockEntityOutageClient{
+			addOutageCommunicationFn: func(_ context.Context, id string, body []byte) ([]byte, error) {
+				capturedID = id
+				capturedBody = body
+				return []byte(`{"message":"Communication added successfully","communication":{"id":"11111111-1111-1111-1111-111111111111","isPublic":true}}`), nil
+			},
+		}
+		h := NewOutageHandler(client)
+		reqPayload := `{"channel":"external","body":"status update"}`
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages/"+testOutageID+"/communications", strings.NewReader(reqPayload)))
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.AddOutageCommunication(w, r)
+		assertStatus(t, w, http.StatusCreated)
+		if capturedID != testOutageID {
+			t.Errorf("upstream received id %q, want %q", capturedID, testOutageID)
+		}
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to add outage communication.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityOutageClient{
+					addOutageCommunicationFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewOutageHandler(client)
+				body := `{"channel":"internal","body":"note"}`
+				r := withUser(httptest.NewRequest(http.MethodPost, "/outages/"+testOutageID+"/communications", strings.NewReader(body)))
+				r.SetPathValue("id", testOutageID)
+				w := httptest.NewRecorder()
+				h.AddOutageCommunication(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+			})
+		}
+	})
+}
+
+func TestSearchOutageCommunications(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := httptest.NewRequest(http.MethodPost, "/outages/"+testOutageID+"/communications/search", strings.NewReader(`{}`))
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.SearchOutageCommunications(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages/not-a-uuid/communications/search", strings.NewReader(`{}`)))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.SearchOutageCommunications(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+	})
+
+	t.Run("forwards body and returns 200", func(t *testing.T) {
+		var capturedID string
+		client := &mockEntityOutageClient{
+			searchOutageCommunicationsFn: func(_ context.Context, id string, _ []byte) ([]byte, error) {
+				capturedID = id
+				return []byte(`{"communications":[],"total":2,"limit":20,"offset":0}`), nil
+			},
+		}
+		h := NewOutageHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/outages/"+testOutageID+"/communications/search", strings.NewReader(`{}`)))
+		r.SetPathValue("id", testOutageID)
+		w := httptest.NewRecorder()
+		h.SearchOutageCommunications(w, r)
+		assertStatus(t, w, http.StatusOK)
+		if capturedID != testOutageID {
+			t.Errorf("upstream received id %q, want %q", capturedID, testOutageID)
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to search outage communications.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityOutageClient{
+					searchOutageCommunicationsFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewOutageHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/outages/"+testOutageID+"/communications/search", strings.NewReader(`{}`)))
+				r.SetPathValue("id", testOutageID)
+				w := httptest.NewRecorder()
+				h.SearchOutageCommunications(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+			})
+		}
+	})
+}
+
+func TestGetOutageMetadata(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewOutageHandler(&mockEntityOutageClient{})
+		r := httptest.NewRequest(http.MethodGet, "/outages/metadata", nil)
+		w := httptest.NewRecorder()
+		h.GetOutageMetadata(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+	})
+
+	t.Run("returns 200 with the upstream result", func(t *testing.T) {
+		client := &mockEntityOutageClient{
+			getOutageMetadataFn: func(_ context.Context) ([]byte, error) {
+				return []byte(`{"types":[{"value":"outage","label":"Outage"}],"statuses":[],"communicationChannels":[],"statusPageClouds":["asgardeo"]}`), nil
+			},
+		}
+		h := NewOutageHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/outages/metadata", nil))
+		w := httptest.NewRecorder()
+		h.GetOutageMetadata(w, r)
+		assertStatus(t, w, http.StatusOK)
+		resp := decodeJSON[map[string]any](t, w)
+		clouds, _ := resp["statusPageClouds"].([]any)
+		if len(clouds) != 1 || clouds[0] != "asgardeo" {
+			t.Errorf("response statusPageClouds = %v, want [asgardeo]", resp["statusPageClouds"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to retrieve outage metadata.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityOutageClient{
+					getOutageMetadataFn: func(_ context.Context) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewOutageHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/outages/metadata", nil))
+				w := httptest.NewRecorder()
+				h.GetOutageMetadata(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+			})
+		}
+	})
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Second PR in a three-part layered rollout (entity-service, this PR: BFF, then webapp) adding
outage tracking, change-request field parity, incident specialist handoff, and service-request
catalog-variable metadata. This PR proxies the entity-service layer (already open in a prior PR)
through the CSM BFF that the webapp calls.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Proxy all 7 outage entity-service resources through the BFF, with request-boundary validation
  (required fields, enum checks, UUID-format checks) but full-body passthrough of the actual
  payload.
- Proxy the incident specialist handoff operation, surfacing `githubIssueError` distinctly when
  the handoff itself succeeds but the follow-up GitHub issue could not be created — never folded
  silently into a clean success.
- Confirm (not assume) whether change-request field parity and catalog-variable metadata need any
  BFF code at all, given both were built as typed mappers one layer down.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

No UI in this PR (BFF layer only). Outage handlers mirror the existing `problems.go` handler
pattern in this codebase exactly. The incident handoff handler forwards the response as a raw,
unmodified byte passthrough so `githubIssueError` always reaches the webapp intact, and
additionally does a partial decode of just that one field to log a warning server-side when it's
non-nil — matching an existing partial-decode-for-observability idiom already used elsewhere in
this BFF. Change-request field parity was traced end to end (interface signatures, client
methods, response writing) and confirmed to be a genuine raw-`[]byte` passthrough with no typed
struct anywhere in the BFF — zero code needed. Catalog-variable metadata was confirmed the same
way (`git diff` on the relevant handler is empty).

## User stories
> Summary of user stories addressed by this change

Same as the entity-service PR — this is the plumbing layer between that and the webapp PR that
follows.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Adds BFF support for outage tracking and incident specialist handoff; confirms change-request
field parity and catalog-variable metadata require no BFF changes.

## Documentation
N/A for this PR — no user-facing surface yet (BFF only). The webapp PR updates `/help`.

## Training
N/A — backend-only change.

## Certification
N/A — backend-only change.

## Marketing
N/A — internal SRE tooling.

## Automation tests
 - Unit tests
   > New `outages_test.go` (auth, body-size, validation, happy path, upstream-error mapping,
     all 7 handlers) and extended `incidents_test.go` (12 handoff subtests, including a dedicated
     test asserting `githubIssueError` passes through on an otherwise-successful handoff). `go
     test ./...` passes across all packages. `go test -race ./...` is clean in every package this
     PR touches; a pre-existing, unrelated race in `internal/entity` (confirmed present on
     unmodified `main` too) is untouched by this change.
 - Integration tests
   > Not run at this layer — this PR is unit-tested against a mocked entity-service client. Live
     verification happened one layer down (entity-service PR) and one layer up (webapp PR).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go service, not Java
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Part of a three-PR series: entity-service (`cs-tools#1632`), this PR (BFF), and a webapp PR to
follow, all for the same four features.

## Migrations (if applicable)
N/A

## Test environment
Go toolchain per `go.mod` in `apps/csm-portal/backend/`. No browser/UI involved in this PR.

## Learning
N/A
