### PR TITLE
[CSM][Web] Add SRE Team filter to Incidents, Problems, and Change Requests

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2474,6 +2474,30 @@ export interface BePatchChangeRequestResponse {
   updatedBy?: string;
 }
 
+/**
+ * `field` enum accepted by a change-request search's generic `filters`
+ * array — mirrors the entity-service's `changeRequestFilterFieldSet` (see
+ * `change_request_filters.go`) exactly. This is separate from the
+ * pre-existing named fields below (`states`/`impacts`/`closedOn`/...),
+ * which stay outside this array.
+ */
+export type BeChangeRequestFieldFilterField =
+  | "createdOn"
+  | "assignmentGroupId"
+  | "approval";
+
+/** `op` enum accepted by a change-request search's generic `filters` array
+ * — mirrors `changeRequestFilterOpSet` in `change_request_filters.go`.
+ * Field/op compatibility is enforced only on the backend. */
+export type BeChangeRequestFieldFilterOp = "gte" | "lte" | "in" | "eq";
+
+/** One entry in a change-request search's generic `filters` array. */
+export interface BeChangeRequestFieldFilter {
+  field: BeChangeRequestFieldFilterField;
+  op: BeChangeRequestFieldFilterOp;
+  values?: string[];
+}
+
 export interface BeChangeRequestSearchPayload {
   filters?: {
     projectIds?: string[];
@@ -2488,6 +2512,13 @@ export interface BeChangeRequestSearchPayload {
      * searchQuery scan.
      */
     number?: string;
+    /**
+     * The generic field/op/values filter array (see
+     * {@link BeChangeRequestFieldFilter}) — additive alongside the named
+     * fields above. Only the SRE Team control (`assignmentGroupId`/`"in"`)
+     * populates this today.
+     */
+    filters?: BeChangeRequestFieldFilter[];
   };
   sortBy?: {
     field?: "createdOn" | "updatedOn";
@@ -2717,6 +2748,41 @@ export interface BePatchIncidentResponse {
   incident: BeIncidentDetail;
 }
 
+/**
+ * `field` enum accepted by an incident search's generic `filters` array —
+ * mirrors the entity-service's `incidentFilterFieldSet` (see
+ * `incident_filters.go`) exactly. Deliberately a superset of what this
+ * portal currently builds a control for (only `assignmentGroupId`, for the
+ * SRE Team filter, at present) — narrowing the FE type to just that one
+ * value would create a stale-type problem the moment another field gets a
+ * control.
+ */
+export type BeIncidentFieldFilterField =
+  | "state"
+  | "assignmentGroupId"
+  | "businessServiceId"
+  | "createdOn"
+  | "slaViolated"
+  | "madeSla"
+  | "productName";
+
+/**
+ * `op` enum accepted by an incident search's generic `filters` array,
+ * independent of `field` — mirrors `incidentFilterOpSet` in
+ * `incident_filters.go`. Field/op compatibility is enforced only on the
+ * backend, not narrowed here.
+ */
+export type BeIncidentFieldFilterOp = "in" | "gte" | "lte" | "eq";
+
+/** One entry in an incident search's generic `filters` array — same "field
+ * op values" shape as {@link BeCaseFieldFilter}, scoped to incidents' own
+ * field/op allow-list. */
+export interface BeIncidentFieldFilter {
+  field: BeIncidentFieldFilterField;
+  op: BeIncidentFieldFilterOp;
+  values?: string[];
+}
+
 export interface BeIncidentSearchPayload {
   filters?: {
     searchQuery?: string;
@@ -2747,6 +2813,13 @@ export interface BeIncidentSearchPayload {
      * scan.
      */
     number?: string;
+    /**
+     * The generic field/op/values filter array (see {@link BeIncidentFieldFilter}) —
+     * additive alongside the named fields above, not a replacement for them.
+     * Only the SRE Team control (`assignmentGroupId`/`"in"`) populates this
+     * today.
+     */
+    filters?: BeIncidentFieldFilter[];
   };
   sortBy?: {
     field?: "createdOn" | "updatedOn" | "openedOn";
@@ -2803,6 +2876,26 @@ export interface BeProblemSearchView {
   assignedTo?: BeEntityRef | null;
 }
 
+/**
+ * `field` enum accepted by a problem search's generic `filters` array —
+ * mirrors the entity-service's `problemFilterFieldSet` (see
+ * `problem_filters.go`) exactly. Notably smaller than incidents'/change
+ * requests' own field sets — don't assume parity across resources.
+ */
+export type BeProblemFieldFilterField = "state" | "assignmentGroupId";
+
+/** `op` enum accepted by a problem search's generic `filters` array —
+ * mirrors `problemFilterOpSet` in `problem_filters.go`; today every
+ * supported field only accepts `"in"`. */
+export type BeProblemFieldFilterOp = "in";
+
+/** One entry in a problem search's generic `filters` array. */
+export interface BeProblemFieldFilter {
+  field: BeProblemFieldFilterField;
+  op: BeProblemFieldFilterOp;
+  values?: string[];
+}
+
 export interface BeProblemSearchFilters {
   searchQuery?: string;
   /**
@@ -2817,6 +2910,12 @@ export interface BeProblemSearchFilters {
    * a first-class filter rather than through the free-text searchQuery scan.
    */
   number?: string;
+  /**
+   * The generic field/op/values filter array (see {@link BeProblemFieldFilter}) —
+   * additive alongside `states` above. Only the SRE Team control
+   * (`assignmentGroupId`/`"in"`) populates this today.
+   */
+  filters?: BeProblemFieldFilter[];
 }
 
 export interface BeProblemSearchPayload {

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
@@ -35,6 +35,7 @@ import {
   X,
 } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, type JSX } from "react";
+import { useTeams } from "@features/csm-dashboard/api/useTeams";
 import {
   CHANGE_REQUEST_IMPACTS,
   CHANGE_REQUEST_STATES,
@@ -99,6 +100,22 @@ export default function ChangeRequestsFilterBar({
         label: changeRequestImpactLabel(i),
       })),
     [],
+  );
+
+  // Change requests are SRE-owned, so this control is scoped to the
+  // `sre-abt` team family — see `IncidentsFilterBar`'s equivalent note on
+  // why this isn't `cre-abt` (the cases list's own "SRE Team" control's
+  // family scoping).
+  const { data: teams } = useTeams(true, "sre-abt");
+  const sreTeamOptions = useMemo(
+    () =>
+      (teams ?? [])
+        .filter(
+          (t): t is typeof t & { sreGroupId: string } =>
+            Boolean(t.sreGroupId) && t.family === "sre-abt",
+        )
+        .map((t) => ({ value: t.sreGroupId, label: t.name })),
+    [teams],
   );
 
   return (
@@ -182,6 +199,15 @@ export default function ChangeRequestsFilterBar({
                 values={filters.impacts}
                 options={impactOptions}
                 onChange={(next) => onChange({ ...filters, impacts: next })}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+              <MultiSelectField
+                id="cr-filter-sre-team"
+                label="SRE Team"
+                values={filters.sreTeamIds}
+                options={sreTeamOptions}
+                onChange={(next) => onChange({ ...filters, sreTeamIds: next })}
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.test.tsx
@@ -34,6 +34,13 @@ vi.mock("@features/csm-operations/api/useSearchChangeRequests", () => ({
   useSearchChangeRequests: vi.fn(),
 }));
 
+// The filter bar's SRE Team control goes through the shared team registry
+// query — stub it out so this test doesn't need a QueryClientProvider,
+// same rationale as the other mocks below.
+vi.mock("@features/csm-dashboard/api/useTeams", () => ({
+  useTeams: () => ({ data: [], isLoading: false }),
+}));
+
 // Only the column picker's storage key derives from the signed-in user.
 vi.mock("@context/current-user/CurrentUserContext", () => ({
   useCurrentUser: () => ({ user: { id: "user-1" }, isLoading: false, isError: false }),

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -43,6 +43,7 @@ import { useBackendApi } from "@api/backend/client";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useSearchChangeRequests } from "@features/csm-operations/api/useSearchChangeRequests";
 import {
+  buildChangeRequestSearchFilters,
   changeRequestImpactColor,
   changeRequestImpactLabel,
   changeRequestStateColor,
@@ -122,16 +123,6 @@ function formatDate(value?: string | null): string {
   );
 }
 
-/** Convert a YYYY-MM-DD date picker value to an ISO 8601 string at midnight UTC. */
-function toISOStart(date: string): string {
-  return `${date}T00:00:00Z`;
-}
-
-/** Convert a YYYY-MM-DD date picker value to an ISO 8601 string at end-of-day UTC. */
-function toISOEnd(date: string): string {
-  return `${date}T23:59:59Z`;
-}
-
 /**
  * Change-requests listing for the Operations → Change requests tab. Searches
  * `POST /change-requests/search` with server-side pagination and filters
@@ -153,20 +144,10 @@ export default function ChangeRequestsTab(): JSX.Element {
 
   const payload = useMemo(
     () => ({
-      filters: {
-        ...(debouncedSearch.length > 0 && { searchQuery: debouncedSearch }),
-        ...(filters.states.length > 0 && { states: filters.states }),
-        ...(filters.impacts.length > 0 && { impacts: filters.impacts }),
-        ...(filters.closedStartDate && {
-          closedStartDate: toISOStart(filters.closedStartDate),
-        }),
-        ...(filters.closedEndDate && {
-          closedEndDate: toISOEnd(filters.closedEndDate),
-        }),
-      },
+      filters: buildChangeRequestSearchFilters(filters, debouncedSearch),
       pagination: { offset: page * rowsPerPage, limit: rowsPerPage },
     }),
-    [debouncedSearch, filters.states, filters.impacts, filters.closedStartDate, filters.closedEndDate, page, rowsPerPage],
+    [filters, debouncedSearch, page, rowsPerPage],
   );
 
   const { data, isLoading, isError, error, isFetching, refetch, dataUpdatedAt } =

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.test.tsx
@@ -32,6 +32,21 @@ vi.mock("@features/csm-operations/api/useIncidentProductNameOptions", () => ({
   useIncidentProductNameOptions: () => useIncidentProductNameOptionsMock(),
 }));
 
+// The SRE Team control's options come from the shared team registry query —
+// stub it out too, same rationale as the product options above.
+const useTeamsMock = vi.fn(() => ({
+  data: [
+    { id: "apollo", name: "Apollo SRE Team", family: "sre-abt", sreGroupId: "team-apollo" },
+    // Wrong family — must not surface as an SRE Team option here (that's
+    // the cases list's CRE Team control's job, not this one's).
+    { id: "atlas", name: "Atlas CRE Team", family: "cre-abt", creGroupId: "team-atlas" },
+  ],
+  isLoading: false,
+}));
+vi.mock("@features/csm-dashboard/api/useTeams", () => ({
+  useTeams: () => useTeamsMock(),
+}));
+
 /**
  * Render the filter bar over `DEFAULT_INCIDENT_FILTERS` with the given prop
  * overrides, returning the `onChange`/`onReset`/`onFiltersToggle` spies. The bar
@@ -119,6 +134,21 @@ describe("IncidentsFilterBar", () => {
     renderFilterBar();
     expect(screen.getByRole("button", { name: /^filters$/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /clear filters/i })).not.toBeInTheDocument();
+  });
+
+  it("offers only sre-abt-family teams as SRE Team options, keyed by sreGroupId", () => {
+    const { onChange } = renderFilterBar();
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "SRE Team" }));
+    expect(screen.getByRole("option", { name: "Apollo SRE Team" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Atlas CRE Team" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("option", { name: "Apollo SRE Team" }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_INCIDENT_FILTERS,
+      sreTeamIds: ["team-apollo"],
+    });
   });
 
   it("calls onReset when Clear filters is clicked", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.tsx
@@ -32,6 +32,7 @@ import {
 import { ChevronDown, ChevronUp, ListFilter, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, type JSX } from "react";
 import type { BeIncidentPriority } from "@api/backend/types";
+import { useTeams } from "@features/csm-dashboard/api/useTeams";
 import {
   countActiveIncidentFilters,
   incidentPriorityLabel,
@@ -84,7 +85,7 @@ interface IncidentsFilterBarProps {
 }
 
 /**
- * Search + filters bar for the Incidents tab: priority, product,
+ * Search + filters bar for the Incidents tab: priority, product, SRE team,
  * SLA-violated, and created date range (see `IncidentSearchPayload.filters` in
  * openapi.yaml — there's still no server-side state/category filter to build
  * a control for). The created-date bounds are inclusive and interpreted in
@@ -118,6 +119,24 @@ export default function IncidentsFilterBar({
         label: incidentPriorityLabel(p),
       })),
     [],
+  );
+
+  // SRE Team: incidents are SRE-owned, so this is scoped to the `sre-abt`
+  // team family (unlike the cases list's own "SRE Team" filter, which is
+  // deliberately scoped to `cre-abt` per an explicit, later-flagged-as-
+  // likely-mistaken product instruction — see `CasesFilterBar.tsx`'s
+  // `sreTeamOptions`. This is a fresh field on a different resource, not a
+  // copy of that decision).
+  const { data: teams } = useTeams(true, "sre-abt");
+  const sreTeamOptions = useMemo(
+    () =>
+      (teams ?? [])
+        .filter(
+          (t): t is typeof t & { sreGroupId: string } =>
+            Boolean(t.sreGroupId) && t.family === "sre-abt",
+        )
+        .map((t) => ({ value: t.sreGroupId, label: t.name })),
+    [teams],
   );
 
   const handlePriorityChange = (next: BeIncidentPriority[]): void => {
@@ -224,6 +243,16 @@ export default function IncidentsFilterBar({
               <IncidentProductMultiSelect
                 values={filters.products}
                 onChange={(next) => onChange({ ...filters, products: next })}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+              <MultiSelectField
+                id="incident-filter-sre-team"
+                label="SRE Team"
+                values={filters.sreTeamIds}
+                options={sreTeamOptions}
+                onChange={(next) => onChange({ ...filters, sreTeamIds: next })}
               />
             </Grid>
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.test.tsx
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type * as React from "react";
+import { DEFAULT_PROBLEM_FILTERS } from "@features/csm-operations/utils/problems";
+import ProblemsFilterBar from "@features/csm-operations/components/ProblemsFilterBar";
+
+// The SRE Team control's options come from the shared team registry query —
+// stub it out, same as IncidentsFilterBar.test.tsx's own mock.
+const useTeamsMock = vi.fn(() => ({
+  data: [
+    { id: "apollo", name: "Apollo SRE Team", family: "sre-abt", sreGroupId: "team-apollo" },
+    // Wrong family — must not surface as an SRE Team option here.
+    { id: "atlas", name: "Atlas CRE Team", family: "cre-abt", creGroupId: "team-atlas" },
+  ],
+  isLoading: false,
+}));
+vi.mock("@features/csm-dashboard/api/useTeams", () => ({
+  useTeams: () => useTeamsMock(),
+}));
+
+function renderFilterBar(
+  overrides: Partial<React.ComponentProps<typeof ProblemsFilterBar>> = {},
+) {
+  const onChange = vi.fn();
+  const onReset = vi.fn();
+  const onFiltersToggle = vi.fn();
+  render(
+    <ProblemsFilterBar
+      filters={DEFAULT_PROBLEM_FILTERS}
+      onChange={onChange}
+      onReset={onReset}
+      isFiltersOpen
+      onFiltersToggle={onFiltersToggle}
+      {...overrides}
+    />,
+  );
+  return { onChange, onReset, onFiltersToggle };
+}
+
+describe("ProblemsFilterBar", () => {
+  it("selecting a state sets it on the filter object", () => {
+    const { onChange } = renderFilterBar();
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "State" }));
+    fireEvent.click(screen.getByRole("option", { name: /^new$/i }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_PROBLEM_FILTERS,
+      states: ["NEW"],
+    });
+  });
+
+  it("offers only sre-abt-family teams as SRE Team options, keyed by sreGroupId", () => {
+    const { onChange } = renderFilterBar();
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "SRE Team" }));
+    expect(screen.getByRole("option", { name: "Apollo SRE Team" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Atlas CRE Team" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("option", { name: "Apollo SRE Team" }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_PROBLEM_FILTERS,
+      sreTeamIds: ["team-apollo"],
+    });
+  });
+
+  it("shows the active-filter count and a Clear filters action once a filter is set", () => {
+    renderFilterBar({ filters: { ...DEFAULT_PROBLEM_FILTERS, sreTeamIds: ["team-apollo"] } });
+    expect(screen.getByRole("button", { name: /filters \(1\)/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /clear filters/i })).toBeInTheDocument();
+  });
+
+  it("shows no active-filter badge and no Clear filters action for the defaults", () => {
+    renderFilterBar();
+    expect(screen.getByRole("button", { name: /^filters$/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /clear filters/i })).not.toBeInTheDocument();
+  });
+
+  it("calls onReset when Clear filters is clicked", () => {
+    const { onReset } = renderFilterBar({
+      filters: { ...DEFAULT_PROBLEM_FILTERS, states: ["NEW"] },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.tsx
@@ -27,6 +27,7 @@ import {
 import { ChevronDown, ChevronUp, ListFilter, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, type JSX } from "react";
 import type { BeProblemState } from "@api/backend/types";
+import { useTeams } from "@features/csm-dashboard/api/useTeams";
 import {
   countActiveProblemFilters,
   PROBLEM_STATES,
@@ -44,9 +45,9 @@ interface ProblemsFilterBarProps {
 }
 
 /**
- * Search + State filter bar for the Problem management tab. Kept simple by
- * design (search + a single state control) — see the caveat on
- * `BeProblemSearchFilters.states` before adding more filter fields.
+ * Search + State + SRE Team filter bar for the Problem management tab. Kept
+ * simple by design — see the caveat on `BeProblemSearchFilters.states`
+ * before adding more filter fields.
  */
 export default function ProblemsFilterBar({
   filters,
@@ -70,6 +71,21 @@ export default function ProblemsFilterBar({
   const handleStateChange = (next: BeProblemState[]): void => {
     onChange({ ...filters, states: next });
   };
+
+  // Problems are SRE-owned, so this control is scoped to the `sre-abt` team
+  // family — see `IncidentsFilterBar`'s equivalent note on why this isn't
+  // `cre-abt` (the cases list's own "SRE Team" control's family scoping).
+  const { data: teams } = useTeams(true, "sre-abt");
+  const sreTeamOptions = useMemo(
+    () =>
+      (teams ?? [])
+        .filter(
+          (t): t is typeof t & { sreGroupId: string } =>
+            Boolean(t.sreGroupId) && t.family === "sre-abt",
+        )
+        .map((t) => ({ value: t.sreGroupId, label: t.name })),
+    [teams],
+  );
 
   return (
     <Paper sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
@@ -139,6 +155,15 @@ export default function ProblemsFilterBar({
                 values={filters.states}
                 options={stateOptions}
                 onChange={handleStateChange}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+              <MultiSelectField
+                id="problem-filter-sre-team"
+                label="SRE Team"
+                values={filters.sreTeamIds}
+                options={sreTeamOptions}
+                onChange={(next) => onChange({ ...filters, sreTeamIds: next })}
               />
             </Grid>
           </Grid>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
@@ -36,6 +36,7 @@ import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchProblems } from "@features/csm-operations/api/useSearchProblems";
 import {
+  buildProblemSearchFilters,
   DEFAULT_PROBLEM_FILTERS,
   problemStateColor,
   problemStateLabel,
@@ -63,13 +64,10 @@ export default function ProblemsTab(): JSX.Element {
 
   const payload = useMemo(
     () => ({
-      filters: {
-        ...(debouncedSearch.length > 0 && { searchQuery: debouncedSearch }),
-        ...(filters.states.length > 0 && { states: filters.states }),
-      },
+      filters: buildProblemSearchFilters(filters, debouncedSearch),
       pagination: { offset: page * rowsPerPage, limit: rowsPerPage },
     }),
-    [debouncedSearch, filters.states, page, rowsPerPage],
+    [filters, debouncedSearch, page, rowsPerPage],
   );
 
   const { data, isLoading, isError, error, isFetching, refetch, dataUpdatedAt } =

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/changeRequests.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/changeRequests.test.ts
@@ -16,8 +16,11 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  buildChangeRequestSearchFilters,
   buildCloneChangeRequestNavState,
   changeRequestBlockingReason,
+  countActiveCRFilters,
+  DEFAULT_CR_FILTERS,
 } from "@features/csm-operations/utils/changeRequests";
 import type { BeChangeRequestApproval, BeChangeRequestDetail } from "@api/backend/types";
 
@@ -218,5 +221,59 @@ describe("changeRequestBlockingReason", () => {
     expect(
       changeRequestBlockingReason([approval({ stage: "Assess", status: "requested" })]),
     ).toBe("Awaiting Assess approval");
+  });
+});
+
+describe("countActiveCRFilters", () => {
+  it("is 0 for the default filters", () => {
+    expect(countActiveCRFilters(DEFAULT_CR_FILTERS)).toBe(0);
+  });
+
+  it("is 1 when an SRE team filter is set", () => {
+    expect(
+      countActiveCRFilters({ ...DEFAULT_CR_FILTERS, sreTeamIds: ["team-apollo"] }),
+    ).toBe(1);
+  });
+});
+
+describe("buildChangeRequestSearchFilters", () => {
+  it("returns an empty object for the defaults with no search text", () => {
+    expect(buildChangeRequestSearchFilters(DEFAULT_CR_FILTERS, "")).toEqual({});
+  });
+
+  it("includes states/impacts/closed-date bounds when set", () => {
+    expect(
+      buildChangeRequestSearchFilters(
+        {
+          ...DEFAULT_CR_FILTERS,
+          states: ["implement"],
+          impacts: ["high"],
+          closedStartDate: "2026-01-01",
+          closedEndDate: "2026-01-31",
+        },
+        "rollback",
+      ),
+    ).toEqual({
+      searchQuery: "rollback",
+      states: ["implement"],
+      impacts: ["high"],
+      closedStartDate: "2026-01-01T00:00:00Z",
+      closedEndDate: "2026-01-31T23:59:59Z",
+    });
+  });
+
+  it("sends selected SRE teams as an assignmentGroupId/in generic filter entry", () => {
+    expect(
+      buildChangeRequestSearchFilters(
+        { ...DEFAULT_CR_FILTERS, sreTeamIds: ["team-apollo", "team-atlas"] },
+        "",
+      ),
+    ).toEqual({
+      filters: [{ field: "assignmentGroupId", op: "in", values: ["team-apollo", "team-atlas"] }],
+    });
+  });
+
+  it("omits the generic filters array entirely when no SRE team is selected", () => {
+    expect(buildChangeRequestSearchFilters(DEFAULT_CR_FILTERS, "")).not.toHaveProperty("filters");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/incidents.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/incidents.test.ts
@@ -109,6 +109,7 @@ describe("buildIncidentSearchFilters", () => {
       createdStartDate: "2026-05-01",
       createdEndDate: "2026-05-31",
       products: ["Choreo"],
+      sreTeamIds: [],
     };
     expect(buildIncidentSearchFilters(filters, "timeout")).toEqual({
       searchQuery: "timeout",
@@ -118,6 +119,22 @@ describe("buildIncidentSearchFilters", () => {
       endCreatedDate: "2026-05-31T23:59:59Z",
       productNames: ["Choreo"],
     });
+  });
+
+  it("sends selected SRE teams as an assignmentGroupId/in generic filter entry", () => {
+    const filters: IncidentFilters = {
+      ...DEFAULT_INCIDENT_FILTERS,
+      sreTeamIds: ["team-apollo", "team-atlas"],
+    };
+    expect(buildIncidentSearchFilters(filters, "")).toEqual({
+      filters: [{ field: "assignmentGroupId", op: "in", values: ["team-apollo", "team-atlas"] }],
+    });
+  });
+
+  it("omits the generic filters array entirely when no SRE team is selected", () => {
+    expect(buildIncidentSearchFilters(DEFAULT_INCIDENT_FILTERS, "")).not.toHaveProperty(
+      "filters",
+    );
   });
 });
 
@@ -140,6 +157,9 @@ describe("countActiveIncidentFilters", () => {
       countActiveIncidentFilters({ ...DEFAULT_INCIDENT_FILTERS, products: ["Choreo"] }),
     ).toBe(1);
     expect(
+      countActiveIncidentFilters({ ...DEFAULT_INCIDENT_FILTERS, sreTeamIds: ["team-apollo"] }),
+    ).toBe(1);
+    expect(
       countActiveIncidentFilters({
         ...DEFAULT_INCIDENT_FILTERS,
         slaViolated: true,
@@ -147,7 +167,8 @@ describe("countActiveIncidentFilters", () => {
         createdEndDate: "2026-05-31",
         products: ["Choreo"],
         priorities: ["HIGH"],
+        sreTeamIds: ["team-apollo"],
       }),
-    ).toBe(5);
+    ).toBe(6);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/problems.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/problems.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  buildProblemSearchFilters,
   countActiveProblemFilters,
   DEFAULT_PROBLEM_FILTERS,
   PROBLEM_STATES,
@@ -83,5 +84,54 @@ describe("countActiveProblemFilters", () => {
 
   it("is 1 when a state filter is set", () => {
     expect(countActiveProblemFilters({ ...DEFAULT_PROBLEM_FILTERS, states: ["NEW"] })).toBe(1);
+  });
+
+  it("is 1 when an SRE team filter is set", () => {
+    expect(
+      countActiveProblemFilters({ ...DEFAULT_PROBLEM_FILTERS, sreTeamIds: ["team-1"] }),
+    ).toBe(1);
+  });
+
+  it("is 2 when both state and SRE team filters are set", () => {
+    expect(
+      countActiveProblemFilters({
+        ...DEFAULT_PROBLEM_FILTERS,
+        states: ["NEW"],
+        sreTeamIds: ["team-1"],
+      }),
+    ).toBe(2);
+  });
+});
+
+describe("buildProblemSearchFilters", () => {
+  it("returns an empty object for the defaults with no search text", () => {
+    expect(buildProblemSearchFilters(DEFAULT_PROBLEM_FILTERS, "")).toEqual({});
+  });
+
+  it("includes searchQuery only when the debounced search text is non-empty", () => {
+    expect(buildProblemSearchFilters(DEFAULT_PROBLEM_FILTERS, "disk full")).toEqual({
+      searchQuery: "disk full",
+    });
+  });
+
+  it("includes states when set", () => {
+    expect(
+      buildProblemSearchFilters({ ...DEFAULT_PROBLEM_FILTERS, states: ["NEW", "ASSESS"] }, ""),
+    ).toEqual({ states: ["NEW", "ASSESS"] });
+  });
+
+  it("sends selected SRE teams as an assignmentGroupId/in generic filter entry", () => {
+    expect(
+      buildProblemSearchFilters(
+        { ...DEFAULT_PROBLEM_FILTERS, sreTeamIds: ["team-apollo", "team-atlas"] },
+        "",
+      ),
+    ).toEqual({
+      filters: [{ field: "assignmentGroupId", op: "in", values: ["team-apollo", "team-atlas"] }],
+    });
+  });
+
+  it("omits the generic filters array entirely when no SRE team is selected", () => {
+    expect(buildProblemSearchFilters(DEFAULT_PROBLEM_FILTERS, "")).not.toHaveProperty("filters");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
@@ -18,6 +18,7 @@ import type {
   BeChangeRequestApproval,
   BeChangeRequestDetail,
   BeChangeRequestImpact,
+  BeChangeRequestSearchPayload,
   BeChangeRequestState,
   BeChangeRequestType,
 } from "@api/backend/types";
@@ -259,6 +260,10 @@ export interface ChangeRequestFilters {
   closedStartDate: string;
   /** YYYY-MM-DD local date string, or empty. */
   closedEndDate: string;
+  /** Selected SRE team `sreGroupId`s — sent as a generic
+   * `{ field: "assignmentGroupId", op: "in" }` filter entry (see
+   * `buildChangeRequestSearchFilters`), not a named payload field. */
+  sreTeamIds: string[];
 }
 
 export const DEFAULT_CR_FILTERS: ChangeRequestFilters = {
@@ -267,6 +272,7 @@ export const DEFAULT_CR_FILTERS: ChangeRequestFilters = {
   impacts: [],
   closedStartDate: "",
   closedEndDate: "",
+  sreTeamIds: [],
 };
 
 /** Count non-search active filters (used for the badge on the Filters button). */
@@ -275,8 +281,46 @@ export function countActiveCRFilters(filters: ChangeRequestFilters): number {
     (filters.states.length > 0 ? 1 : 0) +
     (filters.impacts.length > 0 ? 1 : 0) +
     (filters.closedStartDate ? 1 : 0) +
-    (filters.closedEndDate ? 1 : 0)
+    (filters.closedEndDate ? 1 : 0) +
+    (filters.sreTeamIds.length > 0 ? 1 : 0)
   );
+}
+
+/** Convert a YYYY-MM-DD date picker value to an ISO 8601 string at midnight UTC. */
+export function crDateOnlyToISOStart(date: string): string {
+  return `${date}T00:00:00Z`;
+}
+
+/** Convert a YYYY-MM-DD date picker value to an ISO 8601 string at end-of-day UTC. */
+export function crDateOnlyToISOEnd(date: string): string {
+  return `${date}T23:59:59Z`;
+}
+
+/**
+ * Build `ChangeRequestSearchPayload.filters` from the UI's
+ * {@link ChangeRequestFilters} plus the (separately debounced) search text
+ * — mirrors `buildIncidentSearchFilters` in `incidents.ts`.
+ */
+export function buildChangeRequestSearchFilters(
+  filters: ChangeRequestFilters,
+  debouncedSearch: string,
+): NonNullable<BeChangeRequestSearchPayload["filters"]> {
+  return {
+    ...(debouncedSearch.length > 0 && { searchQuery: debouncedSearch }),
+    ...(filters.states.length > 0 && { states: filters.states }),
+    ...(filters.impacts.length > 0 && { impacts: filters.impacts }),
+    ...(filters.closedStartDate && {
+      closedStartDate: crDateOnlyToISOStart(filters.closedStartDate),
+    }),
+    ...(filters.closedEndDate && {
+      closedEndDate: crDateOnlyToISOEnd(filters.closedEndDate),
+    }),
+    ...(filters.sreTeamIds.length > 0 && {
+      filters: [
+        { field: "assignmentGroupId" as const, op: "in" as const, values: filters.sreTeamIds },
+      ],
+    }),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestsFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestsFiltersUrl.test.ts
@@ -30,7 +30,7 @@ describe("readChangeRequestFiltersFromUrl", () => {
 
   it("parses a fully-populated query string", () => {
     const params = new URLSearchParams(
-      "crQ=rollback&crStates=implement,review&crImpacts=high,low&crClosedFrom=2026-01-01&crClosedTo=2026-01-31",
+      "crQ=rollback&crStates=implement,review&crImpacts=high,low&crClosedFrom=2026-01-01&crClosedTo=2026-01-31&crSreTeams=team-apollo,team-atlas",
     );
     expect(readChangeRequestFiltersFromUrl(params)).toEqual({
       search: "rollback",
@@ -38,7 +38,16 @@ describe("readChangeRequestFiltersFromUrl", () => {
       impacts: ["high", "low"],
       closedStartDate: "2026-01-01",
       closedEndDate: "2026-01-31",
+      sreTeamIds: ["team-apollo", "team-atlas"],
     });
+  });
+
+  it("drops blank/whitespace SRE team entries", () => {
+    const params = new URLSearchParams("crSreTeams=team-apollo,%20%20,,team-atlas");
+    expect(readChangeRequestFiltersFromUrl(params).sreTeamIds).toEqual([
+      "team-apollo",
+      "team-atlas",
+    ]);
   });
 
   it("drops values outside the allowed state/impact enums", () => {
@@ -79,10 +88,19 @@ describe("writeChangeRequestFiltersToUrl", () => {
       impacts: ["high" as const],
       closedStartDate: "2026-01-01",
       closedEndDate: "2026-01-31",
+      sreTeamIds: ["team-apollo"],
     };
     const round = readChangeRequestFiltersFromUrl(
       writeChangeRequestFiltersToUrl(filters),
     );
     expect(round).toEqual(filters);
+  });
+
+  it("omits crSreTeams when no SRE team is selected", () => {
+    const params = writeChangeRequestFiltersToUrl({
+      ...DEFAULT_CR_FILTERS,
+      sreTeamIds: [],
+    });
+    expect(params.has("crSreTeams")).toBe(false);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestsFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestsFiltersUrl.ts
@@ -30,6 +30,7 @@ export const CR_FILTER_PARAM_KEYS = [
   "crImpacts",
   "crClosedFrom",
   "crClosedTo",
+  "crSreTeams",
 ] as const;
 
 const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
@@ -67,6 +68,19 @@ function parseDateOnly(raw: string | null): string {
 }
 
 /**
+ * Comma-separated SRE team ids (`sreGroupId` UUIDs) — not a fixed enum,
+ * blank entries dropped. Mirrors `parseTeamIdsCsv` in
+ * `incidentsFiltersUrl.ts`.
+ */
+function parseTeamIdsCsv(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
  * Read change-request filters from the URL. Unknown/malformed values (a
  * hand-edited or stale query string) are dropped rather than passed through,
  * so they fall back to the default (unfiltered) behaviour instead of being
@@ -81,6 +95,7 @@ export function readChangeRequestFiltersFromUrl(
     impacts: parseCsv(params.get("crImpacts"), CHANGE_REQUEST_IMPACTS),
     closedStartDate: parseDateOnly(params.get("crClosedFrom")),
     closedEndDate: parseDateOnly(params.get("crClosedTo")),
+    sreTeamIds: parseTeamIdsCsv(params.get("crSreTeams")),
   };
 }
 
@@ -97,5 +112,6 @@ export function writeChangeRequestFiltersToUrl(
   if (f.impacts.length) out.set("crImpacts", f.impacts.join(","));
   if (f.closedStartDate) out.set("crClosedFrom", f.closedStartDate);
   if (f.closedEndDate) out.set("crClosedTo", f.closedEndDate);
+  if (f.sreTeamIds.length) out.set("crSreTeams", f.sreTeamIds.join(","));
   return out;
 }

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/incidents.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/incidents.ts
@@ -130,8 +130,10 @@ export function incidentPriorityColor(priority?: string | null): ChipColor {
 /**
  * Filters for the incidents list. The backend's `IncidentSearchPayload.filters`
  * supports `searchQuery`, `priorities`, `parentIds`, `slaViolated`,
- * `startCreatedDate`/`endCreatedDate`, and `productNames` (see openapi.yaml);
- * there's no server-side state/category filter to build a control for.
+ * `startCreatedDate`/`endCreatedDate`, and `productNames` (see openapi.yaml),
+ * plus the generic `filters` array this feeds `sreTeamIds` through as an
+ * `assignmentGroupId`/`"in"` entry; there's no server-side state/category
+ * filter to build a control for.
  */
 export interface IncidentFilters {
   search: string;
@@ -146,6 +148,10 @@ export interface IncidentFilters {
   /** Selected service/product names — see `productNames`' coverage caveat
    * at the API (`BeIncidentSearchPayload`). */
   products: string[];
+  /** Selected SRE team `sreGroupId`s — sent as a generic
+   * `{ field: "assignmentGroupId", op: "in" }` filter entry (see
+   * `buildIncidentSearchFilters`), not a named payload field. */
+  sreTeamIds: string[];
 }
 
 export const DEFAULT_INCIDENT_FILTERS: IncidentFilters = {
@@ -155,6 +161,7 @@ export const DEFAULT_INCIDENT_FILTERS: IncidentFilters = {
   createdStartDate: "",
   createdEndDate: "",
   products: [],
+  sreTeamIds: [],
 };
 
 /** Count non-search active filters (used for the badge on the Filters button). */
@@ -164,7 +171,8 @@ export function countActiveIncidentFilters(filters: IncidentFilters): number {
     (filters.slaViolated ? 1 : 0) +
     (filters.createdStartDate ? 1 : 0) +
     (filters.createdEndDate ? 1 : 0) +
-    (filters.products.length > 0 ? 1 : 0)
+    (filters.products.length > 0 ? 1 : 0) +
+    (filters.sreTeamIds.length > 0 ? 1 : 0)
   );
 }
 
@@ -204,5 +212,10 @@ export function buildIncidentSearchFilters(
       endCreatedDate: incidentDateOnlyToUTCEnd(filters.createdEndDate),
     }),
     ...(filters.products.length > 0 && { productNames: filters.products }),
+    ...(filters.sreTeamIds.length > 0 && {
+      filters: [
+        { field: "assignmentGroupId" as const, op: "in" as const, values: filters.sreTeamIds },
+      ],
+    }),
   };
 }

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentsFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentsFiltersUrl.test.ts
@@ -31,7 +31,8 @@ describe("readIncidentFiltersFromUrl", () => {
   it("parses a fully-populated query string", () => {
     const params = new URLSearchParams(
       "incQ=timeout&incPriorities=HIGH,LOW&incSlaViolated=1" +
-        "&incCreatedFrom=2026-05-01&incCreatedTo=2026-05-31&incProducts=Choreo,Asgardeo",
+        "&incCreatedFrom=2026-05-01&incCreatedTo=2026-05-31&incProducts=Choreo,Asgardeo" +
+        "&incSreTeams=team-apollo,team-atlas",
     );
     expect(readIncidentFiltersFromUrl(params)).toEqual({
       search: "timeout",
@@ -40,7 +41,16 @@ describe("readIncidentFiltersFromUrl", () => {
       createdStartDate: "2026-05-01",
       createdEndDate: "2026-05-31",
       products: ["Choreo", "Asgardeo"],
+      sreTeamIds: ["team-apollo", "team-atlas"],
     });
+  });
+
+  it("drops blank/whitespace SRE team entries", () => {
+    const params = new URLSearchParams("incSreTeams=team-apollo,%20%20,,team-atlas");
+    expect(readIncidentFiltersFromUrl(params).sreTeamIds).toEqual([
+      "team-apollo",
+      "team-atlas",
+    ]);
   });
 
   it("drops values outside the allowed priority enum", () => {
@@ -125,8 +135,17 @@ describe("writeIncidentFiltersToUrl", () => {
       createdStartDate: "2026-05-01",
       createdEndDate: "2026-05-31",
       products: ["Choreo", "Asgardeo"],
+      sreTeamIds: ["team-apollo", "team-atlas"],
     };
     const round = readIncidentFiltersFromUrl(writeIncidentFiltersToUrl(filters));
     expect(round).toEqual(filters);
+  });
+
+  it("omits incSreTeams when no SRE team is selected", () => {
+    const params = writeIncidentFiltersToUrl({
+      ...DEFAULT_INCIDENT_FILTERS,
+      sreTeamIds: [],
+    });
+    expect(params.has("incSreTeams")).toBe(false);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentsFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentsFiltersUrl.ts
@@ -29,6 +29,7 @@ export const INCIDENT_FILTER_PARAM_KEYS = [
   "incCreatedFrom",
   "incCreatedTo",
   "incProducts",
+  "incSreTeams",
 ] as const;
 
 const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
@@ -84,6 +85,21 @@ function parseProductsCsv(raw: string | null): string[] {
 }
 
 /**
+ * Comma-separated SRE team ids (`sreGroupId` UUIDs) — same shape as
+ * `parseProductsCsv`: not a fixed enum, blank entries dropped. A stale/
+ * hand-edited id that no longer matches a real team just yields an
+ * unexpectedly narrow (possibly empty) result set rather than an error, same
+ * as `parseProductsCsv`'s own tolerance.
+ */
+function parseTeamIdsCsv(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
  * Read incident filters from the URL. An unknown/malformed value (a
  * hand-edited or stale query string) is dropped rather than passed through,
  * so it falls back to the default (unfiltered) behaviour instead of being
@@ -111,6 +127,7 @@ export function readIncidentFiltersFromUrl(
     createdStartDate,
     createdEndDate,
     products: parseProductsCsv(params.get("incProducts")),
+    sreTeamIds: parseTeamIdsCsv(params.get("incSreTeams")),
   };
 }
 
@@ -126,5 +143,6 @@ export function writeIncidentFiltersToUrl(f: IncidentFilters): URLSearchParams {
   if (f.createdStartDate) out.set("incCreatedFrom", f.createdStartDate);
   if (f.createdEndDate) out.set("incCreatedTo", f.createdEndDate);
   if (f.products.length) out.set("incProducts", f.products.join(","));
+  if (f.sreTeamIds.length) out.set("incSreTeams", f.sreTeamIds.join(","));
   return out;
 }

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/problems.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/problems.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import type { BeProblemState } from "@api/backend/types";
+import type { BeProblemSearchFilters, BeProblemState } from "@api/backend/types";
 
 type ChipColor = "default" | "info" | "warning" | "success" | "error";
 
@@ -93,21 +93,48 @@ export function getNextProblemTransition(
 }
 
 /**
- * Filters for the problems list. Deliberately just search + state — see the
- * caveat on `BeProblemSearchFilters.states` in `api/backend/types.ts` (not yet
- * confirmed live against the backend).
+ * Filters for the problems list. Deliberately just search + state + SRE
+ * team — see the caveat on `BeProblemSearchFilters.states` in
+ * `api/backend/types.ts` (not yet confirmed live against the backend).
  */
 export interface ProblemFilters {
   search: string;
   states: BeProblemState[];
+  /** Selected SRE team `sreGroupId`s — sent as a generic
+   * `{ field: "assignmentGroupId", op: "in" }` filter entry (see
+   * `buildProblemSearchFilters`), not a named payload field. */
+  sreTeamIds: string[];
 }
 
 export const DEFAULT_PROBLEM_FILTERS: ProblemFilters = {
   search: "",
   states: [],
+  sreTeamIds: [],
 };
 
 /** Count active (non-search) filters, used for the badge on the Filters button. */
 export function countActiveProblemFilters(filters: ProblemFilters): number {
-  return filters.states.length > 0 ? 1 : 0;
+  return (
+    (filters.states.length > 0 ? 1 : 0) + (filters.sreTeamIds.length > 0 ? 1 : 0)
+  );
+}
+
+/**
+ * Build `ProblemSearchPayload.filters` from the UI's {@link ProblemFilters}
+ * plus the (separately debounced) search text — mirrors
+ * `buildIncidentSearchFilters` in `incidents.ts`.
+ */
+export function buildProblemSearchFilters(
+  filters: ProblemFilters,
+  debouncedSearch: string,
+): BeProblemSearchFilters {
+  return {
+    ...(debouncedSearch.length > 0 && { searchQuery: debouncedSearch }),
+    ...(filters.states.length > 0 && { states: filters.states }),
+    ...(filters.sreTeamIds.length > 0 && {
+      filters: [
+        { field: "assignmentGroupId" as const, op: "in" as const, values: filters.sreTeamIds },
+      ],
+    }),
+  };
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

CS engineers had no way to filter the Incidents, Problems, or Change Requests lists by SRE
team from the CSM webapp, even though the underlying `entity-service` already accepts an
`assignmentGroupId` filter for all three resources (already merged into `main` ahead of this
PR — the webapp's own types just hadn't caught up to that contract). Service Requests already
got this via the earlier Advanced Filters PR (#1630), since SRs are a case-type variant.

No linked issues — scoped directly from a working session.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Add an "SRE Team" filter control to the Simple-mode filter bar on Incidents, Problems, and
Change Requests, wired to the backend's existing `assignmentGroupId` filter.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

FE-only change in `apps/csm-portal/webapp`. Added the generic `field/op/value` filter-array
shape (`BeIncidentFieldFilter`/`BeProblemFieldFilter`/`BeChangeRequestFieldFilter`) to each
resource's search payload type in `api/backend/types.ts`, matching each resource's real
backend allow-list exactly (the three are not identical — Incident accepts 7 fields with 4
ops, Problem only 2 fields with 1 op, Change Request 3 fields with 4 ops). Added `sreTeamIds`
to each resource's filter state, wired into its search-payload builder as
`{field: "assignmentGroupId", op: "in", values: sreTeamIds}`, and added the "SRE Team" control
to each filter bar, sourced from the same `useTeams(true)` hook the cases list's CRE Team
control already uses, filtered to `family === "sre-abt"`.

Live-verified via real network capture against the running local stack (staging backend, real
ServiceNow DEV data): confirmed the URL params on Incidents and Change Requests (both
URL-driven tabs) produce the correct `assignmentGroupId` filter entry in the real outgoing
`POST /incidents/search` / `POST /change-requests/search` request body. Problems' control
renders correctly but that tab isn't URL-driven, matching its existing pattern (not a gap
introduced here).

**Known data gap, not a code issue**: the live team registry's two SRE ABT entries ("Apollo
SRE Group", "Artemis SRE Group") don't have `sreGroupId` populated yet, so the dropdown is
currently empty in the deployed environment until that's configured — same known gap already
flagged on the cases list's own SRE Team control.

## User stories
> Summary of user stories addressed by this change>

- As a CS engineer, I can filter the Incidents/Problems/Change Requests lists by SRE team, the
  same way I can already filter Cases by CRE/SRE team.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Added an SRE Team filter to the Incidents, Problems, and Change Requests lists.

## Documentation
N/A — no `/help` topic exists yet for these three list pages' filter bars (unlike Cases,
which has one); no doc to update.

## Training
N/A — no training content repo impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal CS-engineer tooling, not customer/market-facing.

## Automation tests
 - Unit tests
   > New/updated Vitest coverage for all three resources' filter-building functions and filter-bar controls, plus the shared type additions. `npx vitest run src/features/csm-operations` — 35 files, 394 tests, all passing.
 - Integration tests
   > None added; verified live via real network capture (URL params -> actual outgoing request body) against the running staging backend during development, described in Approach.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, not a Java/Go target for FindSecurityBugs; `eslint` ran clean on every touched file instead.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample apps affected.

## Related PRs
Builds on #1630 ([CSM][Web] Advanced/Simple case filters, OR groups, and a Call Requests
filter bar), which established the same `useTeams(true)` + team-family filtering pattern this
PR reuses for a different set of resources.

## Migrations (if applicable)
N/A — no data migrations; FE-only change against an already-live backend contract.

## Test environment
Local dev stack (`scripts/csm-local-stack.sh up stg-be`): webapp on Node/Vite against the
deployed Choreo staging backend, real ServiceNow-backed data, Chrome (latest) via the
DevTools Protocol for live network-level verification.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Traced the actual runtime call chain for Incidents/Problems/Change Requests before writing any
code — confirmed they bypass the Ballerina `digiops-cs/entity-service` entirely and go
directly from the Go `entity-service` to ServiceNow's `x_wso2_customer_0` scripted API. Read
the real SN Script Includes (live-verified against the deployed
`sys_script_include` records on `wso2sndev`, not just a static doc) before assuming any SN-side
work was needed — found the SN layer already supported the filter, which is why this PR ends
up FE-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SRE Team multi-select filtering for change requests, incidents, and problems.
  * Added support for applying selected SRE teams to search results.
  * Preserved SRE Team selections in shareable URLs for change requests and incidents.
  * Added additional search filter options for supported fields and conditions.

* **Tests**
  * Added coverage for SRE Team selection, filtering, active-filter counts, URL handling, and filter reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->