### PR TITLE
[CSM Portal] Render dashboard section widgets in config array order

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.test.tsx
@@ -120,7 +120,7 @@ describe("DashboardWidgetGrid", () => {
     // regardless of array position, so reordering this config array had no
     // visible effect. This asserts the fix: DOM order follows array order.
     renderGrid([
-      makeWidget({ widgetId: "trend_widget", shape: "bar" }),
+      makeWidget({ widgetId: "trend_widget", shape: "bar", groupBy: { field: "status" } }),
       makeWidget({ widgetId: "list_widget", shape: "list" }),
       makeWidget({ widgetId: "count_widget", shape: "count" }),
     ]);

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.test.tsx
@@ -112,4 +112,23 @@ describe("DashboardWidgetGrid", () => {
       screen.getByRole("button", { name: "Refresh no_action_widget" }),
     ).toBeInTheDocument();
   });
+
+  it("renders a section's widgets in the config's own array order, not grouped/reordered by shape", () => {
+    // Deliberately lists a bar-shape widget ahead of a list-shape widget
+    // within the same (default/untitled) section — the old implementation
+    // hardcoded every list/count tile ahead of every pie/bar tile
+    // regardless of array position, so reordering this config array had no
+    // visible effect. This asserts the fix: DOM order follows array order.
+    renderGrid([
+      makeWidget({ widgetId: "trend_widget", shape: "bar" }),
+      makeWidget({ widgetId: "list_widget", shape: "list" }),
+      makeWidget({ widgetId: "count_widget", shape: "count" }),
+    ]);
+
+    const tileIds = screen
+      .getAllByTestId(/^tile-/)
+      .map((el) => el.getAttribute("data-testid"));
+
+    expect(tileIds).toEqual(["tile-trend_widget", "tile-list_widget", "tile-count_widget"]);
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
@@ -227,12 +227,7 @@ export default function DashboardWidgetGrid({
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
       {groups.map((group, i) => {
-        // Chart-shaped widgets (pie/bar) are visually grouped into their
-        // own row below this group's count/list tiles, rather than sharing
-        // one undifferentiated grid with them.
-        const mainWidgets = group.widgets.filter((w) => w.shape !== "pie" && w.shape !== "bar");
-        const chartWidgets = group.widgets.filter((w) => w.shape === "pie" || w.shape === "bar");
-        if (mainWidgets.length === 0 && chartWidgets.length === 0) return null;
+        if (group.widgets.length === 0) return null;
 
         // Namespaced so a real section named e.g. `"__default_0"` can never
         // collide with the synthetic key generated for the unnamed section —
@@ -285,15 +280,11 @@ export default function DashboardWidgetGrid({
                   </Box>
                 </Box>
               </Box>
-              {mainWidgets.length > 0 && (
-                <Box sx={WIDGET_GRID_SX}>{mainWidgets.map(renderTile)}</Box>
-              )}
-              {chartWidgets.length > 0 && (
-                <>
-                  {mainWidgets.length > 0 && <Divider sx={{ my: 0.5 }} />}
-                  <Box sx={WIDGET_GRID_SX}>{chartWidgets.map(renderTile)}</Box>
-                </>
-              )}
+              {/* Rendered in the config's own array order — see this
+                  component's doc comment on why the widget grouping/order
+                  must follow `group.widgets` as-is, not a shape-based
+                  split. */}
+              <Box sx={WIDGET_GRID_SX}>{group.widgets.map(renderTile)}</Box>
             </Box>
           </Fragment>
         );


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The CSM dashboard's `DashboardWidgetGrid` always rendered a section's list/count-shape widgets in one grid box followed by its pie/bar-shape widgets in a second grid box, regardless of the order those widgets actually appear in the section's own `widgets` array. A user asked for a bar-chart widget to render above a list widget in the same section; reordering the config's JSON array had zero effect because the shape-based split ignored array order entirely.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Widgets within a dashboard section now render in the exact order they appear in the config's `widgets` array — no forced shape-based grouping.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

In `DashboardWidgetGrid.tsx`, removed the `mainWidgets`/`chartWidgets` filter-and-split (which always rendered list/count tiles before pie/bar tiles, with a divider between the two boxes) and replaced it with a single `WIDGET_GRID_SX` box rendering `group.widgets.map(renderTile)` directly, preserving array order. Per-widget shape styling (`widgetGridColumnSx`, list-shape forcing full row width, etc.) is untouched — only the forced two-box split/ordering is removed. No new schema field was introduced; the widget array itself is the ordering mechanism, per design intent.

## User stories
> Summary of user stories addressed by this change>

As a dashboard config author, reordering widgets in a section's config array changes their render order on screen, including mixed list/chart orderings.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed: dashboard section widgets now render in the order configured, instead of always grouping list/count widgets ahead of chart widgets.

## Documentation
N/A — internal CSM-portal dashboard rendering behavior, no external product docs describe this.

## Training
N/A — no training content covers CSM dashboard widget internals.

## Certification
N/A — not covered by certification exams.

## Marketing
N/A — internal bug fix, not a marketable feature.

## Automation tests
 - Unit tests
   > Added a test in `DashboardWidgetGrid.test.tsx` asserting that a section with widgets in `[bar, list, count]` config order renders tiles in that exact DOM order (`tile-trend_widget`, `tile-list_widget`, `tile-count_widget`), which fails against the previous shape-based split. Full existing suite (`DashboardWidgetGrid.test.tsx`, `.lazyLoad.test.tsx`, `.refresh.test.tsx`, `.realisticViewport.test.tsx`) still passes unmodified aside from the new test — none of them asserted on the old forced shape order.
 - Integration tests
   > None added; this is a pure frontend rendering-order fix behind an existing config-driven component, no backend/API surface changed.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A — no security-relevant code touched (pure render-order change, no new inputs/outputs/auth paths)
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, not a Java/JVM component this tool covers
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new sample/example code added.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data/schema migration; existing dashboard configs already have their widget arrays in the intended order (fixed separately, outside this repo), so this is a visual no-op for current dashboards and only changes behavior for configs that previously relied on (or were fighting) the forced shape ordering.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

macOS (Darwin), Node/pnpm toolchain per `apps/csm-portal/webapp/package.json`; verified via `vitest run` (jsdom environment), `tsc -b && vite build`, and `eslint .`. No manual browser pass performed.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

N/A — straightforward removal of a hardcoded shape-based split in favor of the array's own order; no external research needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard widgets now appear in the configured order, regardless of widget type.
  * Widgets are displayed together in a consistent grid instead of being split into separate rows.
  * Empty dashboard sections are omitted from the display.

* **Tests**
  * Added coverage to verify widget ordering matches the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->