### PR TITLE
[Scheduled-Tasks] add open_cases_report sub-cron

### DIFF
--- a/operations/csm-scheduled-tasks/CLAUDE.md
+++ b/operations/csm-scheduled-tasks/CLAUDE.md
@@ -139,6 +139,31 @@ query on every tick.
 even though both point at the same `CUSTOMER_ENTITY_SERVICE_BASE_URL`/credentials — see that
 package's own doc comment for why case search isn't just another method on `ledger.Client`.
 
+## Open cases report
+
+`internal/opencases.SendReport`, registered as `"open_cases_report"`, is a narrower, more urgent
+sibling of "Stale cases report" above: it flags a case nobody has even started working on yet,
+rather than any case that's merely been open a long time. Queries entity-service's
+`POST /cases/search` (via `internal/entitycases.Client.SearchCasesInStateCreatedBeforeYesterday`)
+for every case whose `state` is *exactly* `open` (not "any non-closed state" — a case that's since
+moved to `work_in_progress` or anything else no longer belongs here) and whose `createdOn` falls
+before the start of yesterday, then emails a report table of them (oldest first) via
+`notify.RenderOpenCasesReport`.
+
+"Before yesterday" is a calendar-day boundary computed in UTC (start of today, truncated, minus 24
+hours), not a rolling duration like `SearchOpenCasesOlderThan`'s: a case created at 23:59 yesterday
+is excluded, one created at 00:01 the day before is included, regardless of what time of day the
+task itself runs. Same `TZ=UTC` deployment caveat as "Housekeeping" above applies to what "yesterday"
+means in the first place.
+
+Default schedule `0 8 * * *` (daily at 08:00, after "Stale cases report"'s 07:00 slot); override via
+`SUB_CRON_SCHEDULES`. Recipients work exactly like "Stale cases report" above: this task's own
+`SUB_CRON_RECIPIENTS` entry, unrelated to `ALERT_RECIPIENTS`, no report sent (and no entity-service
+query run) if empty. Shares `internal/entitycases.Client` and the row-rendering helpers in
+`internal/notify` with "Stale cases report", but has its own template
+(`internal/notify/templates/open_cases_report.html`) per this component's own "Per-task report
+emails" below.
+
 ## Alerting
 
 Two layers, combined:
@@ -159,16 +184,16 @@ empty — it still fails and retries normally either way, just silently as far a
 `ALERTS_ENABLED` (env var, default `true`) is a global kill switch above both layers —
 `engine.Engine.AlertsEnabled` — for going quiet during a maintenance window or a known-noisy period
 without editing any recipients config. Despite the name, it's not limited to failure alerts: it's
-the single switch for every email this component sends, so `stale_cases_report`'s own report email
-(see "Stale cases report" above) reads the same underlying value directly too, since that email
-isn't sent through `Engine.recordFailure` at all. For a failed task, `false` only silences the
-email — the failure is still recorded in entity-service and logged either way, and retries proceed
-normally. For `stale_cases_report` specifically, `false` skips the entity-service query and report
-rendering entirely, not just the send (see `stalecases.SendReport`'s own doc comment) — the task
-still succeeds and its ledger row still updates, it just does no work that tick. When
-`ALERTS_ENABLED` is `false`, `EMAIL_BASE_URL` is also no longer required at startup even if
-recipients are configured, since no email will ever actually be sent — see
-cmd/server/main.go's startup check.
+the single switch for every email this component sends, so `stale_cases_report`'s and
+`open_cases_report`'s own report emails (see "Stale cases report"/"Open cases report" above) each
+read the same underlying value directly too, since neither is sent through `Engine.recordFailure`
+at all. For a failed task, `false` only silences the email — the failure is still recorded in
+entity-service and logged either way, and retries proceed normally. For either report task
+specifically, `false` skips the entity-service query and report rendering entirely, not just the
+send (see `stalecases.SendReport`/`opencases.SendReport`'s own doc comments) — the task still
+succeeds and its ledger row still updates, it just does no work that tick. When `ALERTS_ENABLED` is
+`false`, `EMAIL_BASE_URL` is also no longer required at startup even if recipients are configured,
+since no email will ever actually be sent — see cmd/server/main.go's startup check.
 
 **Every single failed attempt sends an alert, not just a final give-up** — there is no "fully
 failed" or exhausted state in this design (see "The core mechanism" above), so this fires each time
@@ -184,9 +209,9 @@ that service's own functions of the same name) — task name, period, attempt co
 and the failure's error message.
 
 The engine itself still never sends a success email on any task's behalf — `stale_cases_report`'s
-report (see "Stale cases report" above) is sent from inside that task's own handler, not through
-this alerting path at all. See "Per-task report emails" below for why that's not a generic engine
-feature.
+and `open_cases_report`'s own reports (see "Stale cases report"/"Open cases report" above) are each
+sent from inside that task's own handler, not through this alerting path at all. See "Per-task
+report emails" below for why that's not a generic engine feature.
 
 ## Environment variables
 
@@ -202,7 +227,7 @@ feature.
 | `ALERT_RECIPIENTS` | No | Comma-separated email addresses alerted on every failed sub-cron attempt, for every task — see "Alerting" above |
 | `DRIVER_INTERVAL` | No (default `1h`) | This component's own expected invocation cadence — must match the cron trigger configured on the Choreo Scheduled Task component itself |
 | `SUB_CRON_SCHEDULES` | No | JSON object `{"<task.Name>": "<cron expression>"}` overriding any registered task's schedule by name — see "Adding a sub-cron" above. A task not mentioned keeps its own hardcoded default |
-| `SUB_CRON_RECIPIENTS` | No | JSON object `{"<task.Name>": {"to": [...], "cc": [...]}}` giving a registered task its own extra failure-alert audience, on top of `ALERT_RECIPIENTS` — or, for `stale_cases_report` specifically, its report's actual recipients (see "Stale cases report" above). A task not mentioned gets no per-task recipients |
+| `SUB_CRON_RECIPIENTS` | No | JSON object `{"<task.Name>": {"to": [...], "cc": [...]}}` giving a registered task its own extra failure-alert audience, on top of `ALERT_RECIPIENTS` — or, for a report-style task, its report's actual recipients (see "Alerting" above for which tasks work which way). A task not mentioned gets no per-task recipients |
 | `HOUSEKEEPING_RETENTION_DAYS` | No (default `30`) | Plain integer number of days of resolved history the `housekeeping_cleanup` sub-cron keeps — see "Housekeeping" above |
 
 No app-level execution timeout is configured here — Choreo's own Scheduled Task execution-time
@@ -222,15 +247,19 @@ succeeded" template was tried and dropped early on: different sub-crons want gen
 report content (a usage report reads nothing like a billing summary), so one shared shape would
 either stay generic to the point of being useless or grow special cases per task.
 
-`stale_cases_report` (see "Stale cases report" above) is the first real instance of the shape that
-replaced it: the sub-cron's own package (`internal/stalecases`) owns both its template
-(`internal/notify/templates/stale_cases_report.html`, following `alert.html`'s pattern) and its
-recipients (its own `SUB_CRON_RECIPIENTS` entry, passed into `stalecases.SendReport` as plain `to`/
-`cc` slices) — the report is sent from inside the `Handler` closure itself, entirely outside
-`engine.Engine`'s own success/failure path. A future report-sending sub-cron follows the same
-pattern: its own template, its own render function in `internal/notify`, its own recipients wired
-through in `cmd/server/main.go` — there still isn't, and isn't meant to be, one shared "send a
-report" mechanism in `engine`.
+`stale_cases_report` and `open_cases_report` (see "Stale cases report"/"Open cases report" above)
+are the two real instances of the shape that replaced it. Each sub-cron's own package
+(`internal/stalecases`, `internal/opencases`) owns its own template
+(`internal/notify/templates/{stale,open}_cases_report.html`, following `alert.html`'s pattern) and
+its own recipients (its own `SUB_CRON_RECIPIENTS` entry, passed in as plain `to`/`cc` slices) — the
+report is sent from inside the `Handler` closure itself, entirely outside `engine.Engine`'s own
+success/failure path. What they *do* share is the case-search client (`internal/entitycases.Client`)
+and the row-rendering helpers in `internal/notify` (`renderCaseRows`/`humanizeState`/etc.) — real,
+already-duplicated logic worth sharing, as distinct from the report's own template/copy, which
+stays owned per task on purpose. A future report-sending sub-cron follows the same split: reuse
+whatever's genuinely identical (a case-search method, a rendering helper), but keep its own
+template, its own render function, and its own recipients wired through in `cmd/server/main.go` —
+there still isn't, and isn't meant to be, one shared "send a report" mechanism in `engine`.
 
 ## Future: events
 

--- a/operations/csm-scheduled-tasks/CLAUDE.md
+++ b/operations/csm-scheduled-tasks/CLAUDE.md
@@ -150,13 +150,17 @@ moved to `work_in_progress` or anything else no longer belongs here) and whose `
 before the start of yesterday, then emails a report table of them (oldest first) via
 `notify.RenderOpenCasesReport`.
 
-"Before yesterday" is a calendar-day boundary computed in UTC (start of today, truncated, minus 24
-hours), not a rolling duration like `SearchOpenCasesOlderThan`'s: a case created at 23:59 yesterday
-is excluded, one created at 00:01 the day before is included, regardless of what time of day the
-task itself runs. Same `TZ=UTC` deployment caveat as "Housekeeping" above applies to what "yesterday"
-means in the first place.
+"Before yesterday" is a calendar-day boundary computed in UTC (`time.Now().UTC().Truncate(24 *
+time.Hour)`, minus 24 hours) — always UTC, regardless of the deployment's own `TZ` setting, unlike a
+rolling duration such as `SearchOpenCasesOlderThan`'s: a case created at 23:59 yesterday (UTC) is
+excluded, one created at 00:01 the day before is included, regardless of what time of day the task
+itself runs. The "Housekeeping" section's `TZ=UTC` caveat is about something different — when the
+*cron schedule itself* fires (`internal/schedule.PeriodKey`'s own local-time interpretation) — and
+doesn't apply here: this cutoff is UTC-anchored no matter what `TZ` the process runs with.
 
-Default schedule `0 8 * * *` (daily at 08:00, after "Stale cases report"'s 07:00 slot); override via
+Default schedule `0 8 * * *` (daily at 08:00, after "Stale cases report"'s 07:00 slot — this time
+itself *is* subject to the same `TZ=UTC` caveat as "Housekeeping" above, since it's a cron schedule);
+override via
 `SUB_CRON_SCHEDULES`. Recipients work exactly like "Stale cases report" above: this task's own
 `SUB_CRON_RECIPIENTS` entry, unrelated to `ALERT_RECIPIENTS`, no report sent (and no entity-service
 query run) if empty. Shares `internal/entitycases.Client` and the row-rendering helpers in

--- a/operations/csm-scheduled-tasks/README.md
+++ b/operations/csm-scheduled-tasks/README.md
@@ -31,11 +31,12 @@ csm-scheduled-tasks/
 │   ├── registry/registry.go # Task{Name, Schedule, Handler, RetryBackoff, To, Cc}
 │   ├── engine/engine.go     # Tick: claim → run → report back, once per task per invocation
 │   ├── ledger/client.go     # entity-service client for this component's own durable state (Attempt/Complete/Fail/DeleteResolvedBefore)
-│   ├── entitycases/client.go # Separate, read-only entity-service client for case search — used by report-style sub-crons (see CLAUDE.md, "Stale cases report")
-│   ├── notify/              # Email sending — same internal email service csm-notification-service uses; alert.html (failure alerts) and stale_cases_report.html (see CLAUDE.md, "Per-task report emails")
+│   ├── entitycases/client.go # Separate, read-only entity-service client for case search — used by report-style sub-crons (see CLAUDE.md, "Per-task report emails")
+│   ├── notify/              # Email sending — same internal email service csm-notification-service uses; alert.html (failure alerts) plus one template per report-style sub-cron (see CLAUDE.md, "Per-task report emails")
 │   ├── httpsec/httpsec.go   # Shared HTTPS/redirect guards for ledger, entitycases, and notify's OAuth2 clients
 │   ├── housekeeping/        # Sub-cron: deletes old resolved scheduled_task_run rows (see CLAUDE.md, "Housekeeping")
 │   ├── stalecases/          # Sub-cron: reports cases open too long (see CLAUDE.md, "Stale cases report")
+│   ├── opencases/           # Sub-cron: reports cases still in Open state (see CLAUDE.md, "Open cases report")
 │   └── apierror/errors.go   # Typed upstream-error wrapper, shared by ledger, entitycases, and notify
 ```
 
@@ -52,9 +53,10 @@ go run ./cmd/server
 ```
 
 Each run is one tick against whichever entity-service `.env` points at, then the process exits.
-Two sub-crons are registered today: `housekeeping_cleanup` (see `CLAUDE.md`, "Housekeeping") and
-`stale_cases_report` (see `CLAUDE.md`, "Stale cases report"); see `CLAUDE.md` ("Adding a sub-cron")
-for how to register another.
+Three sub-crons are registered today: `housekeeping_cleanup` (see `CLAUDE.md`, "Housekeeping"),
+`stale_cases_report` (see `CLAUDE.md`, "Stale cases report"), and `open_cases_report` (see
+`CLAUDE.md`, "Open cases report"); see `CLAUDE.md` ("Adding a sub-cron") for how to register
+another.
 
 ## Environment variables
 

--- a/operations/csm-scheduled-tasks/cmd/server/main.go
+++ b/operations/csm-scheduled-tasks/cmd/server/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/housekeeping"
 	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/ledger"
 	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/notify"
+	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/opencases"
 	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/registry"
 	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/stalecases"
 )
@@ -150,6 +151,9 @@ func main() {
 	// if that changes.
 	const staleCaseThreshold = 30 * 24 * time.Hour
 
+	const openCasesTaskName = "open_cases_report"
+	openCasesTo, openCasesCc := recipientsFor(recipientOverrides, openCasesTaskName)
+
 	tasks := []registry.Task{
 		// This component's first real sub-cron: deletes rows from
 		// entity-service's scheduled_task_run table that succeeded or were
@@ -180,6 +184,19 @@ func main() {
 				staleCaseThreshold, staleCasesTo, staleCasesCc, alertsEnabled),
 			To: staleCasesTo,
 			Cc: staleCasesCc,
+		},
+		// Emails openCasesTo/Cc a report of every case created before
+		// yesterday that's still in "open" state (nobody has moved it out of
+		// initial triage) — see internal/opencases's own doc comment. Sends
+		// nothing (but still succeeds) if openCasesTo is empty. Default
+		// schedule is daily at 08:00 (again, TZ=UTC-dependent — see above);
+		// override via SUB_CRON_SCHEDULES if needed.
+		{
+			Name:     openCasesTaskName,
+			Schedule: scheduleFor(scheduleOverrides, openCasesTaskName, "0 8 * * *"),
+			Handler:  opencases.SendReport(entityCasesClient, emailClient, openCasesTo, openCasesCc, alertsEnabled),
+			To:       openCasesTo,
+			Cc:       openCasesCc,
 		},
 	}
 

--- a/operations/csm-scheduled-tasks/internal/entitycases/client.go
+++ b/operations/csm-scheduled-tasks/internal/entitycases/client.go
@@ -146,19 +146,19 @@ type Case struct {
 	UpdatedOn  time.Time
 }
 
-// searchPageSize is the page size SearchOpenCasesOlderThan requests —
-// entity-service's own case-search caps limit at 50 (see that service's
-// normalizePagination), so this just always asks for the largest page
-// allowed, to fetch the fewest pages possible.
+// searchPageSize is the page size searchCases requests — entity-service's
+// own case-search caps limit at 50 (see that service's normalizePagination),
+// so this just always asks for the largest page allowed, to fetch the fewest
+// pages possible.
 const searchPageSize = 50
 
-// maxSearchPages caps how many pages SearchOpenCasesOlderThan will fetch, as
-// a safety net against a huge or unexpectedly-shaped result turning one
-// report run into an unbounded loop. 20 pages at searchPageSize is 1,000
-// cases — an "open more than N days" report anywhere near that size has
-// bigger problems than this cap, but the cap keeps a malformed response
-// (e.g. Total always greater than what's actually returned) from looping
-// forever rather than just producing an incomplete report.
+// maxSearchPages caps how many pages searchCases will fetch, as a safety net
+// against a huge or unexpectedly-shaped result turning one report run into
+// an unbounded loop. 20 pages at searchPageSize is 1,000 cases — a report
+// like this anywhere near that size has bigger problems than this cap, but
+// the cap keeps a malformed response (e.g. Total always greater than what's
+// actually returned) from looping forever rather than just producing an
+// incomplete report.
 const maxSearchPages = 20
 
 // searchCasesRequest/searchCasesFilters/caseFieldFilter/caseSort/pagination
@@ -257,27 +257,48 @@ type searchCasesResponse struct {
 // and whose createdOn is at least olderThan in the past — the entity-service
 // query behind an "open too long" report. Sorted oldest-first (createdOn
 // ascending), so a caller building a report table can just take the
-// returned order as given. Paginates through entity-service's own 50-row
-// page cap internally (see searchPageSize/maxSearchPages); the caller
-// always gets one flat slice back.
+// returned order as given.
+func (c *Client) SearchOpenCasesOlderThan(ctx context.Context, olderThan time.Duration) ([]Case, error) {
+	cutoff := time.Now().Add(-olderThan).UTC().Format(time.RFC3339)
+	return c.searchCases(ctx, []caseFieldFilter{
+		{Field: "state", Op: "notIn", Values: []string{"closed"}},
+		{Field: "createdOn", Op: "lte", Values: []string{cutoff}},
+	})
+}
+
+// SearchCasesInStateCreatedBeforeYesterday returns every case whose state is
+// exactly state (not "not closed" — an exact match, e.g. "open") and whose
+// createdOn falls before the start of yesterday. Unlike
+// SearchOpenCasesOlderThan's rolling-duration cutoff, this is a calendar-day
+// boundary computed in UTC: a case created at 23:59 yesterday is excluded, one
+// created at 00:01 the day before is included, regardless of what time of day
+// this method itself is called — "before yesterday" is a calendar concept,
+// not a fixed number of hours ago. Sorted oldest-first, same as
+// SearchOpenCasesOlderThan.
+func (c *Client) SearchCasesInStateCreatedBeforeYesterday(ctx context.Context, state string) ([]Case, error) {
+	startOfToday := time.Now().UTC().Truncate(24 * time.Hour)
+	startOfYesterday := startOfToday.Add(-24 * time.Hour)
+	cutoff := startOfYesterday.Format(time.RFC3339)
+	return c.searchCases(ctx, []caseFieldFilter{
+		{Field: "state", Op: "in", Values: []string{state}},
+		{Field: "createdOn", Op: "lte", Values: []string{cutoff}},
+	})
+}
+
+// searchCases runs one case-search query to completion, paginating through
+// entity-service's own 50-row page cap internally (see
+// searchPageSize/maxSearchPages) and returning one flat, oldest-first slice.
 //
 // Returns an error, rather than a silently-truncated slice, if the result
 // set is still larger than maxSearchPages*searchPageSize after the last
 // allowed page — a caller building a report from a partial result would
 // otherwise under-report without any indication it happened.
-func (c *Client) SearchOpenCasesOlderThan(ctx context.Context, olderThan time.Duration) ([]Case, error) {
-	cutoff := time.Now().Add(-olderThan).UTC().Format(time.RFC3339)
-
+func (c *Client) searchCases(ctx context.Context, filters []caseFieldFilter) ([]Case, error) {
 	var all []Case
 	offset := 0
 	for page := 0; page < maxSearchPages; page++ {
 		reqBody, err := json.Marshal(searchCasesRequest{
-			Filters: searchCasesFilters{
-				Filters: []caseFieldFilter{
-					{Field: "state", Op: "notIn", Values: []string{"closed"}},
-					{Field: "createdOn", Op: "lte", Values: []string{cutoff}},
-				},
-			},
+			Filters:    searchCasesFilters{Filters: filters},
 			SortBy:     caseSort{Field: "createdOn", Order: "asc"},
 			Pagination: pagination{Limit: searchPageSize, Offset: offset},
 		})

--- a/operations/csm-scheduled-tasks/internal/notify/templates.go
+++ b/operations/csm-scheduled-tasks/internal/notify/templates.go
@@ -33,6 +33,9 @@ var alertTemplateRaw string
 //go:embed templates/stale_cases_report.html
 var staleCasesReportTemplateRaw string
 
+//go:embed templates/open_cases_report.html
+var openCasesReportTemplateRaw string
+
 // wso2LogoURL is the white WSO2 logo variant — the alert template's header
 // sits on an orange background, unlike
 // integrations/csm-notification-service's own equivalent constant of the
@@ -52,6 +55,7 @@ func bakeLogo(raw string) string {
 
 var alertTemplate = bakeLogo(alertTemplateRaw)
 var staleCasesReportTemplate = bakeLogo(staleCasesReportTemplateRaw)
+var openCasesReportTemplate = bakeLogo(openCasesReportTemplateRaw)
 
 // escapeHTML mirrors integrations/csm-notification-service's own
 // internal/notifications.escapeHTML exactly: HTML-escapes s and
@@ -129,6 +133,26 @@ func RenderStaleCasesReport(data StaleCasesReportData) string {
 		"<!-- [YEAR] -->", strconv.Itoa(time.Now().Year()),
 	)
 	return replacer.Replace(staleCasesReportTemplate)
+}
+
+// OpenCasesReportData holds every value substituted into the "cases still in
+// Open state" HTML email template.
+type OpenCasesReportData struct {
+	Cases []entitycases.Case
+}
+
+// RenderOpenCasesReport fills in the "cases still in Open state" HTML email
+// template — shares renderCaseRows with RenderStaleCasesReport (the table
+// shape is identical), but its own template file/copy per this component's
+// own CLAUDE.md ("Per-task report emails" — each report-sending sub-cron
+// owns its own template).
+func RenderOpenCasesReport(data OpenCasesReportData) string {
+	replacer := strings.NewReplacer(
+		"<!-- [CASE_COUNT] -->", strconv.Itoa(len(data.Cases)),
+		"<!-- [CASE_ROWS] -->", renderCaseRows(data.Cases),
+		"<!-- [YEAR] -->", strconv.Itoa(time.Now().Year()),
+	)
+	return replacer.Replace(openCasesReportTemplate)
 }
 
 // renderCaseRows builds one <tr> per case for RenderStaleCasesReport. A case

--- a/operations/csm-scheduled-tasks/internal/notify/templates/open_cases_report.html
+++ b/operations/csm-scheduled-tasks/internal/notify/templates/open_cases_report.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="supported-color-schemes" content="light dark" />
+    <title>CSM Scheduled Tasks: cases still in Open state</title>
+
+    <style type="text/css">
+        @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700;900&display=swap");
+
+        body {
+            font-family: 'Roboto', Helvetica, Arial, sans-serif;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+            margin: 0;
+            padding: 0;
+        }
+
+        table td { border-collapse: collapse; }
+        img { border: 0; outline: none; text-decoration: none; }
+
+        .wso2_orange { color: #ff7300 !important; }
+        .footerContent a { color: #465868; }
+        .footerContent a:hover { color: #ff7300 !important; }
+
+        @media only screen and (max-width: 650px) {
+            .bodyContent { padding: 0 20px 30px !important; }
+        }
+
+        @media (prefers-color-scheme: dark) {
+            body, .bgtest { background-color: #202124 !important; color: #e2e2e2 !important; }
+            .Bodyconetntdark { background-color: #282f34 !important; }
+            p, li, td { color: #e2e2e2 !important; }
+            .wso2_orange { color: #ff957d !important; }
+            .footerContent { color: #a2a3a4 !important; }
+            .footerContent a { color: #bbbdc1 !important; }
+            .reportTable th { background-color: #33383d !important; color: #e2e2e2 !important; }
+            .reportTable td { border-color: #454b52 !important; }
+        }
+    </style>
+</head>
+
+<body class="bgtest" style="margin:0; padding:0; background-color:#f8f9fa;">
+
+    <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:#f8f9fa;">
+        <tr>
+            <td align="center" valign="top">
+
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:800px;">
+                    <tr>
+                        <td align="center" bgcolor="#ff7101" style="padding:30px 0;">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:800px;">
+                                <tr>
+                                    <td align="left" style="padding:0 30px;">
+                                        <img src="<!-- [LOGO_SRC] -->" alt="WSO2 Logo" width="120" style="display:block;" />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td align="left" style="padding:16px 30px 0; color:#ffffff; font-size:13px; font-weight:700; letter-spacing:1px; text-transform:uppercase;">
+                                        CSM Scheduled Tasks &middot; Open Cases Report
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+                <br/>
+
+                <!-- Main Content -->
+                <table bgcolor="#ffffff" border="0" cellpadding="0" cellspacing="0" class="Bodyconetntdark" width="100%" style="max-width:800px; margin:auto; box-shadow:0 2px 12px rgba(0,0,0,0.1);">
+                    <tr>
+                        <td class="bodyContent" style="padding:40px 50px; color:#465868; font-size:16px; line-height:24px; text-align:left;">
+
+                            <p style="margin:0 0 30px;">
+                                <strong><!-- [CASE_COUNT] --></strong> case(s) were created before yesterday and are
+                                still in the <strong>Open</strong> state — nobody has moved them out of initial
+                                triage yet. Oldest first.
+                            </p>
+
+                            <table class="reportTable" border="0" cellpadding="0" cellspacing="0" width="100%" style="font-size:13px; border-collapse:collapse;">
+                                <thead>
+                                    <tr>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Case</th>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Account</th>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Assigned To</th>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">State</th>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Severity</th>
+                                        <th align="right" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Days Open</th>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Updated</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <!-- [CASE_ROWS] -->
+                                </tbody>
+                            </table>
+
+                            <p style="margin:40px 0 0; font-size:13px; color:#8a8f98;">
+                                This is an automated report from the CSM Scheduled Tasks service.
+                            </p>
+
+                        </td>
+                    </tr>
+                </table>
+
+                <!-- Footer -->
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:800px; background-color:#e8eaed; padding:30px 0;">
+                    <tr>
+                        <td align="center" style="padding:0 50px;">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td align="left" class="footerContent" style="color:#465868; font-size:12px; line-height:16px;">
+                                        &copy; <!-- [YEAR] --> WSO2 LLC. All Rights Reserved.
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/operations/csm-scheduled-tasks/internal/opencases/opencases.go
+++ b/operations/csm-scheduled-tasks/internal/opencases/opencases.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package opencases is the "cases still in Open state" report sub-cron: it
+// finds every case created before yesterday that has never moved out of the
+// initial "open" state, and emails a report of them. Distinct from
+// internal/stalecases (any non-closed state, 30 days) — this one flags a
+// narrower, more urgent signal: a case nobody has even started working on
+// yet. Same shape otherwise: see internal/stalecases's own package doc
+// comment for why this report is sent from inside the handler itself, not
+// through engine.Engine's failure-alert path.
+package opencases
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/entitycases"
+	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/notify"
+)
+
+// openState is entity-service's exact CaseState value this report queries —
+// see entity-service's own domain.CaseStateOpen. Unlike
+// stalecases.SendReport's "not closed" filter, this is an exact match: a
+// case that has since moved to work_in_progress (or any other non-open,
+// non-closed state) no longer belongs in this specific report.
+const openState = "open"
+
+// CaseSearcher is the subset of *entitycases.Client this package depends on.
+type CaseSearcher interface {
+	SearchCasesInStateCreatedBeforeYesterday(ctx context.Context, state string) ([]entitycases.Case, error)
+}
+
+// EmailSender is the subset of *notify.Client this package depends on.
+type EmailSender interface {
+	SendEmail(ctx context.Context, to, cc []string, subject, htmlBody string) error
+}
+
+// SendReport returns a registry.Task.Handler that finds every case created
+// before yesterday and still in "open" state, and emails to/cc a report of
+// them. Recipients are exactly this task's own SUB_CRON_RECIPIENTS entry
+// (see cmd/server/main.go) — same reasoning as stalecases.SendReport's own
+// doc comment: unrelated to the standing ALERT_RECIPIENTS failure-alert
+// audience.
+//
+// emailsEnabled is cmd/server/main.go's ALERTS_ENABLED — see
+// stalecases.SendReport's own doc comment for why this silences report
+// emails too, not just failure alerts.
+//
+// If emailsEnabled is false or to is empty, the returned handler skips the
+// case search entirely and returns nil (success) — same reasoning as
+// stalecases.SendReport.
+func SendReport(cases CaseSearcher, email EmailSender, to, cc []string, emailsEnabled bool) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		if !emailsEnabled || len(to) == 0 {
+			return nil
+		}
+
+		found, err := cases.SearchCasesInStateCreatedBeforeYesterday(ctx, openState)
+		if err != nil {
+			return fmt.Errorf("opencases: search open cases: %w", err)
+		}
+
+		subject := "[Action-Required][Report] Cases created before yesterday still in Open state"
+		body := notify.RenderOpenCasesReport(notify.OpenCasesReportData{
+			Cases: found,
+		})
+		if err := email.SendEmail(ctx, to, cc, subject, body); err != nil {
+			return fmt.Errorf("opencases: send report email: %w", err)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `open_cases_report`, a third sub-cron on `operations/csm-scheduled-tasks`, which reports every case created before yesterday that's still in the exact `open` state (nobody has moved it out of initial triage) — a narrower, more urgent signal than `stale_cases_report`'s "any non-closed state, 30 days" check.
- "Before yesterday" is a calendar-day boundary computed in UTC (start of today, truncated, minus 24 hours) via a new `entitycases.Client.SearchCasesInStateCreatedBeforeYesterday` method — not a rolling duration like `SearchOpenCasesOlderThan`'s, so the report doesn't drift with what time of day the task happens to run.
- Generalizes `entitycases.Client`'s pagination/date-parsing into a private `searchCases` helper shared by both `SearchOpenCasesOlderThan` and the new method — no behavior change to the existing `stale_cases_report` path.
- New `internal/opencases` package, following the same shape as `internal/stalecases`: its own template (`internal/notify/templates/open_cases_report.html`) and render function (`notify.RenderOpenCasesReport`), reusing the shared row-rendering helpers already in `internal/notify`.
- Registered as `open_cases_report`, default schedule `0 8 * * *` (after `stale_cases_report`'s 07:00 slot), recipients via its own `SUB_CRON_RECIPIENTS` entry (no report sent if unconfigured, unrelated to `ALERT_RECIPIENTS`), respects `ALERTS_ENABLED`.
- CLAUDE.md/README.md updated to document the new sub-cron and generalize the shared config docs (per earlier feedback, not naming a specific task in `.env.example`).

## Test plan
- [x] `gofmt -l .`, `go build ./...`, `go vet ./...` clean
- [x] `gosec ./...` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities
- [x] Verified the "before yesterday" UTC calendar-boundary math, the state=`in [open]` filter shape, and `opencases.SendReport`'s subject/body rendering and enable/recipients skip logic, via temporary scratch tests against synthetic data (not committed)
- [ ] Live end-to-end verification against a real entity-service deployment (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a daily email report for cases that remain in the **Open** state and were created before the previous day.
  * Reports include case counts, case details, WSO2 branding, and responsive light/dark email layouts.
  * Added configuration for report recipients, scheduling, alerting, and email enablement.
* **Documentation**
  * Updated setup and local-running documentation to include the new scheduled report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->