### PR TITLE
[CSM Portal] Fix content area collapsing during silent-reauth recovery

### DIFF
--- a/apps/csm-portal/webapp/src/layouts/AppLayout.silentAuth.test.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppLayout.silentAuth.test.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+// Regression test for the "silent re-auth stretches the UI" bug: once the
+// app has initialized (a real page has been shown at least once), a LATER
+// transient flip of the Asgardeo SDK's `isLoading` flag -- which happens
+// when `useAuthApiClient.ts`'s recovery chain calls `signIn()` to force a
+// full re-authentication redirect after a dead refresh token, shortly
+// before the browser actually navigates away -- must NOT collapse the
+// content area's padding back to 0. Reproduced live against a real
+// deployment by expiring the stored token and corrupting its refresh
+// token, then diffing `getBoundingClientRect()` of the page content across
+// the recovery window: the content box's x-inset measurably dropped from
+// 88px (64px sidebar + 24px padding) to 64px (padding collapsed to 0) and
+// back, i.e. the content visibly snapped to the edges and back -- while
+// `useAsgardeo().isLoading` was live-read (not latched) by `AppLayout`'s
+// padding sx.
+vi.mock("@wso2/oxygen-ui", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@wso2/oxygen-ui")>()),
+  useAppShell: () => ({
+    state: { sidebarCollapsed: false, expandedMenus: [] },
+    actions: { toggleSidebar: vi.fn(), setActiveMenuItem: vi.fn(), toggleMenu: vi.fn() },
+  }),
+}));
+
+// Mutable across renders so the test can simulate the SDK's `isLoading`
+// flipping true -> false (initial sign-in settles) -> true again (a later
+// forced-redirect attempt) without remounting the component.
+const asgardeoState: { isLoading: boolean; isSignedIn: boolean } = {
+  isLoading: true,
+  isSignedIn: true,
+};
+vi.mock("@asgardeo/react", () => ({
+  useAsgardeo: () => ({ ...asgardeoState }),
+}));
+
+vi.mock("@context/linear-loader/LoaderContext", () => ({
+  useLoader: () => ({ isVisible: false }),
+}));
+vi.mock("@context/error-page/ErrorPageContext", () => ({
+  useErrorPageContext: () => ({ isErrorPageDisplayed: false }),
+}));
+vi.mock("@providers/IdleTimeoutProvider", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@context/case-tabs/CaseTabsContext", () => ({
+  CaseTabsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@features/case-tabs/components/CaseTabsWorkspace", () => ({
+  CaseTabsContentHost: () => null,
+  CaseTabStripBar: () => null,
+}));
+vi.mock("@features/csm-recent/hooks/useRecentViews", () => ({
+  useSyncRecentViewsIdentity: () => undefined,
+}));
+vi.mock("@components/notification-banner/GlobalNotificationBanner", () => ({
+  default: () => null,
+}));
+vi.mock("@components/announcement-banner/HtmlAnnouncementBanner", () => ({
+  default: () => null,
+}));
+vi.mock("@components/mobile-app-banner/MobileAppBanner", () => ({ default: () => null }));
+vi.mock("@components/top-banner/TopBanner", () => ({ default: () => null }));
+vi.mock("@components/header/Header", () => ({ default: () => <div data-testid="header" /> }));
+vi.mock("@components/side-nav-bar/CsmSideBar", () => ({ default: () => null }));
+
+const { default: AppLayout } = await import("./AppLayout");
+
+describe("AppLayout content padding across a post-init auth loading flip", () => {
+  it("keeps the content area's padding once initialized, even when isLoading flips true again later", () => {
+    asgardeoState.isLoading = true;
+    asgardeoState.isSignedIn = true;
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={["/cases"]}>
+        <AppLayout>
+          <div data-testid="routed-page" />
+        </AppLayout>
+      </MemoryRouter>,
+    );
+
+    // Cold boot: routed content isn't shown yet (the one-time loading
+    // spinner is) -- unaffected by this fix, just establishing the starting
+    // state.
+    expect(screen.queryByTestId("routed-page")).not.toBeInTheDocument();
+
+    // Initial auth settles -- `hasInitialized` latches true and the routed
+    // page appears, padded.
+    asgardeoState.isLoading = false;
+    rerender(
+      <MemoryRouter initialEntries={["/cases"]}>
+        <AppLayout>
+          <div data-testid="routed-page" />
+        </AppLayout>
+      </MemoryRouter>,
+    );
+
+    const routedPage = screen.getByTestId("routed-page");
+    const contentBox = routedPage.parentElement;
+    expect(contentBox).not.toBeNull();
+    expect(contentBox).toHaveStyle({ padding: "24px" });
+
+    // A later recovery-chain-forced `signIn()` flips `isLoading` true again
+    // (see useAuthApiClient.ts's `redirectToSignIn`) well after init. The
+    // padding must NOT collapse back to 0 this time -- that collapse (and
+    // the snap-back once it resolves) is exactly the reported "stretch".
+    asgardeoState.isLoading = true;
+    rerender(
+      <MemoryRouter initialEntries={["/cases"]}>
+        <AppLayout>
+          <div data-testid="routed-page" />
+        </AppLayout>
+      </MemoryRouter>,
+    );
+
+    const contentBoxAfter = screen.getByTestId("routed-page").parentElement;
+    expect(contentBoxAfter).toHaveStyle({ padding: "24px" });
+  });
+});

--- a/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
@@ -229,7 +229,25 @@ export default function AppLayout({
                   display: "flex",
                   flexDirection: "column",
                   overflow: "auto",
-                  ...(isAuthLoading ? { p: 0 } : { p: 3 }),
+                  // Zero padding only for the initial cold-boot loading spinner
+                  // below (centers it flush, no boxed inset). Gated on the
+                  // `hasInitialized` LATCH, not the live `isAuthLoading` flag
+                  // directly: once the app has initialized once, `isAuthLoading`
+                  // can still flip true again later — e.g. the recovery chain in
+                  // `useAuthApiClient.ts` calls `signIn()` for a forced
+                  // re-authentication redirect after a dead refresh token, and
+                  // the SDK sets its loading flag before that redirect actually
+                  // navigates away. Reading the live flag here made the padding
+                  // (and therefore the content width/position) collapse to 0 and
+                  // snap back for that whole window on every such recovery,
+                  // visible as the content area suddenly stretching edge-to-edge
+                  // and back — reproduced and measured via getBoundingClientRect
+                  // during a forced-expiry repro; see the task notes for the
+                  // exact before/after rects. `hasInitialized` already exists as
+                  // the one-way "have we ever finished initial auth" latch (see
+                  // its own effect above) and is the correct gate for a
+                  // one-time-only layout decision like this.
+                  ...(hasInitialized ? { p: 3 } : { p: 0 }),
                 }}
               >
                 {!hasInitialized ? (


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

When a user's refresh token has expired mid-session, the CSM portal performs a silent re-auth. During the recovery window right before that resolves (or falls through to a forced sign-in redirect), the main content area visibly collapses to the viewport edge and then snaps back, making the page look stretched/misaligned for a couple of seconds.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Keep the content area's layout (padding) stable throughout any post-initial-load auth state change, so the auth SDK's transient loading flag never causes a visible layout shift once the app has already rendered once.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Root cause: `AppLayout.tsx`'s main content `Box` set its padding directly from the Asgardeo SDK's raw `isAuthLoading` flag (`isAuthLoading ? p:0 : p:3`). That flag isn't only `true` during initial app boot — it flips `true` again later in the session when the token-refresh recovery chain in `useAuthApiClient.ts` (retry → silent reauth attempt → poll → forced sign-in redirect) is exhausted, right before the browser navigates away for a full sign-in. During that window the padding collapses from 24px to 0px, then snaps back once the flag settles.

Fix: use the existing `hasInitialized` latch (already used a few lines away in the same component, for sidebar/header-controls visibility, for the identical reason) instead of the raw `isAuthLoading` flag when deciding content padding. Once the app has initialized once, padding stays stable regardless of later auth-loading blips.

Verified empirically by measuring `getBoundingClientRect()` of page content across a forced silent-reauth recovery window: content inset went 88px → 64px → 88px before the fix, and stayed stable at 88px after.

## User stories
> Summary of user stories addressed by this change

As a CS engineer using the CSM portal, when my session token silently refreshes in the background, the page layout should not visibly jump/stretch.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed a UI glitch where the CSM portal's main content area would briefly collapse to the viewport edge and snap back during a background token refresh.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal rendering bug fix, no user-facing behavior or flow changes to document.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal bug fix, not a feature.

## Automation tests
 - Unit tests
   > Added `AppLayout.silentAuth.test.tsx`: mounts `AppLayout` with a controllable `useAsgardeo` mock, drives `isLoading` true → false → true (simulating a post-initial-load auth blip), and asserts content padding stays at 24px on the second flip. Fails against the pre-fix code (received `padding: 0px`), passes against the fix. Full suite: 249 test files, 2546 tests, all passing.
 - Integration tests
   > Manually verified against real stg-be traffic: reproduced an expired-refresh-token scenario per the original bug report and measured DOM layout before/after the fix.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A — pure CSS/layout logic change, no security surface
 - Ran FindSecurityBugs plugin and verified report? N/A — not applicable to this TypeScript/React codebase
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Node/npm per repo `apps/csm-portal/webapp/package.json`; tested against CSM staging backend (stg-be) in Chrome via CDP.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the main content area from unexpectedly collapsing its padding during later authentication activity.
  * Maintained consistent page spacing after initial authentication, including during re-authentication redirects.

* **Tests**
  * Added regression coverage to verify content padding remains consistent when authentication loading resumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->