### PR TITLE
[CSM Portal] Add product vulnerability full-replace sync endpoint

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2998,6 +2998,37 @@ type SearchProductVulnerabilitiesResponse struct {
 	Offset                 int                        `json:"offset"`
 }
 
+// ProductVulnerabilitySyncItem is one entry submitted to a full-replace sync of product
+// vulnerabilities. WSO2ID is the join key the downstream data source uses to match this item
+// against an existing record.
+type ProductVulnerabilitySyncItem struct {
+	WSO2ID                 string `json:"wso2Id"`
+	ComponentName          string `json:"componentName"`
+	ApprovedBySecurityTeam bool   `json:"approvedBySecurityTeam"`
+	ComponentType          string `json:"componentType"`
+	ComponentVersion       string `json:"componentVersion"`
+	CVE                    string `json:"cve"`
+	Justification          string `json:"justification"`
+	ProductName            string `json:"productName"`
+	ProductVersion         string `json:"productVersion"`
+	Resolution             string `json:"resolution"`
+	ScannerName            string `json:"scannerName"`
+	Severity               any    `json:"severity"`
+	UpdateLevel            string `json:"updateLevel"`
+	UseCase                string `json:"useCase"`
+	VulnerabilityID        string `json:"vulnerabilityId"`
+	WSO2Resolution         string `json:"wso2Resolution"`
+}
+
+// ProductVulnerabilitySyncResult reports the outcome of a full-replace product vulnerability
+// sync. Fields are pointers because the downstream data source may omit or partially populate
+// them; a nil field means the count was not reported, not that it was zero.
+type ProductVulnerabilitySyncResult struct {
+	InsertedRecords *int `json:"insertedRecords,omitempty"`
+	UpdatedRecords  *int `json:"updatedRecords,omitempty"`
+	DeletedRecords  *int `json:"deletedRecords,omitempty"`
+}
+
 // CallRequestStateType is the state of a call request as a domain string enum.
 type CallRequestStateType string
 

--- a/entity-service/internal/handler/product_vulnerability_handler.go
+++ b/entity-service/internal/handler/product_vulnerability_handler.go
@@ -62,3 +62,23 @@ func (h *ProductVulnerabilityHandler) GetProductVulnerability(w http.ResponseWri
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(result)
 }
+
+// SyncProductVulnerabilities handles POST /products/vulnerabilities/sync.
+//
+// This is a full-replace sync: the submitted items MUST be the complete current set of
+// product vulnerabilities, never a partial delta. The downstream data source deletes any
+// existing record not present in the submitted items and upserts everything that is.
+func (h *ProductVulnerabilityHandler) SyncProductVulnerabilities(w http.ResponseWriter, r *http.Request) {
+	var req []domain.ProductVulnerabilitySyncItem
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	result, err := h.svc.SyncProductVulnerabilities(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(result)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -348,6 +348,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	if productVulnerabilityHandler != nil {
 		mux.HandleFunc("POST /products/vulnerabilities/search", productVulnerabilityHandler.SearchProductVulnerabilities)
 		mux.HandleFunc("GET /products/vulnerabilities/{id}", productVulnerabilityHandler.GetProductVulnerability)
+		mux.HandleFunc("POST /products/vulnerabilities/sync", productVulnerabilityHandler.SyncProductVulnerabilities)
 	}
 
 	if itServiceHandler != nil {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -440,6 +440,13 @@ type ProductVulnerabilityService interface {
 	// GetProductVulnerability returns the detail of a single vulnerability by its UUID.
 	// A NotFoundError is returned if the vulnerability does not exist.
 	GetProductVulnerability(ctx context.Context, id string) (domain.ProductVulnerabilityView, error)
+
+	// SyncProductVulnerabilities replaces the full set of product vulnerabilities with the
+	// given items. This is a full-replace sync: ServiceNow deletes any existing record whose
+	// WSO2ID is not present in items and upserts everything that is. Callers MUST submit the
+	// complete current set, never a partial delta, or downstream records will be deleted.
+	// Supported by the ServiceNow data source only.
+	SyncProductVulnerabilities(ctx context.Context, items []domain.ProductVulnerabilitySyncItem) (domain.ProductVulnerabilitySyncResult, error)
 }
 
 // AlertService defines the operations available on alerts.

--- a/entity-service/internal/service/sn_product_vulnerability_service.go
+++ b/entity-service/internal/service/sn_product_vulnerability_service.go
@@ -185,3 +185,83 @@ func (s *snProductVulnerabilityService) GetProductVulnerability(ctx context.Cont
 
 	return snVulnerabilityToView(v), nil
 }
+
+// snProductVulnerabilitySyncItem mirrors the Choreo POST /products/vulnerabilities/sync
+// request item shape.
+type snProductVulnerabilitySyncItem struct {
+	WSO2ID                 string `json:"wso2Id"`
+	ComponentName          string `json:"componentName"`
+	ApprovedBySecurityTeam bool   `json:"approvedBySecurityTeam"`
+	ComponentType          string `json:"componentType"`
+	ComponentVersion       string `json:"componentVersion"`
+	CVE                    string `json:"cve"`
+	Justification          string `json:"justification"`
+	ProductName            string `json:"productName"`
+	ProductVersion         string `json:"productVersion"`
+	Resolution             string `json:"resolution"`
+	ScannerName            string `json:"scannerName"`
+	Severity               any    `json:"severity"`
+	UpdateLevel            string `json:"updateLevel"`
+	UseCase                string `json:"useCase"`
+	VulnerabilityID        string `json:"vulnerabilityId"`
+	WSO2Resolution         string `json:"wso2Resolution"`
+}
+
+// snProductVulnerabilitySyncResponse mirrors the Choreo POST /products/vulnerabilities/sync
+// response body. Fields are pointers because the downstream service may omit or partially
+// populate them.
+type snProductVulnerabilitySyncResponse struct {
+	InsertedRecords *int `json:"insertedRecords,omitempty"`
+	UpdatedRecords  *int `json:"updatedRecords,omitempty"`
+	DeletedRecords  *int `json:"deletedRecords,omitempty"`
+}
+
+func snProductVulnerabilitySyncItemFromDomain(item domain.ProductVulnerabilitySyncItem) snProductVulnerabilitySyncItem {
+	return snProductVulnerabilitySyncItem{
+		WSO2ID:                 item.WSO2ID,
+		ComponentName:          item.ComponentName,
+		ApprovedBySecurityTeam: item.ApprovedBySecurityTeam,
+		ComponentType:          item.ComponentType,
+		ComponentVersion:       item.ComponentVersion,
+		CVE:                    item.CVE,
+		Justification:          item.Justification,
+		ProductName:            item.ProductName,
+		ProductVersion:         item.ProductVersion,
+		Resolution:             item.Resolution,
+		ScannerName:            item.ScannerName,
+		Severity:               item.Severity,
+		UpdateLevel:            item.UpdateLevel,
+		UseCase:                item.UseCase,
+		VulnerabilityID:        item.VulnerabilityID,
+		WSO2Resolution:         item.WSO2Resolution,
+	}
+}
+
+// SyncProductVulnerabilities replaces the full set of product vulnerabilities with the given
+// items. This is a machine-to-machine call with no end-user identity: unlike the read methods
+// above, it does not forward a user id token — the downstream endpoint is triggered by a
+// system/scheduled caller, not an interactive user session, so no x-user-id-token is available
+// to forward. An empty token is passed, which the client omits the header for (see
+// integrationservice.Client.Post).
+func (s *snProductVulnerabilityService) SyncProductVulnerabilities(ctx context.Context, items []domain.ProductVulnerabilitySyncItem) (domain.ProductVulnerabilitySyncResult, error) {
+	payload := make([]snProductVulnerabilitySyncItem, 0, len(items))
+	for _, item := range items {
+		payload = append(payload, snProductVulnerabilitySyncItemFromDomain(item))
+	}
+
+	raw, err := s.client.Post(ctx, "/products/vulnerabilities/sync", "", payload)
+	if err != nil {
+		return domain.ProductVulnerabilitySyncResult{}, err
+	}
+
+	var snResp snProductVulnerabilitySyncResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.ProductVulnerabilitySyncResult{}, fmt.Errorf("sn sync product vulnerabilities: parse response: %w", err)
+	}
+
+	return domain.ProductVulnerabilitySyncResult{
+		InsertedRecords: snResp.InsertedRecords,
+		UpdatedRecords:  snResp.UpdatedRecords,
+		DeletedRecords:  snResp.DeletedRecords,
+	}, nil
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2407,6 +2407,52 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /products/vulnerabilities/sync:
+    post:
+      summary: >-
+        Full-replace sync of product vulnerabilities (ServiceNow data source only).
+      description: >-
+        This is a full-replace sync, not an incremental update. The submitted items MUST be
+        the complete current set of product vulnerabilities: the downstream data source
+        deletes any existing record whose wso2Id is not present in the submitted array and
+        upserts everything that is. Submitting a partial list will delete the records omitted
+        from it. Intended for machine-to-machine callers (e.g. a scheduled sync job), not
+        interactive user sessions.
+      operationId: syncProductVulnerabilities
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/ProductVulnerabilitySyncItem'
+      responses:
+        "201":
+          description: Sync applied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductVulnerabilitySyncResult'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /alerts/{id}:
     get:
       summary: Get an alert by ID.
@@ -8034,6 +8080,62 @@ components:
           type: integer
         offset:
           type: integer
+
+    ProductVulnerabilitySyncItem:
+      type: object
+      description: >-
+        One entry in a full-replace product vulnerability sync. wso2Id is the join key used
+        to match this item against an existing record.
+      required:
+        - wso2Id
+      properties:
+        wso2Id:
+          type: string
+        componentName:
+          type: string
+        approvedBySecurityTeam:
+          type: boolean
+        componentType:
+          type: string
+        componentVersion:
+          type: string
+        cve:
+          type: string
+        justification:
+          type: string
+        productName:
+          type: string
+        productVersion:
+          type: string
+        resolution:
+          type: string
+        scannerName:
+          type: string
+        severity: {}
+        updateLevel:
+          type: string
+        useCase:
+          type: string
+        vulnerabilityId:
+          type: string
+        wso2Resolution:
+          type: string
+
+    ProductVulnerabilitySyncResult:
+      type: object
+      description: >-
+        Outcome of a full-replace product vulnerability sync. Fields may be omitted by the
+        downstream data source if a count was not reported.
+      properties:
+        insertedRecords:
+          type: integer
+          nullable: true
+        updatedRecords:
+          type: integer
+          nullable: true
+        deletedRecords:
+          type: integer
+          nullable: true
 
     CallRequestState:
       type: object


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The Go entity-service exposes read-only product vulnerability endpoints (`search`, `get`, `meta`) but has no way to write vulnerability data. A separate scheduled sync job needs a write path to refresh the full set of product vulnerabilities from an upstream scanner feed.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Add `POST /products/vulnerabilities/sync` to the Go entity-service that accepts the complete current set of product vulnerabilities and applies it as a full replace.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Mirrors the existing three product-vulnerability methods:
- `interfaces.go`: adds `SyncProductVulnerabilities` to `ProductVulnerabilityService`, documented as a full-replace operation — the downstream data source deletes any existing record whose join key is not present in the submitted items and upserts everything that is, so callers must submit the complete current set, never a partial delta.
- `sn_product_vulnerability_service.go`: implements the method on `snProductVulnerabilityService`, POSTing to a corresponding new resource on the same backing service the existing read methods already call (a corresponding entity-service change is tracked separately). This call is machine-to-machine with no end-user identity, so it forwards an empty token — the client already omits the identity header when the token is empty, same as the existing read paths do when no token is present.
- `entity.go`: adds `ProductVulnerabilitySyncItem` (request item) and `ProductVulnerabilitySyncResult` (response, pointer fields since counts may be partially reported) domain types, following this file's existing conventions for the entity.
- `product_vulnerability_handler.go`: adds `SyncProductVulnerabilities`, decoding a JSON array body and responding `201 Created` (a write, unlike the existing `200` read responses).
- `routes.go`: wires `POST /products/vulnerabilities/sync` into the existing `productVulnerabilityHandler != nil` block, gated the same way as the other three routes (ServiceNow data source only).
- `openapi.yaml`: documents the new path and its two new schemas, including an explicit warning that this is a full-replace sync and a partial submission causes downstream data loss.

Purely additive — the existing search/get/meta routes, handlers, and service methods are untouched.

## User stories
> Summary of user stories addressed by this change

As a scheduled sync job, I can push the full current set of product vulnerabilities to the entity-service so downstream consumers see up-to-date vulnerability data without the entity-service needing direct access to the scanner feed.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Added a write endpoint to the Go entity-service for syncing the full set of product vulnerabilities.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A — this is a machine-to-machine sync endpoint for a backend job, not a user-facing feature; no product/user documentation is affected.

## Training
N/A — no training content impact for this internal sync endpoint.

## Certification
N/A — no certification exam impact for this internal sync endpoint.

## Marketing
N/A — no user-facing feature to promote.

## Automation tests
 - Unit tests
   > Sibling methods (`SearchProductVulnerabilities`, `GetProductVulnerability`, `GetVulnerabilityMeta`) have no dedicated unit tests in this package, so no new test file was added for the new method — matching the existing coverage convention for this entity rather than introducing a new one.
 - Integration tests
   > None available in this worktree: the downstream resource this endpoint calls has not been deployed to any reachable environment yet. Verified via `go build ./...`, `go vet ./...`, and the full existing test suite (`go test ./...`), all passing.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — not part of this Go module's toolchain; relied on `go vet` instead
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new samples for this internal endpoint.

## Related PRs
> List any other related PRs

A corresponding entity-service change (separate repo, tracked separately) adds the resource this endpoint proxies to. Not linked here per repo policy on cross-repo references.

## Migrations (if applicable)
N/A — no schema or data migration; this is a stateless proxy endpoint.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Go toolchain per `go.mod` in this module, macOS (Darwin), no browser/DB involved — built and tested locally in a git worktree; no live call against the downstream service was possible (not yet deployed anywhere reachable).

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Followed the existing pattern in this file set for the three read methods on this entity (request/response struct shape, error handling via `client.Post` + `writeServiceError`, data-source gating in `routes.go`).
