### PR TITLE
[CSM][Web] Dashboard widget click-through shows widget name, not generic page title

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.test.tsx
@@ -36,6 +36,7 @@ import CsmCasesPage from "@features/csm-cases/pages/CsmCasesPage";
 
 describe("CsmCasesPage — case-type filter visibility", () => {
   it("no longer passes hideTypeFilter, so the case-type control is shown", () => {
+    issuesViewSpy.mockClear();
     render(
       <MemoryRouter>
         <CsmCasesPage />
@@ -51,5 +52,36 @@ describe("CsmCasesPage — case-type filter visibility", () => {
     // visible, no longer pins the *query* -- see
     // CsmIssuesView.typeFilterLock.test.tsx for that behavior.
     expect(props.lockedFilters).toEqual({ caseTypes: ["case"] });
+  });
+});
+
+// digiops-cs#2914: a dashboard widget's click-through carries its own
+// displayName as the `wt` query param (see
+// `WIDGET_RESOURCE_CONFIG.case.buildHref`), which this page must render as
+// its heading instead of the hardcoded default -- but only when present, so
+// a normal left-nav visit (no `wt` param) is completely unaffected.
+describe("CsmCasesPage — title override from a dashboard widget click-through", () => {
+  it('defaults to "Cases" when no wt param is present (normal nav visit)', () => {
+    issuesViewSpy.mockClear();
+    render(
+      <MemoryRouter initialEntries={["/cases"]}>
+        <CsmCasesPage />
+      </MemoryRouter>,
+    );
+
+    const props = issuesViewSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(props.title).toBe("Cases");
+  });
+
+  it("uses the wt param as the title when present (widget click-through)", () => {
+    issuesViewSpy.mockClear();
+    render(
+      <MemoryRouter initialEntries={["/cases?wt=Total+Outstanding&states=open"]}>
+        <CsmCasesPage />
+      </MemoryRouter>,
+    );
+
+    const props = issuesViewSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(props.title).toBe("Total Outstanding");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -17,17 +17,32 @@
 import { Button } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
 import { type JSX } from "react";
+import { useSearchParams } from "react-router";
 
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
+import { readWidgetTitleParam } from "@features/csm-dashboard/utils/widgetPreviewUrl";
 import { useNavTransition } from "@hooks/useNavTransition";
 
-/** All-cases list — the shared issues view across every case type. */
+/**
+ * All-cases list — the shared issues view across every case type.
+ *
+ * `title` defaults to "Cases", the page's own real identity for a normal
+ * left-nav visit, but is overridden by a dashboard widget's own
+ * `displayName` when this page was reached via a `case`-resourceType
+ * widget's tile click (see `WIDGET_RESOURCE_CONFIG.case.buildHref` in
+ * `widgetResourceConfig.ts`, and `appendWidgetTitleParam`'s own doc comment)
+ * — digiops-cs#2914: several dashboard widgets all drill through to this one
+ * page, and a hardcoded "Cases" heading made it unclear which widget's
+ * filtered result set was actually being shown.
+ */
 export default function CsmCasesPage(): JSX.Element {
   const navigate = useNavTransition();
+  const [searchParams] = useSearchParams();
+  const title = readWidgetTitleParam(searchParams) ?? "Cases";
 
   return (
     <CsmIssuesView
-      title="Cases"
+      title={title}
       entityNoun="cases"
       // Cases list defaults to support cases (`caseTypes: ["case"]`) on a
       // fresh visit, but, unlike the other issue-type pages (Operations/

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
@@ -30,6 +30,7 @@ import {
   WIDGET_RESOURCE_CONFIG,
 } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { readCasesFiltersFromUrl } from "@features/csm-cases/utils/casesFiltersUrl";
+import { WIDGET_TITLE_PARAM } from "@features/csm-dashboard/utils/widgetPreviewUrl";
 
 function hrefParams(href: string): URLSearchParams {
   const [, qs] = href.split("?");
@@ -387,6 +388,47 @@ describe("WIDGET_RESOURCE_CONFIG — case-table resourceTypes beyond `case`", ()
     expect(href.startsWith("/engagements?")).toBe(true);
     const params = hrefParams(href);
     expect(params.get("states")).toBe("open");
+  });
+
+  // digiops-cs#2914: case/engagement click-throughs land on real, permanent
+  // nav pages (/cases, /engagements) with a hardcoded heading — the widget's
+  // own displayName must be carried through as WIDGET_TITLE_PARAM so that
+  // page can show it instead, since several widgets all drill through to the
+  // same page.
+  it("case's buildHref carries the widget's displayName as WIDGET_TITLE_PARAM", () => {
+    const href = WIDGET_RESOURCE_CONFIG.case.buildHref(
+      { filters: [{ field: "state", op: "in", values: ["open"] }] },
+      { widgetId: "outstanding_cases", displayName: "Total Outstanding" },
+    );
+    const params = hrefParams(href);
+    expect(params.get(WIDGET_TITLE_PARAM)).toBe("Total Outstanding");
+    // The rest of the translated filter is unaffected by the addition.
+    expect(params.get("states")).toBe("open");
+  });
+
+  it("case's buildHref omits WIDGET_TITLE_PARAM when no ctx/displayName is given", () => {
+    const href = WIDGET_RESOURCE_CONFIG.case.buildHref({
+      filters: [{ field: "state", op: "in", values: ["open"] }],
+    });
+    expect(hrefParams(href).has(WIDGET_TITLE_PARAM)).toBe(false);
+  });
+
+  it("engagement's buildHref carries the widget's displayName as WIDGET_TITLE_PARAM", () => {
+    const href = WIDGET_RESOURCE_CONFIG.engagement.buildHref(
+      { filters: [{ field: "state", op: "in", values: ["open"] }] },
+      { widgetId: "migration_summary_outstanding", displayName: "Total Outstanding" },
+    );
+    expect(href.startsWith("/engagements?")).toBe(true);
+    const params = hrefParams(href);
+    expect(params.get(WIDGET_TITLE_PARAM)).toBe("Total Outstanding");
+    expect(params.get("states")).toBe("open");
+  });
+
+  it("engagement's buildHref omits WIDGET_TITLE_PARAM when no ctx/displayName is given", () => {
+    const href = WIDGET_RESOURCE_CONFIG.engagement.buildHref({
+      filters: [{ field: "state", op: "in", values: ["open"] }],
+    });
+    expect(hrefParams(href).has(WIDGET_TITLE_PARAM)).toBe(false);
   });
 
   it("announcement's buildHref is the unfiltered /announcements page (no URL filter scheme exists there yet)", () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -60,6 +60,7 @@ import { writeChangeRequestFiltersToUrl } from "@features/csm-operations/utils/c
 import { taskStateLabel } from "@features/csm-cases/utils/taskState";
 import type { BeTaskState } from "@api/backend/types";
 import {
+  appendWidgetTitleParam,
   buildWidgetPreviewHref,
   isAnyOfBranchArray,
 } from "@features/csm-dashboard/utils/widgetPreviewUrl";
@@ -448,13 +449,25 @@ function securityCenterHref(tab: string, params?: URLSearchParams): string {
  * output — always just this one type — doesn't need to be (and isn't)
  * dropped here; it's simply redundant with what the page already locks.
  */
-function caseTypeListHref(basePath: string, filters: Record<string, unknown>): string {
+function caseTypeListHref(
+  basePath: string,
+  filters: Record<string, unknown>,
+  displayName?: string,
+): string {
   const full: CasesFilters = {
     ...DEFAULT_CASES_FILTERS,
     ...translateCaseDashboardFilters(filters),
   };
   const qs = writeCasesFiltersToUrl(full).toString();
-  return qs ? `${basePath}?${qs}` : basePath;
+  const href = qs ? `${basePath}?${qs}` : basePath;
+  // `displayName`, when given, is appended as WIDGET_TITLE_PARAM so the
+  // destination page (a real, permanent nav page with its own hardcoded
+  // heading -- see CsmEngagementsPage.tsx) can show the originating
+  // widget's own name instead (digiops-cs#2914) -- see
+  // appendWidgetTitleParam's own doc comment for why this is a separate,
+  // cosmetic-only param from every CasesFilters field this function
+  // otherwise writes.
+  return appendWidgetTitleParam(href, displayName);
 }
 
 /**
@@ -659,7 +672,10 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     secondaryLabel: stateSecondaryLabel,
     buildHref: (filters, ctx) =>
       caseFamilyBuildHref("cases", filters, ctx, () =>
-        casesHref(translateCaseDashboardFilters(filters)),
+        appendWidgetTitleParam(
+          casesHref(translateCaseDashboardFilters(filters)),
+          ctx?.displayName,
+        ),
       ),
     icon: Briefcase,
     iconColor: "primary",
@@ -749,7 +765,9 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
     buildHref: (filters, ctx) =>
-      caseFamilyBuildHref("engagements", filters, ctx, () => caseTypeListHref("/engagements", filters)),
+      caseFamilyBuildHref("engagements", filters, ctx, () =>
+        caseTypeListHref("/engagements", filters, ctx?.displayName),
+      ),
     icon: Handshake,
     iconColor: "secondary",
     previewSlug: "engagements",

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.test.ts
@@ -16,10 +16,13 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  appendWidgetTitleParam,
   buildWidgetPreviewHref,
   describeWidgetFilters,
   parseWidgetPreviewFilters,
+  readWidgetTitleParam,
   resolveCurrentUserSentinels,
+  WIDGET_TITLE_PARAM,
 } from "./widgetPreviewUrl";
 
 const CURRENT_USER_ID = "11111111-aaaa-bbbb-cccc-000000000001";
@@ -359,5 +362,41 @@ describe("describeWidgetFilters", () => {
 
   it("returns an empty list for empty/absent filters", () => {
     expect(describeWidgetFilters({})).toEqual([]);
+  });
+});
+
+describe("appendWidgetTitleParam / readWidgetTitleParam", () => {
+  it("appends the widget's displayName as WIDGET_TITLE_PARAM to a bare path", () => {
+    const href = appendWidgetTitleParam("/engagements", "Total Outstanding");
+    expect(href).toBe(`/engagements?${WIDGET_TITLE_PARAM}=Total+Outstanding`);
+  });
+
+  it("appends to a path that already has query params, without disturbing them", () => {
+    const href = appendWidgetTitleParam(
+      "/cases?states=open&severities=S1",
+      "My Critical & High Cases",
+    );
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(href.startsWith("/cases?")).toBe(true);
+    expect(params.get("states")).toBe("open");
+    expect(params.get("severities")).toBe("S1");
+    expect(params.get(WIDGET_TITLE_PARAM)).toBe("My Critical & High Cases");
+  });
+
+  it("is a no-op when displayName is absent or empty", () => {
+    expect(appendWidgetTitleParam("/engagements", undefined)).toBe("/engagements");
+    expect(appendWidgetTitleParam("/engagements", "")).toBe("/engagements");
+    expect(appendWidgetTitleParam("/cases?states=open", undefined)).toBe("/cases?states=open");
+  });
+
+  it("round-trips through readWidgetTitleParam", () => {
+    const href = appendWidgetTitleParam("/engagements?types=engagement", "Migration Summary");
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(readWidgetTitleParam(params)).toBe("Migration Summary");
+  });
+
+  it("readWidgetTitleParam returns undefined when the param is absent or empty", () => {
+    expect(readWidgetTitleParam(new URLSearchParams("states=open"))).toBeUndefined();
+    expect(readWidgetTitleParam(new URLSearchParams(`${WIDGET_TITLE_PARAM}=`))).toBeUndefined();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
@@ -32,6 +32,50 @@ const ANY_OF_PARAM = "_anyOf";
 
 const RESERVED_PARAMS = new Set(["w", "n", CASE_FILTER_MARKER, ANY_OF_PARAM]);
 
+/**
+ * Query param carrying a dashboard widget's own `displayName`, appended to a
+ * click-through href for the two resourceTypes (`case`, `engagement`) whose
+ * `buildHref` lands on a real, permanent nav page (`/cases`, `/engagements`
+ * — see `caseFamilyBuildHref`'s fallback in `widgetResourceConfig.ts`)
+ * rather than the generic dashboard-widget preview page above. Those nav
+ * pages otherwise render a hardcoded heading ("Cases"/"Engagements"); this
+ * param lets them show the originating widget's own name instead, without
+ * affecting a plain nav visit (which never sets it).
+ *
+ * Deliberately a *different* param than `n` above: `n` belongs to the
+ * dashboard-widget preview page's own URL scheme (paired with `w`, and read
+ * by `parseWidgetPreviewFilters`'s caller, not this file). `wt` ("widget
+ * title") is scoped to this narrower, single-purpose use — a heading
+ * override, not a full preview-page identity — and deliberately excluded
+ * from `RESERVED_PARAMS`/`parseWidgetPreviewFilters`'s filter parsing since
+ * it never reaches that code path (`/cases`/`/engagements` have their own
+ * filter parsing in `casesFiltersUrl.ts`, which never reads this key either
+ * — purely cosmetic, heading-only).
+ */
+export const WIDGET_TITLE_PARAM = "wt";
+
+/** Appends `WIDGET_TITLE_PARAM` (the click-through widget's own
+ * `displayName`) to an already-built `/cases`/`/engagements` href, so that
+ * page's heading can show it instead of falling back to its hardcoded
+ * default. A no-op (returns `href` unchanged) when `displayName` is absent
+ * or empty — never emits `wt=` with nothing meaningful in it. */
+export function appendWidgetTitleParam(href: string, displayName: string | undefined): string {
+  if (!displayName) return href;
+  const [path, query = ""] = href.split("?");
+  const params = new URLSearchParams(query);
+  params.set(WIDGET_TITLE_PARAM, displayName);
+  return `${path}?${params.toString()}`;
+}
+
+/** Reads `WIDGET_TITLE_PARAM` back off a `/cases`/`/engagements` URL's own
+ * search params — the inverse of `appendWidgetTitleParam`. `undefined` when
+ * absent or empty, so a caller can cleanly fall back to that page's own
+ * default heading. */
+export function readWidgetTitleParam(searchParams: URLSearchParams): string | undefined {
+  const v = searchParams.get(WIDGET_TITLE_PARAM);
+  return v && v.length > 0 ? v : undefined;
+}
+
 /** Placeholder swapped in for the signed-in user's own id wherever a
  * widget's (opaque, backend-resolved) filters carry it — e.g. "My Cases"
  * resolves to `assignedUserIds: ["<real uuid>"]` — so a bookmarked/shared

--- a/apps/csm-portal/webapp/src/features/csm-engagements/pages/CsmEngagementsPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-engagements/pages/CsmEngagementsPage.test.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+// `CsmIssuesView` does all the real search/filtering work and is covered by
+// its own tests -- this file only checks the props `CsmEngagementsPage`
+// supplies to it, in particular the `title` override behavior.
+const issuesViewSpy = vi.fn();
+vi.mock("@features/csm-cases/components/CsmIssuesView", () => ({
+  default: (props: Record<string, unknown>) => {
+    issuesViewSpy(props);
+    return <div>IssuesView</div>;
+  },
+}));
+
+import CsmEngagementsPage from "@features/csm-engagements/pages/CsmEngagementsPage";
+
+// digiops-cs#2914: a dashboard widget's click-through carries its own
+// displayName as the `wt` query param (see
+// `WIDGET_RESOURCE_CONFIG.engagement.buildHref`), which this page must
+// render as its heading instead of the hardcoded default -- but only when
+// present, so a normal left-nav visit (no `wt` param) is completely
+// unaffected.
+describe("CsmEngagementsPage — title override from a dashboard widget click-through", () => {
+  it('defaults to "Engagements" when no wt param is present (normal nav visit)', () => {
+    issuesViewSpy.mockClear();
+    render(
+      <MemoryRouter initialEntries={["/engagements"]}>
+        <CsmEngagementsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("IssuesView")).toBeInTheDocument();
+    expect(issuesViewSpy).toHaveBeenCalledTimes(1);
+    const props = issuesViewSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(props.title).toBe("Engagements");
+    // Every other prop this page locks stays intact -- the title override
+    // is purely additive.
+    expect(props.lockedFilters).toEqual({ caseTypes: ["engagement"] });
+  });
+
+  it("uses the wt param as the title when present (widget click-through)", () => {
+    issuesViewSpy.mockClear();
+    render(
+      <MemoryRouter initialEntries={["/engagements?wt=Total+Outstanding&states=open"]}>
+        <CsmEngagementsPage />
+      </MemoryRouter>,
+    );
+
+    const props = issuesViewSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(props.title).toBe("Total Outstanding");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-engagements/pages/CsmEngagementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-engagements/pages/CsmEngagementsPage.tsx
@@ -17,21 +17,34 @@
 import { Button } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
 import { type JSX } from "react";
+import { useSearchParams } from "react-router";
 
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
+import { readWidgetTitleParam } from "@features/csm-dashboard/utils/widgetPreviewUrl";
 import { useNavTransition } from "@hooks/useNavTransition";
 
 /**
  * Cross-customer engagements list — filters the shared issues view to
  * `type: engagement` and surfaces the engagement-type sub-filter so engineers
  * can narrow by migration, consultancy, onboarding, etc.
+ *
+ * `title` defaults to "Engagements", the page's own real identity for a
+ * normal left-nav visit, but is overridden by a dashboard widget's own
+ * `displayName` when this page was reached via an `engagement`-resourceType
+ * widget's tile click (see `WIDGET_RESOURCE_CONFIG.engagement.buildHref` in
+ * `widgetResourceConfig.ts`, and `appendWidgetTitleParam`'s own doc comment)
+ * — digiops-cs#2914: several dashboard widgets all drill through to this one
+ * page, and a hardcoded "Engagements" heading made it unclear which widget's
+ * filtered result set was actually being shown.
  */
 export default function CsmEngagementsPage(): JSX.Element {
   const navigate = useNavTransition();
+  const [searchParams] = useSearchParams();
+  const title = readWidgetTitleParam(searchParams) ?? "Engagements";
 
   return (
     <CsmIssuesView
-      title="Engagements"
+      title={title}
       entityNoun="engagements"
       lockedFilters={{ caseTypes: ["engagement"] }}
       hideTypeFilter


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Dashboard widgets of resourceType `case`/`engagement` that click through to the app's real `/cases`/`/engagements` nav pages (any widget without an `anyOf` cross-field-OR branch) always showed the page's own static heading ("Cases"/"Engagements") instead of the widget's own name — confusing when several widgets on the same dashboard all drill through to the same page. Reported internally against the Migration Engineers' Dashboard, tracked separately (not linked here per this repo's cross-repo reference policy).

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Clicking a dashboard widget now shows that widget's own display name as the page heading on `/cases`/`/engagements`. Normal left-nav navigation to those pages is unaffected — they still show "Cases"/"Engagements".

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Added a new short-lived query param (`wt`, "widget title") alongside the dashboard-widget-preview URL helpers in `widgetPreviewUrl.ts`. The `case` and `engagement` resourceType `buildHref` fallbacks in `widgetResourceConfig.ts` now append the widget's `displayName` via this param when building the click-through URL. `CsmCasesPage`/`CsmEngagementsPage` read the param via `useSearchParams()` and pass it into `CsmIssuesView`'s existing `title` prop, falling back to the current static string when absent. `CsmIssuesView` itself is untouched. The param is deliberately not registered in the dashboard-preview page's own `RESERVED_PARAMS` (it belongs to `/cases`/`/engagements`'s URL space) and does not participate in `CasesFilters` parsing, so it's cosmetic-only and can't affect filtering or be a footgun on a shared/bookmarked link.

Other case-family resourceTypes (`security_report_analysis`, `service_request`, `announcement`, `incident_task`) route to tabbed pages with a different title pattern and were left untouched.

## User stories
> Summary of user stories addressed by this change

As a CS engineer using a team dashboard, when I click a widget's count/tile, I want the resulting list page to show that widget's name so I know what I'm looking at, especially when several widgets funnel into the same underlying page.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fix: dashboard widget click-through on the Cases and Engagements pages now shows the clicked widget's own name as the page heading instead of the generic page title.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A — cosmetic heading change on an existing flow, no new user-facing concept to document.

## Automation tests
 - Unit tests
   > Code coverage information

Extended `widgetPreviewUrl.test.ts` and `widgetResourceConfig.test.ts` with the new param's round-trip and `buildHref` output; extended `CsmCasesPage.test.tsx` and added `CsmEngagementsPage.test.tsx` covering both the override-present and override-absent (default title) cases. Full suite: `npx vitest run` → 251 files / 2585 tests passed.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend change, no Java code touched
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

`npx tsc --noEmit` clean, `npx eslint` clean on changed files, `pnpm run build` succeeds. Not yet manually verified in a running browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtQCa9XFUMbyh8zVrU7k3E


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard widget click-throughs to Cases and Engagements now preserve and display the originating widget’s title.
  * Cases and Engagements pages use the widget title when provided, with “Cases” and “Engagements” as defaults.

* **Bug Fixes**
  * Improved navigation context when opening case or engagement lists from dashboard widgets.

* **Tests**
  * Added coverage for widget-title propagation, URL handling, default page titles, and preserved filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->