### PR TITLE
[CSM Portal] Add POST /vulnerabilities/sync to csm-integration-service

### DIFF
--- a/integrations/csm-integration-service/README.md
+++ b/integrations/csm-integration-service/README.md
@@ -120,7 +120,8 @@ csm-integration-service/
 │   └── handler/
 │       ├── response.go           # Shared writeError/writeJSON/mapUpstreamError + ErrMsg*
 │       ├── accounts.go           # HTTP handlers for account endpoints
-│       └── projects.go           # HTTP handlers for project endpoints
+│       ├── projects.go           # HTTP handlers for project endpoints
+│       └── vulnerabilities.go    # HTTP handler for the product-vulnerability sync endpoint
 ├── .choreo/component.yaml
 ├── openapi.yaml
 └── .env.example
@@ -136,6 +137,7 @@ csm-integration-service/
 - `POST /projects/search` — search projects
 - `POST /projects/{id}/contacts/search` — search a project's contacts
 - `PATCH /projects/{id}` — update project closure-state fields (ACP automation; currently always 401s, see Overview above)
+- `POST /vulnerabilities/sync` — full-replace sync of product-vulnerability records (submit the complete current set on every call, not a delta)
 
 All responses are raw JSON passthrough from the entity service — this service does not
 reshape upstream response bodies.
@@ -149,4 +151,5 @@ curl -X POST http://localhost:8080/accounts/<id>/contacts/search -d '{}'
 curl -X POST http://localhost:8080/projects/search -d '{}'
 curl http://localhost:8080/projects/<id>
 curl -X POST http://localhost:8080/projects/<id>/contacts/search -d '{}'
+curl -X POST http://localhost:8080/vulnerabilities/sync -d '[]'
 ```

--- a/integrations/csm-integration-service/cmd/server/main.go
+++ b/integrations/csm-integration-service/cmd/server/main.go
@@ -50,6 +50,7 @@ func main() {
 	entityClient := entity.NewClient(cfg)
 	accountHandler := handler.NewAccountHandler(entityClient)
 	projectHandler := handler.NewProjectHandler(entityClient)
+	vulnerabilityHandler := handler.NewVulnerabilityHandler(entityClient)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
@@ -62,6 +63,7 @@ func main() {
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("POST /projects/{id}/contacts/search", projectHandler.SearchProjectContacts)
 	mux.HandleFunc("PATCH /projects/{id}", projectHandler.UpdateProject)
+	mux.HandleFunc("POST /vulnerabilities/sync", vulnerabilityHandler.SyncProductVulnerabilities)
 
 	addr := ":" + envOrDefault("PORT", "8080")
 

--- a/integrations/csm-integration-service/internal/entity/entity.go
+++ b/integrations/csm-integration-service/internal/entity/entity.go
@@ -73,3 +73,14 @@ func (c *Client) SearchProjectContacts(ctx context.Context, projectID string, bo
 func (c *Client) UpdateProject(ctx context.Context, id string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/projects/%s", url.PathEscape(id)), body)
 }
+
+// SyncProductVulnerabilities calls POST /products/vulnerabilities/sync on the entity
+// service. This is a full-replace sync: the caller must submit the complete current set
+// of product-vulnerability records on every call, not an incremental delta — the
+// downstream ServiceNow-backed operation deletes any existing record not present in the
+// submitted set. Unlike UpdateProject, this entity-service operation accepts pure M2M
+// calls with no forwarded end-user token, so this call is expected to succeed.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) SyncProductVulnerabilities(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/products/vulnerabilities/sync", body)
+}

--- a/integrations/csm-integration-service/internal/handler/helpers_test.go
+++ b/integrations/csm-integration-service/internal/handler/helpers_test.go
@@ -159,3 +159,16 @@ func (m *mockEntityProjectClient) UpdateProject(ctx context.Context, id string, 
 	}
 	return []byte(`{}`), nil
 }
+
+// ----- mock entity vulnerability client -----
+
+type mockEntityVulnerabilityClient struct {
+	syncProductVulnerabilitiesFn func(ctx context.Context, body []byte) ([]byte, error)
+}
+
+func (m *mockEntityVulnerabilityClient) SyncProductVulnerabilities(ctx context.Context, body []byte) ([]byte, error) {
+	if m.syncProductVulnerabilitiesFn != nil {
+		return m.syncProductVulnerabilitiesFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}

--- a/integrations/csm-integration-service/internal/handler/vulnerabilities.go
+++ b/integrations/csm-integration-service/internal/handler/vulnerabilities.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+// entityVulnerabilityClient abstracts the entity service product-vulnerability
+// operations used by VulnerabilityHandler.
+type entityVulnerabilityClient interface {
+	SyncProductVulnerabilities(ctx context.Context, body []byte) ([]byte, error)
+}
+
+// VulnerabilityHandler handles HTTP requests for product-vulnerability operations,
+// delegating to the entity service for data access. See AccountHandler's doc
+// comment: there is no end-user identity checked here — Choreo's API Manager
+// gateway is the trust boundary for this service's M2M/third-party consumers.
+type VulnerabilityHandler struct {
+	entity entityVulnerabilityClient
+}
+
+// NewVulnerabilityHandler creates a VulnerabilityHandler backed by the given entity client.
+func NewVulnerabilityHandler(entity entityVulnerabilityClient) *VulnerabilityHandler {
+	return &VulnerabilityHandler{entity: entity}
+}
+
+// SyncProductVulnerabilities handles POST /vulnerabilities/sync. The request body is
+// forwarded to the entity service verbatim. This is a full-replace sync — the caller
+// must submit the complete current set of product-vulnerability records on every
+// call, not an incremental delta; the entity service's downstream ServiceNow-backed
+// operation deletes any existing record not present in the submitted set. Unlike
+// UpdateProject, this entity-service operation accepts pure M2M calls with no
+// forwarded end-user token, so this call is expected to actually succeed.
+func (h *VulnerabilityHandler) SyncProductVulnerabilities(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SyncProductVulnerabilities(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SyncProductVulnerabilities failed", "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to sync product vulnerabilities.")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, result)
+}

--- a/integrations/csm-integration-service/internal/handler/vulnerabilities_test.go
+++ b/integrations/csm-integration-service/internal/handler/vulnerabilities_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSyncProductVulnerabilities(t *testing.T) {
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewVulnerabilityHandler(&mockEntityVulnerabilityClient{})
+		r := httptest.NewRequest(http.MethodPost, "/vulnerabilities/sync", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1)))
+		w := httptest.NewRecorder()
+		h.SyncProductVulnerabilities(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewVulnerabilityHandler(&mockEntityVulnerabilityClient{})
+		r := httptest.NewRequest(http.MethodPost, "/vulnerabilities/sync", strings.NewReader(`not-json`))
+		w := httptest.NewRecorder()
+		h.SyncProductVulnerabilities(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 201 with response", func(t *testing.T) {
+		const reqPayload = `[{"productId":"prod-1","vulnerabilityId":"CVE-2026-0001"}]`
+		var capturedBody []byte
+		client := &mockEntityVulnerabilityClient{
+			syncProductVulnerabilitiesFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"insertedRecords":1,"updatedRecords":0,"deletedRecords":0}`), nil
+			},
+		}
+		h := NewVulnerabilityHandler(client)
+		r := httptest.NewRequest(http.MethodPost, "/vulnerabilities/sync", strings.NewReader(reqPayload))
+		w := httptest.NewRecorder()
+		h.SyncProductVulnerabilities(w, r)
+
+		assertStatus(t, w, http.StatusCreated)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["insertedRecords"] != float64(1) {
+			t.Errorf("insertedRecords = %v, want 1", resp["insertedRecords"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to sync product vulnerabilities.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityVulnerabilityClient{
+					syncProductVulnerabilitiesFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewVulnerabilityHandler(client)
+				r := httptest.NewRequest(http.MethodPost, "/vulnerabilities/sync", strings.NewReader(`[]`))
+				w := httptest.NewRecorder()
+				h.SyncProductVulnerabilities(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/integrations/csm-integration-service/openapi.yaml
+++ b/integrations/csm-integration-service/openapi.yaml
@@ -341,6 +341,55 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /vulnerabilities/sync:
+    post:
+      summary: Full-replace sync of product-vulnerability records.
+      description: >
+        This is a full-replace sync, not an incremental delta: the caller must
+        submit the complete current set of product-vulnerability records on
+        every call. The entity service's downstream ServiceNow-backed operation
+        deletes any existing record not present in the submitted set. The
+        request body is forwarded to the entity service verbatim.
+      operationId: syncProductVulnerabilities
+      requestBody:
+        description: Complete current set of product-vulnerability records.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductVulnerabilitySyncPayload'
+      responses:
+        "201":
+          description: The sync was applied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductVulnerabilitySyncResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized (upstream reported an authorization failure)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   securitySchemes:
     oauth2ClientCredentials:
@@ -637,3 +686,28 @@ components:
           type: string
         project:
           $ref: '#/components/schemas/ProjectUpdateResult'
+
+    ProductVulnerabilitySyncPayload:
+      type: array
+      description: >
+        The complete current set of product-vulnerability records. Any record
+        omitted from this array is treated as removed by the downstream sync.
+      items:
+        type: object
+        additionalProperties: true
+        description: >
+          Opaque per-record payload passed through to the entity service
+          as-is — its shape is not defined or validated by this layer.
+
+    ProductVulnerabilitySyncResponse:
+      type: object
+      description: >
+        Fields may be partial or omitted depending on the entity service's
+        response for a given sync.
+      properties:
+        insertedRecords:
+          type: integer
+        updatedRecords:
+          type: integer
+        deletedRecords:
+          type: integer


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

CSM Integration Service exposes account/project read and search endpoints for M2M consumers, but has no way to push product-vulnerability data. A companion entity-service change (already in place on this branch) adds `POST /products/vulnerabilities/sync`; this PR adds the corresponding pass-through endpoint on the integration service.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Add `POST /vulnerabilities/sync` to csm-integration-service, forwarding the request body verbatim to the entity service's `POST /products/vulnerabilities/sync`.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- New `VulnerabilityHandler` (`internal/handler/vulnerabilities.go`) mirrors the existing body-forwarding handlers (`SearchAccounts`/`SearchProjects`): reads the body with the shared 1 MiB cap, validates it is JSON, forwards it unmodified, and maps upstream errors with the shared `mapUpstreamError`. Returns `201 Created` on success (matching entity-service's own response for this write) instead of the `200` used by the read/search handlers.
- New `Client.SyncProductVulnerabilities` (`internal/entity/entity.go`) calls `POST /products/vulnerabilities/sync` on the entity service, following the existing method style.
- This is a **full-replace sync**, not a delta: the caller must submit the complete current set of records every time, since the downstream operation deletes anything not present in the submitted set. This is documented on both the handler and the entity-client method, and in `openapi.yaml`.
- No auth/identity code is added — this service has no inbound auth of its own (trust boundary is the gateway), and the entity-service route this calls accepts pure M2M calls with no forwarded end-user token, same as every other endpoint here except `PATCH /projects/{id}`.
- Wired into `cmd/server/main.go` alongside the existing handlers; `openapi.yaml` and `README.md` updated to document the new endpoint.
- Purely additive: no existing handler, entity-client method, or route was modified.

## User stories
> Summary of user stories addressed by this change

As an M2M integration, I can push the complete current set of product-vulnerability records through the CSM Integration Service so they land in the platform's data store via the entity service.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Added `POST /vulnerabilities/sync` to the CSM Integration Service.

## Documentation
N/A — internal M2M service API documented in this PR's own `openapi.yaml`; no external product documentation is affected.

## Training
N/A — no training content is affected.

## Certification
N/A — no certification exam content is affected.

## Marketing
N/A — internal M2M API addition with no customer-facing surface.

## Automation tests
 - Unit tests
   > Added `internal/handler/vulnerabilities_test.go` (table-driven, matching `accounts_test.go`/`projects_test.go` coverage: oversized body, invalid JSON, successful forward-and-201, and the full `upstreamErrors` mapping table) and a mock client in `helpers_test.go`. `go test -race ./...` passes for the whole module.
 - Integration tests
   > None added — this service has no integration test suite; existing coverage pattern (unit tests against a mock entity client) followed.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go service; this repo's security scan for Go is `gosec`, not run in this session (see Test environment)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new sample apps or usage samples added; `README.md`'s existing curl examples were extended with one line for this endpoint.

## Related PRs
A corresponding entity-service change (in this same repo, on this branch) adds the `POST /products/vulnerabilities/sync` endpoint this PR calls.

## Migrations (if applicable)
N/A — no data migration involved.

## Test environment
Verified locally: `go build ./...`, `go vet ./...`, `go test -race ./...` (Go 1.26, macOS/Darwin). Also smoke-tested by running the server locally with a fake/unreachable `ENTITY_BASE_URL` and confirming `GET /health` returns 200 and `POST /vulnerabilities/sync` returns a mapped 500 (not a 404 or panic), proving the route is correctly wired into the mux. No call against a real deployed entity-service or ServiceNow was possible — nothing is deployed yet.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

N/A — followed this service's existing handler/entity-client conventions directly (`accounts.go`, `projects.go`, `entity.go`, `response.go`).
