### PR TITLE
[CSM Portal] Fail-closed attachment share authz, reference-type-aware uploads, safe inline-image ordering

### DIFF
--- a/apps/csm-portal/backend/internal/handler/attachment_storage.go
+++ b/apps/csm-portal/backend/internal/handler/attachment_storage.go
@@ -66,6 +66,18 @@ type sftpgoClient interface {
 	BaseURL() string
 }
 
+// attachmentStorageEntityClient is the entity-service surface
+// AttachmentStorageHandler needs: everything the case attachment flows use,
+// plus the change-request and incident detail lookups that back this
+// handler's per-reference-type access checks (an attachment can reference a
+// case, a change request, or an incident — see referenceType on the entity
+// service's attachment schema).
+type attachmentStorageEntityClient interface {
+	entityCaseClient
+	GetChangeRequest(ctx context.Context, id string) ([]byte, error)
+	GetIncident(ctx context.Context, id string) ([]byte, error)
+}
+
 // AttachmentStorageHandler implements the SFTPGo-backed attachment-storage
 // endpoints: minting a write-scoped SFTPGo share before an upload, and
 // creating a short-lived read-scoped public download share for an
@@ -79,13 +91,13 @@ type sftpgoClient interface {
 // cmd/server/main.go. The existing streaming attachment endpoints on
 // CaseHandler are completely unaffected by this handler and by the flag.
 type AttachmentStorageHandler struct {
-	entity entityCaseClient
+	entity attachmentStorageEntityClient
 	sftpgo sftpgoClient
 }
 
 // NewAttachmentStorageHandler creates an AttachmentStorageHandler backed by
 // the given entity and SFTPGo clients.
-func NewAttachmentStorageHandler(entity entityCaseClient, sftpgo sftpgoClient) *AttachmentStorageHandler {
+func NewAttachmentStorageHandler(entity attachmentStorageEntityClient, sftpgo sftpgoClient) *AttachmentStorageHandler {
 	return &AttachmentStorageHandler{entity: entity, sftpgo: sftpgo}
 }
 
@@ -112,7 +124,23 @@ type mintUploadTokenRequest struct {
 	// Mirrors AttachmentCreatePayload.description on the existing
 	// (non-SFTPGo) attachment-creation path.
 	Description *string `json:"description,omitempty"`
+	// ReferenceType identifies what kind of entity the path's {id} refers to:
+	// "case" (the default when omitted, preserving the pre-existing contract
+	// for every caller that never sends this field), "change_request", or
+	// "incident" — the same reference types the existing (non-SFTPGo)
+	// POST /attachments path accepts. Additive: the field is optional, and an
+	// unrecognised value is rejected with 400 rather than guessed at.
+	ReferenceType string `json:"referenceType,omitempty"`
 }
+
+// Attachment reference types accepted by MintUploadToken and understood by
+// CreateAttachmentShare. Mirrors the entity service's ReferenceType enum for
+// the subset of entities this handler can authorize against.
+const (
+	refTypeCase          = "case"
+	refTypeChangeRequest = "change_request"
+	refTypeIncident      = "incident"
+)
 
 // uploadTokenResponse is the response body of
 // POST /cases/{id}/attachments/upload-token.
@@ -183,6 +211,19 @@ type uploadTokenResponse struct {
 // CaseHandler.CreateCaseAttachment already applies (case exists and is not
 // closed): a row is never created, and a share never minted, for a case the
 // caller could not otherwise attach a file to.
+//
+// Reference types other than "case": the request body's optional
+// referenceType field declares what the path's {id} refers to (the route is
+// kept unchanged for compatibility; {id} is really the reference entity's
+// id). "change_request" and "incident" are recognised and authorized (the
+// caller must be able to read the referenced entity, mirroring how the CR and
+// incident detail endpoints gate reads today), but then rejected with 422:
+// the entity service's direct-upload persistence is case-scoped today — it
+// has no storage-key-backed attachment records for change requests or
+// incidents — so those uploads must go through the standard attachment path
+// instead. This gives a clear, honest error rather than the confusing
+// not-found a change-request id used to produce when it was assumed to be a
+// case id. Anything else is rejected with 400.
 func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -190,8 +231,8 @@ func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *htt
 		return
 	}
 
-	caseID := r.PathValue("id")
-	if caseID == "" || !uuidRe.MatchString(caseID) {
+	referenceID := r.PathValue("id")
+	if referenceID == "" || !uuidRe.MatchString(referenceID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -234,6 +275,37 @@ func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *htt
 		return
 	}
 
+	// Empty defaults to "case": every existing caller (which never sends the
+	// field) keeps exactly the pre-existing behavior.
+	referenceType := req.ReferenceType
+	if referenceType == "" {
+		referenceType = refTypeCase
+	}
+	switch referenceType {
+	case refTypeCase:
+		// Falls through to the full flow below.
+	case refTypeChangeRequest, refTypeIncident:
+		// Authorize FIRST — the caller must be able to read the referenced
+		// entity (the same gate its detail endpoint applies: the entity
+		// service's own 403/404 decides) — and only then report the
+		// capability gap. A caller with no access to the entity learns
+		// nothing about which storage modes it supports.
+		if !h.canReadReference(w, r, referenceType, referenceID) {
+			return
+		}
+		// The entity service's direct-upload persistence is case-scoped
+		// today: it has no storage-key-backed attachment records for change
+		// requests or incidents, so there is nothing this flow could durably
+		// record. Fail with a clear 422 instead of pretending — the standard
+		// attachment upload path still works for these types.
+		writeError(w, http.StatusUnprocessableEntity, ErrMsgAttachmentStorageUnsupportedRef)
+		return
+	default:
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	caseID := referenceID
 	projectID, ok := h.canWriteCase(w, r, caseID)
 	if !ok {
 		return
@@ -280,8 +352,8 @@ func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *htt
 		Status        string  `json:"status"`
 		Description   *string `json:"description,omitempty"`
 	}{
-		ReferenceID:   caseID,
-		ReferenceType: "case",
+		ReferenceID:   referenceID,
+		ReferenceType: referenceType,
 		Name:          req.Filename,
 		Type:          req.MimeType,
 		StorageKey:    storageKey,
@@ -445,15 +517,20 @@ func (h *AttachmentStorageHandler) CreateAttachmentShare(w http.ResponseWriter, 
 		return
 	}
 
-	// Read-access check: mirrors the (lack of) additional case-state gating
-	// on GetCaseAttachmentContent and SearchCaseAttachments today — those
-	// endpoints impose no restriction beyond the entity service's own
-	// GetCase access control (a 403/404 from upstream decides who can see
-	// what). Reused here, unchanged, for the read path.
-	if meta.ReferenceType == "case" && meta.ReferenceID != "" {
-		if !h.canReadCase(w, r, meta.ReferenceID) {
-			return
-		}
+	// Read-access check, fail closed: the caller must be shown to have read
+	// access to the entity this attachment references before a public
+	// (passwordless) share URL is ever minted for it. The check is keyed on
+	// the attachment's own referenceType/referenceId as reported by the
+	// entity service; a missing, empty, or unrecognised reference means
+	// access CANNOT be established — deny with 404, never assume a type. (In
+	// particular, the backing data source that predates referenceType on
+	// attachment details reports it empty; its attachments carry no
+	// storageKey and were never shareable through this endpoint anyway.)
+	// Per-type, the check mirrors the gate each entity's own detail/content
+	// endpoints apply today: the entity service's own 403/404 on the detail
+	// lookup decides who can see what.
+	if !h.canReadReference(w, r, meta.ReferenceType, meta.ReferenceID) {
+		return
 	}
 
 	if meta.StorageKey == nil || *meta.StorageKey == "" {
@@ -637,6 +714,44 @@ func sanitizeFilenameForStorageKey(filename string) string {
 	}
 
 	return cleaned
+}
+
+// canReadReference confirms the caller can view the entity an attachment
+// references, dispatching on the attachment's own referenceType. FAIL
+// CLOSED: an empty or unrecognised reference type, or a missing reference
+// id, denies with 404 — it is never assumed to mean "case". An empty
+// referenceType is a real occurrence, not just a defensive case: the backing
+// data source that predates referenceType on attachment details reports it
+// empty. On failure the response has already been written; the caller must
+// only return.
+func (h *AttachmentStorageHandler) canReadReference(w http.ResponseWriter, r *http.Request, referenceType, referenceID string) bool {
+	if referenceID == "" {
+		slog.WarnContext(r.Context(), "attachment access denied: attachment carries no reference id", "referenceType", referenceType)
+		writeError(w, http.StatusNotFound, ErrMsgNotFound)
+		return false
+	}
+	switch referenceType {
+	case refTypeCase:
+		return h.canReadCase(w, r, referenceID)
+	case refTypeChangeRequest:
+		if _, err := h.entity.GetChangeRequest(r.Context(), referenceID); err != nil {
+			slog.ErrorContext(r.Context(), "entity GetChangeRequest failed during attachment-storage read guard", "changeRequestID", referenceID, "err", summarizeErr(err))
+			mapUpstreamErrorGeneric(w, err, "Failed to validate change request access.")
+			return false
+		}
+		return true
+	case refTypeIncident:
+		if _, err := h.entity.GetIncident(r.Context(), referenceID); err != nil {
+			slog.ErrorContext(r.Context(), "entity GetIncident failed during attachment-storage read guard", "incidentID", referenceID, "err", summarizeErr(err))
+			mapUpstreamErrorGeneric(w, err, "Failed to validate incident access.")
+			return false
+		}
+		return true
+	default:
+		slog.WarnContext(r.Context(), "attachment access denied: unrecognised reference type", "referenceType", referenceType)
+		writeError(w, http.StatusNotFound, ErrMsgNotFound)
+		return false
+	}
 }
 
 // canReadCase confirms the caller can view the target case at all — mirrors

--- a/apps/csm-portal/backend/internal/handler/attachment_storage_test.go
+++ b/apps/csm-portal/backend/internal/handler/attachment_storage_test.go
@@ -44,6 +44,21 @@ type mockSftpgoClient struct {
 	createShareCalls  []string // records the storageKey passed on each call
 	createShareScopes []int    // records the scope passed on each CreateShare call
 	uploadBytesCalls  []string // records the storageKey passed on each UploadBytes call
+	removeFileCalls   []string // records the storageKey passed on each RemoveFile call
+	removeFileCtxErrs []error  // records ctx.Err() at the time of each RemoveFile call
+
+	removeFileFn func(ctx context.Context, accessToken, storageKey string) error
+}
+
+// RemoveFile satisfies inlineImageSftpgoClient's rollback byte-cleanup
+// operation (see inline_images.go).
+func (m *mockSftpgoClient) RemoveFile(ctx context.Context, accessToken, storageKey string) error {
+	m.removeFileCalls = append(m.removeFileCalls, storageKey)
+	m.removeFileCtxErrs = append(m.removeFileCtxErrs, ctx.Err())
+	if m.removeFileFn != nil {
+		return m.removeFileFn(ctx, accessToken, storageKey)
+	}
+	return nil
 }
 
 // UploadBytes satisfies inlineImageSftpgoClient (see inline_images.go) in
@@ -543,6 +558,185 @@ func TestMintUploadTokenSkipsShareWhenEntityCreateFails(t *testing.T) {
 	// call sequence; what matters is that CreateShare itself never fires.
 }
 
+// TestMintUploadTokenExplicitCaseReferenceType verifies referenceType "case"
+// sent explicitly behaves exactly like the default: the case write guard
+// runs and the persisted row carries referenceType "case".
+func TestMintUploadTokenExplicitCaseReferenceType(t *testing.T) {
+	t.Parallel()
+	const caseID = "11111111-1111-1111-1111-111111111111"
+	var getCaseCalls int
+	var persistedReferenceType string
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, id string) ([]byte, error) {
+			getCaseCalls++
+			return []byte(`{"state":"work_in_progress"}`), nil
+		},
+		createCaseAttachmentFn: func(ctx context.Context, body []byte) ([]byte, error) {
+			var req struct {
+				ReferenceID   string `json:"referenceId"`
+				ReferenceType string `json:"referenceType"`
+			}
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("decode CreateCaseAttachment body: %v; raw: %s", err, body)
+			}
+			persistedReferenceType = req.ReferenceType
+			if req.ReferenceID != caseID {
+				t.Errorf("referenceId = %q, want %q", req.ReferenceID, caseID)
+			}
+			return createCaseAttachmentFnPending(ctx, body)
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	body := strings.NewReader(`{"filename":"report.pdf","mimeType":"application/pdf","sizeBytes":1024,"referenceType":"case"}`)
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", body))
+	req.SetPathValue("id", caseID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	if getCaseCalls != 1 {
+		t.Errorf("GetCase (case write guard) was called %d times; want 1", getCaseCalls)
+	}
+	if persistedReferenceType != "case" {
+		t.Errorf("persisted referenceType = %q, want %q", persistedReferenceType, "case")
+	}
+}
+
+// TestMintUploadTokenChangeRequestReference verifies the mint endpoint's
+// change_request handling: the caller's access to the change request is
+// checked first (an inaccessible CR yields the upstream's own 403/404, never
+// a capability hint), and an accessible one yields a clear 422 — the
+// direct-upload storage mode cannot persist CR attachments yet — with no row
+// created and no SFTPGo call made.
+func TestMintUploadTokenChangeRequestReference(t *testing.T) {
+	t.Parallel()
+	const crID = "44444444-4444-4444-4444-444444444444"
+
+	newRequest := func() (*http.Request, *httptest.ResponseRecorder) {
+		body := strings.NewReader(`{"filename":"report.pdf","mimeType":"application/pdf","sizeBytes":1024,"referenceType":"change_request"}`)
+		req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+crID+"/attachments/upload-token", body))
+		req.SetPathValue("id", crID)
+		req.Header.Set("x-jwt-assertion", "raw-jwt")
+		return req, httptest.NewRecorder()
+	}
+
+	t.Run("accessible CR yields 422 unsupported", func(t *testing.T) {
+		t.Parallel()
+		var crLookups []string
+		var createCalls int
+		entity := &mockEntityCaseClient{
+			getChangeRequestFn: func(ctx context.Context, id string) ([]byte, error) {
+				crLookups = append(crLookups, id)
+				return []byte(`{}`), nil
+			},
+			createCaseAttachmentFn: func(ctx context.Context, body []byte) ([]byte, error) {
+				createCalls++
+				return createCaseAttachmentFnPending(ctx, body)
+			},
+			getCaseFn: func(ctx context.Context, id string) ([]byte, error) {
+				t.Error("GetCase must not be called for a change_request reference")
+				return []byte(`{}`), nil
+			},
+		}
+		sftpgoMock := &mockSftpgoClient{}
+		h := NewAttachmentStorageHandler(entity, sftpgoMock)
+		req, w := newRequest()
+
+		h.MintUploadToken(w, req)
+
+		assertStatus(t, w, http.StatusUnprocessableEntity)
+		assertErrorMessage(t, w, ErrMsgAttachmentStorageUnsupportedRef)
+		if len(crLookups) != 1 || crLookups[0] != crID {
+			t.Errorf("GetChangeRequest lookups = %v, want exactly [%q]", crLookups, crID)
+		}
+		if createCalls != 0 {
+			t.Errorf("CreateCaseAttachment was called %d times; want 0", createCalls)
+		}
+		if len(sftpgoMock.mintTokenCalls) != 0 || len(sftpgoMock.createShareCalls) != 0 {
+			t.Errorf("sftpgo was called (mint=%d, share=%d); want 0", len(sftpgoMock.mintTokenCalls), len(sftpgoMock.createShareCalls))
+		}
+	})
+
+	t.Run("inaccessible CR yields upstream 404", func(t *testing.T) {
+		t.Parallel()
+		entity := &mockEntityCaseClient{
+			getChangeRequestFn: func(ctx context.Context, id string) ([]byte, error) {
+				return nil, &apierror.Error{StatusCode: http.StatusNotFound, Body: "not found"}
+			},
+		}
+		sftpgoMock := &mockSftpgoClient{}
+		h := NewAttachmentStorageHandler(entity, sftpgoMock)
+		req, w := newRequest()
+
+		h.MintUploadToken(w, req)
+
+		assertStatus(t, w, http.StatusNotFound)
+	})
+}
+
+// TestMintUploadTokenIncidentReference mirrors the change_request behavior
+// for referenceType "incident": access checked via GetIncident, then a clear
+// 422 for the unsupported storage mode.
+func TestMintUploadTokenIncidentReference(t *testing.T) {
+	t.Parallel()
+	const incidentID = "55555555-5555-5555-5555-555555555555"
+	var incidentLookups []string
+	entity := &mockEntityCaseClient{
+		getIncidentFn: func(ctx context.Context, id string) ([]byte, error) {
+			incidentLookups = append(incidentLookups, id)
+			return []byte(`{}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	body := strings.NewReader(`{"filename":"report.pdf","mimeType":"application/pdf","sizeBytes":1024,"referenceType":"incident"}`)
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+incidentID+"/attachments/upload-token", body))
+	req.SetPathValue("id", incidentID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusUnprocessableEntity)
+	assertErrorMessage(t, w, ErrMsgAttachmentStorageUnsupportedRef)
+	if len(incidentLookups) != 1 || incidentLookups[0] != incidentID {
+		t.Errorf("GetIncident lookups = %v, want exactly [%q]", incidentLookups, incidentID)
+	}
+}
+
+// TestMintUploadTokenRejectsUnknownReferenceType verifies an unrecognised
+// referenceType is rejected with 400 before any upstream call.
+func TestMintUploadTokenRejectsUnknownReferenceType(t *testing.T) {
+	t.Parallel()
+	const id = "11111111-1111-1111-1111-111111111111"
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
+			t.Error("GetCase must not be called for an unrecognised reference type")
+			return []byte(`{}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	body := strings.NewReader(`{"filename":"report.pdf","mimeType":"application/pdf","sizeBytes":1024,"referenceType":"deployment"}`)
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+id+"/attachments/upload-token", body))
+	req.SetPathValue("id", id)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+	if len(sftpgoMock.mintTokenCalls) != 0 {
+		t.Errorf("MintToken was called %d times; want 0", len(sftpgoMock.mintTokenCalls))
+	}
+}
+
 // ----- CreateAttachmentShare -----
 
 func TestCreateAttachmentShareRequiresAuth(t *testing.T) {
@@ -600,6 +794,166 @@ func TestCreateAttachmentShareEnforcesReadAccessBeforeMinting(t *testing.T) {
 	if len(sftpgoMock.mintTokenCalls) != 0 || len(sftpgoMock.createShareCalls) != 0 {
 		t.Errorf("sftpgo was called (mint=%d, share=%d); want 0 — access must be checked before minting/sharing",
 			len(sftpgoMock.mintTokenCalls), len(sftpgoMock.createShareCalls))
+	}
+}
+
+// TestCreateAttachmentShareDeniesEmptyReferenceType verifies the fail-closed
+// authorization: an attachment whose details carry NO referenceType (as
+// reported for attachments on the data source that predates the field) must
+// be denied outright — never assumed to be a case — and nothing may reach
+// the SFTPGo client. This closes the bypass where an unpopulated
+// referenceType skipped the read-access check entirely and let any
+// authenticated user mint a public share URL for any attachment id.
+func TestCreateAttachmentShareDeniesEmptyReferenceType(t *testing.T) {
+	t.Parallel()
+	var getCaseCalls int
+	entity := &mockEntityCaseClient{
+		getCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			return []byte(`{"referenceId":"22222222-2222-2222-2222-222222222222","storageKey":"/attachments/att-1"}`), nil
+		},
+		getCaseFn: func(ctx context.Context, id string) ([]byte, error) {
+			getCaseCalls++
+			return []byte(`{}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	attachmentID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/attachments/"+attachmentID+"/share", nil))
+	req.SetPathValue("id", attachmentID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.CreateAttachmentShare(w, req)
+
+	assertStatus(t, w, http.StatusNotFound)
+	if getCaseCalls != 0 {
+		t.Errorf("GetCase was called %d times; want 0 — an empty referenceType must never be treated as a case", getCaseCalls)
+	}
+	if len(sftpgoMock.mintTokenCalls) != 0 || len(sftpgoMock.createShareCalls) != 0 {
+		t.Errorf("sftpgo was called (mint=%d, share=%d); want 0 — an unverifiable reference must fail closed",
+			len(sftpgoMock.mintTokenCalls), len(sftpgoMock.createShareCalls))
+	}
+}
+
+// TestCreateAttachmentShareDeniesUnrecognisedReferenceType verifies a
+// reference type this handler has no access check for is denied rather than
+// let through unauthorized.
+func TestCreateAttachmentShareDeniesUnrecognisedReferenceType(t *testing.T) {
+	t.Parallel()
+	entity := &mockEntityCaseClient{
+		getCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			return []byte(`{"referenceId":"22222222-2222-2222-2222-222222222222","referenceType":"deployment","storageKey":"/attachments/att-1"}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	attachmentID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/attachments/"+attachmentID+"/share", nil))
+	req.SetPathValue("id", attachmentID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.CreateAttachmentShare(w, req)
+
+	assertStatus(t, w, http.StatusNotFound)
+	if len(sftpgoMock.mintTokenCalls) != 0 || len(sftpgoMock.createShareCalls) != 0 {
+		t.Errorf("sftpgo was called (mint=%d, share=%d); want 0", len(sftpgoMock.mintTokenCalls), len(sftpgoMock.createShareCalls))
+	}
+}
+
+// TestCreateAttachmentShareChangeRequestReference verifies a change_request
+// attachment's read check goes through GetChangeRequest (not GetCase), both
+// denying on upstream 403 and proceeding on success.
+func TestCreateAttachmentShareChangeRequestReference(t *testing.T) {
+	t.Parallel()
+	crID := "22222222-2222-2222-2222-222222222222"
+	attachmentID := "11111111-1111-1111-1111-111111111111"
+
+	newRequest := func() (*http.Request, *httptest.ResponseRecorder) {
+		req := withUser(httptest.NewRequest(http.MethodPost, "/attachments/"+attachmentID+"/share", nil))
+		req.SetPathValue("id", attachmentID)
+		req.Header.Set("x-jwt-assertion", "raw-jwt")
+		return req, httptest.NewRecorder()
+	}
+	newEntity := func(getCR func(ctx context.Context, id string) ([]byte, error)) *mockEntityCaseClient {
+		return &mockEntityCaseClient{
+			getCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+				return []byte(`{"referenceId":"` + crID + `","referenceType":"change_request","storageKey":"/attachments/att-1"}`), nil
+			},
+			getCaseFn: func(ctx context.Context, id string) ([]byte, error) {
+				t.Error("GetCase must not be called for a change_request reference")
+				return []byte(`{}`), nil
+			},
+			getChangeRequestFn: getCR,
+		}
+	}
+
+	t.Run("denied on upstream 403", func(t *testing.T) {
+		t.Parallel()
+		sftpgoMock := &mockSftpgoClient{}
+		h := NewAttachmentStorageHandler(newEntity(func(ctx context.Context, id string) ([]byte, error) {
+			return nil, &apierror.Error{StatusCode: http.StatusForbidden, Body: "forbidden"}
+		}), sftpgoMock)
+		req, w := newRequest()
+
+		h.CreateAttachmentShare(w, req)
+
+		assertStatus(t, w, http.StatusForbidden)
+		if len(sftpgoMock.createShareCalls) != 0 {
+			t.Errorf("createShareCalls = %v, want 0", sftpgoMock.createShareCalls)
+		}
+	})
+
+	t.Run("allowed when readable", func(t *testing.T) {
+		t.Parallel()
+		var crLookups []string
+		sftpgoMock := &mockSftpgoClient{}
+		h := NewAttachmentStorageHandler(newEntity(func(ctx context.Context, id string) ([]byte, error) {
+			crLookups = append(crLookups, id)
+			return []byte(`{}`), nil
+		}), sftpgoMock)
+		req, w := newRequest()
+
+		h.CreateAttachmentShare(w, req)
+
+		assertStatus(t, w, http.StatusCreated)
+		if len(crLookups) != 1 || crLookups[0] != crID {
+			t.Errorf("GetChangeRequest lookups = %v, want exactly [%q]", crLookups, crID)
+		}
+	})
+}
+
+// TestCreateAttachmentShareIncidentReferenceDenied verifies an incident
+// attachment's read check goes through GetIncident and denies on upstream
+// 404.
+func TestCreateAttachmentShareIncidentReferenceDenied(t *testing.T) {
+	t.Parallel()
+	incidentID := "22222222-2222-2222-2222-222222222222"
+	entity := &mockEntityCaseClient{
+		getCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			return []byte(`{"referenceId":"` + incidentID + `","referenceType":"incident","storageKey":"/attachments/att-1"}`), nil
+		},
+		getIncidentFn: func(ctx context.Context, id string) ([]byte, error) {
+			return nil, &apierror.Error{StatusCode: http.StatusNotFound, Body: "not found"}
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	attachmentID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/attachments/"+attachmentID+"/share", nil))
+	req.SetPathValue("id", attachmentID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.CreateAttachmentShare(w, req)
+
+	assertStatus(t, w, http.StatusNotFound)
+	if len(sftpgoMock.mintTokenCalls) != 0 {
+		t.Errorf("MintToken was called %d times; want 0", len(sftpgoMock.mintTokenCalls))
 	}
 }
 

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -117,6 +117,25 @@ type mockEntityCaseClient struct {
 	removeCaseTagFn            func(ctx context.Context, caseID, tagID string) ([]byte, error)
 	searchTagsFn               func(ctx context.Context, body []byte) ([]byte, error)
 	getUserMeFn                func(ctx context.Context) ([]byte, error)
+	// getChangeRequestFn/getIncidentFn back the attachmentStorageEntityClient
+	// interface (see attachment_storage.go) so this same mock serves
+	// AttachmentStorageHandler's per-reference-type access checks.
+	getChangeRequestFn func(ctx context.Context, id string) ([]byte, error)
+	getIncidentFn      func(ctx context.Context, id string) ([]byte, error)
+}
+
+func (m *mockEntityCaseClient) GetChangeRequest(ctx context.Context, id string) ([]byte, error) {
+	if m.getChangeRequestFn != nil {
+		return m.getChangeRequestFn(ctx, id)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityCaseClient) GetIncident(ctx context.Context, id string) ([]byte, error) {
+	if m.getIncidentFn != nil {
+		return m.getIncidentFn(ctx, id)
+	}
+	return []byte(`{}`), nil
 }
 
 // GetUserMe defaults to the platform user record for testUser: note the id is

--- a/apps/csm-portal/backend/internal/handler/inline_images.go
+++ b/apps/csm-portal/backend/internal/handler/inline_images.go
@@ -110,6 +110,9 @@ type inlineImageSftpgoClient interface {
 	MintToken(ctx context.Context, email, jwtAssertion string) (*sftpgo.Token, error)
 	CreateShare(ctx context.Context, accessToken, storageKey string, scope int, ttl time.Duration) (string, error)
 	UploadBytes(ctx context.Context, shareID, storageKey string, data []byte, contentType string) error
+	// RemoveFile deletes one already-uploaded object during rollback — see
+	// Process's rollback closure.
+	RemoveFile(ctx context.Context, accessToken, storageKey string) error
 }
 
 // InlineImageProcessor extracts base64 data: URI images embedded in a
@@ -143,11 +146,19 @@ func NewInlineImageProcessor(entity entityCaseClient, sftpgo inlineImageSftpgoCl
 //
 // Any unsupported inline image MIME subtype anywhere in htmlContent is
 // rejected before any image is processed, mirroring ServiceNow's reject-fast
-// behavior. Any failure partway through a multi-image comment — a size
+// behavior.
+//
+// Each image follows the same pending-first ordering as the browser-driven
+// upload flow (see AttachmentStorageHandler.MintUploadToken/ConfirmUpload):
+// the metadata row is created in "pending" status, the bytes are uploaded to
+// SFTPGo, and only then is the row confirmed "complete" — so a crash or
+// upstream failure can never leave a durable "complete" row whose bytes do
+// not exist. Any failure partway through a multi-image comment — a size
 // violation, an entity-service error, or an SFTPGo error — rolls back every
-// attachment already created earlier in this same call (DELETE
-// /attachments/{id}) and rejects the whole comment: a partially-processed
-// comment is never posted.
+// attachment already created earlier in this same call, deleting both the
+// metadata rows (DELETE /attachments/{id}) and any bytes already uploaded to
+// SFTPGo, and rejects the whole comment: a partially-processed comment is
+// never posted.
 func (p *InlineImageProcessor) Process(ctx context.Context, email, jwtAssertion, caseID, projectID, htmlContent string) (string, *inlineImageError) {
 	for _, m := range unsupportedInlineImageTagRe.FindAllStringSubmatch(htmlContent, -1) {
 		detected := strings.ToLower(m[1])
@@ -167,11 +178,27 @@ func (p *InlineImageProcessor) Process(ctx context.Context, email, jwtAssertion,
 	result := htmlContent
 	var accessToken string
 	var createdAttachmentIDs []string
+	var uploadedStorageKeys []string
 
+	// Rollback runs on a context detached from the request's cancellation:
+	// the most likely moment to need cleanup is exactly when the request is
+	// being torn down (caller gone, deadline hit), and a rollback that dies
+	// with the request would leave the orphans it exists to remove. It
+	// deletes BOTH the metadata rows created earlier in this call AND any
+	// bytes already uploaded to SFTPGo (including the possibly-partial
+	// object of the upload that failed), logging — never propagating — each
+	// individual cleanup failure: the whole comment is already being
+	// rejected, and a half-finished cleanup must still attempt the rest.
 	rollback := func() {
+		rbCtx := context.WithoutCancel(ctx)
 		for _, id := range createdAttachmentIDs {
-			if _, err := p.entity.DeleteCaseAttachment(ctx, id); err != nil {
-				slog.ErrorContext(ctx, "inline-image rollback: DeleteCaseAttachment failed", "attachmentID", id, "err", summarizeErr(err))
+			if _, err := p.entity.DeleteCaseAttachment(rbCtx, id); err != nil {
+				slog.ErrorContext(rbCtx, "inline-image rollback: DeleteCaseAttachment failed", "attachmentID", id, "err", summarizeErr(err))
+			}
+		}
+		for _, key := range uploadedStorageKeys {
+			if err := p.sftpgo.RemoveFile(rbCtx, accessToken, key); err != nil {
+				slog.ErrorContext(rbCtx, "inline-image rollback: sftpgo RemoveFile failed", "storageKey", key, "err", summarizeErr(err))
 			}
 		}
 	}
@@ -220,7 +247,14 @@ func (p *InlineImageProcessor) Process(ctx context.Context, email, jwtAssertion,
 			Type:          contentType,
 			StorageKey:    storageKey,
 			SizeBytes:     len(decoded),
-			Status:        "complete",
+			// "pending" until the bytes are actually in SFTPGo — the row is
+			// only confirmed "complete" after UploadBytes succeeds below,
+			// mirroring the browser-driven two-phase flow
+			// (MintUploadToken/ConfirmUpload). A crash or upstream failure
+			// between here and the confirm leaves a pending row (invisible
+			// to attachment lists, reconcilable later), never a durable
+			// "complete" row whose bytes do not exist.
+			Status: "pending",
 		})
 		if err != nil {
 			rollback()
@@ -268,6 +302,19 @@ func (p *InlineImageProcessor) Process(ctx context.Context, email, jwtAssertion,
 
 		if err := p.sftpgo.UploadBytes(ctx, shareID, storageKey, decoded, contentType); err != nil {
 			slog.ErrorContext(ctx, "inline-image sftpgo UploadBytes failed", "caseID", caseID, "err", summarizeErr(err))
+			// A failed TUS upload can still have written a partial object;
+			// include this key in the byte cleanup rather than assuming the
+			// failure left nothing behind.
+			uploadedStorageKeys = append(uploadedStorageKeys, storageKey)
+			rollback()
+			return "", &inlineImageError{status: http.StatusBadGateway, message: "Failed to store an embedded image."}
+		}
+		uploadedStorageKeys = append(uploadedStorageKeys, storageKey)
+
+		// Bytes are in SFTPGo; only now does the row become durable
+		// "complete" — see the Status comment on the create call above.
+		if _, err := p.entity.ConfirmCaseAttachment(ctx, attachmentID); err != nil {
+			slog.ErrorContext(ctx, "inline-image entity ConfirmCaseAttachment failed", "caseID", caseID, "attachmentID", attachmentID, "err", summarizeErr(err))
 			rollback()
 			return "", &inlineImageError{status: http.StatusBadGateway, message: "Failed to store an embedded image."}
 		}

--- a/apps/csm-portal/backend/internal/handler/inline_images_test.go
+++ b/apps/csm-portal/backend/internal/handler/inline_images_test.go
@@ -85,16 +85,22 @@ func TestInlineImageProcessorNoImagesReturnsUnchanged(t *testing.T) {
 
 // TestInlineImageProcessorSingleImage verifies the full happy path for one
 // embedded image: the entity attachment row is created with status
-// "complete", the bytes are written via SFTPGo, and the <img> tag is
-// rewritten to "/<attachmentId>.iix".
+// "pending", the bytes are written via SFTPGo, the row is only then
+// confirmed "complete", and the <img> tag is rewritten to
+// "/<attachmentId>.iix".
 func TestInlineImageProcessorSingleImage(t *testing.T) {
 	t.Parallel()
 	const caseID = "11111111-1111-1111-1111-111111111111"
 	var gotAttachmentBody []byte
+	var confirmedIDs []string
 	entity := &mockEntityCaseClient{
 		createCaseAttachmentFn: func(ctx context.Context, body []byte) ([]byte, error) {
 			gotAttachmentBody = body
-			return []byte(`{"attachment":{"id":"22222222-2222-2222-2222-222222222222","status":"complete"}}`), nil
+			return []byte(`{"attachment":{"id":"22222222-2222-2222-2222-222222222222","status":"pending"}}`), nil
+		},
+		confirmCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			confirmedIDs = append(confirmedIDs, attachmentID)
+			return []byte(`{"attachment":{"id":"` + attachmentID + `","status":"complete"}}`), nil
 		},
 	}
 	sftpgoMock := &mockSftpgoClient{}
@@ -145,8 +151,11 @@ func TestInlineImageProcessorSingleImage(t *testing.T) {
 	if req.Type != "image/png" {
 		t.Errorf("Type = %q, want image/png", req.Type)
 	}
-	if req.Status != "complete" {
-		t.Errorf("Status = %q, want complete — inline-image attachments are created with their bytes already uploaded", req.Status)
+	if req.Status != "pending" {
+		t.Errorf("Status = %q, want pending — the row must not be durable-complete before its bytes exist", req.Status)
+	}
+	if len(confirmedIDs) != 1 || confirmedIDs[0] != "22222222-2222-2222-2222-222222222222" {
+		t.Errorf("confirmedIDs = %v, want exactly the created attachment confirmed after upload", confirmedIDs)
 	}
 	if !strings.HasPrefix(req.Name, "inline-image-") || !strings.HasSuffix(req.Name, ".png") {
 		t.Errorf("Name = %q, want an inline-image-<ts>-<n>.png synthetic filename", req.Name)
@@ -290,6 +299,103 @@ func TestInlineImageProcessorRollsBackOnSecondImageFailure(t *testing.T) {
 	for i, want := range wantDeleted {
 		if deletedIDs[i] != want {
 			t.Errorf("deletedIDs[%d] = %q, want %q", i, deletedIDs[i], want)
+		}
+	}
+
+	// The FIRST image's bytes are already in SFTPGo, and the second's upload
+	// may have written a partial object — rollback must attempt to delete
+	// both, not just the metadata rows.
+	if len(sftpgoMock.removeFileCalls) != 2 {
+		t.Fatalf("removeFileCalls = %v, want 2 — rollback must clean up uploaded bytes, not only rows", sftpgoMock.removeFileCalls)
+	}
+	if sftpgoMock.removeFileCalls[0] != sftpgoMock.uploadBytesCalls[0] || sftpgoMock.removeFileCalls[1] != sftpgoMock.uploadBytesCalls[1] {
+		t.Errorf("removeFileCalls = %v, want the storage keys UploadBytes was given: %v", sftpgoMock.removeFileCalls, sftpgoMock.uploadBytesCalls)
+	}
+}
+
+// TestInlineImageProcessorRollsBackOnConfirmFailure verifies the row is
+// created pending and never left durable when its confirm step fails: the
+// whole comment is rejected and both the row and the uploaded bytes are
+// cleaned up.
+func TestInlineImageProcessorRollsBackOnConfirmFailure(t *testing.T) {
+	t.Parallel()
+	var deletedIDs []string
+	entity := &mockEntityCaseClient{
+		createCaseAttachmentFn: nextAttachmentIDFactory(),
+		confirmCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			return nil, &apierror.Error{StatusCode: http.StatusInternalServerError, Body: "boom"}
+		},
+		deleteCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			deletedIDs = append(deletedIDs, attachmentID)
+			return []byte(`{"message":"deleted"}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	p := NewInlineImageProcessor(entity, sftpgoMock)
+
+	html := dataURIImg("png", tinyPNGBase64(16))
+
+	_, ierr := p.Process(context.Background(), "agent@example.com", "raw-jwt", "case-1", "", html)
+	if ierr == nil {
+		t.Fatal("Process returned no error, want the confirm failure to reject the whole comment")
+	}
+	if len(deletedIDs) != 1 {
+		t.Errorf("deletedIDs = %v, want the unconfirmed row deleted", deletedIDs)
+	}
+	if len(sftpgoMock.removeFileCalls) != 1 {
+		t.Errorf("removeFileCalls = %v, want the uploaded bytes deleted", sftpgoMock.removeFileCalls)
+	}
+}
+
+// TestInlineImageProcessorRollbackSurvivesCancelledContext verifies rollback
+// runs on a context detached from the request's cancellation: even when the
+// parent context is already cancelled by the time the failure surfaces
+// (caller gone, deadline hit), the row deletions and byte cleanups must still
+// be attempted, on a NON-cancelled context.
+func TestInlineImageProcessorRollbackSurvivesCancelledContext(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var deleteCtxErrs []error
+	var deletedIDs []string
+	entity := &mockEntityCaseClient{
+		createCaseAttachmentFn: nextAttachmentIDFactory(),
+		deleteCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			deleteCtxErrs = append(deleteCtxErrs, ctx.Err())
+			deletedIDs = append(deletedIDs, attachmentID)
+			return []byte(`{"message":"deleted"}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{
+		uploadBytesFn: func(ctx context.Context, shareID, storageKey string, data []byte, contentType string) error {
+			// Simulate the request being torn down mid-upload: cancel the
+			// parent context, then fail the upload.
+			cancel()
+			return context.Canceled
+		},
+	}
+	p := NewInlineImageProcessor(entity, sftpgoMock)
+
+	html := dataURIImg("png", tinyPNGBase64(16))
+
+	_, ierr := p.Process(ctx, "agent@example.com", "raw-jwt", "case-1", "", html)
+	if ierr == nil {
+		t.Fatal("Process returned no error, want the upload failure to reject the whole comment")
+	}
+	if len(deletedIDs) != 1 {
+		t.Fatalf("deletedIDs = %v, want the created row deleted despite the cancelled parent context", deletedIDs)
+	}
+	for i, err := range deleteCtxErrs {
+		if err != nil {
+			t.Errorf("DeleteCaseAttachment call %d ran on a cancelled context (%v); rollback must use a detached context", i, err)
+		}
+	}
+	if len(sftpgoMock.removeFileCalls) != 1 {
+		t.Fatalf("removeFileCalls = %v, want the possibly-partial upload cleaned up", sftpgoMock.removeFileCalls)
+	}
+	for i, err := range sftpgoMock.removeFileCtxErrs {
+		if err != nil {
+			t.Errorf("RemoveFile call %d ran on a cancelled context (%v); rollback must use a detached context", i, err)
 		}
 	}
 }

--- a/apps/csm-portal/backend/internal/handler/response.go
+++ b/apps/csm-portal/backend/internal/handler/response.go
@@ -40,8 +40,13 @@ const (
 	ErrMsgWorkNoteOnClosedCase   = "Work notes cannot be added to a closed case."
 	ErrMsgAttachmentOnClosedCase = "Attachments cannot be added to a closed case."
 	ErrMsgAttachmentNotShareable = "This attachment is not available for direct download."
-	ErrMsgInvalidUUID            = "Invalid UUID format."
-	errMsgReadBody               = "Failed to read request body."
+	// ErrMsgAttachmentStorageUnsupportedRef is returned by the direct-upload
+	// (SFTPGo-backed) mint endpoint for a reference type whose attachments
+	// cannot be persisted through that storage mode yet — the caller should
+	// use the standard attachment upload instead.
+	ErrMsgAttachmentStorageUnsupportedRef = "Direct-upload attachment storage is not available for this item type yet. Use the standard attachment upload instead."
+	ErrMsgInvalidUUID                     = "Invalid UUID format."
+	errMsgReadBody                        = "Failed to read request body."
 )
 
 // errorBody is the JSON error payload format matching the customer-portal pattern.

--- a/apps/csm-portal/backend/internal/sftpgo/client.go
+++ b/apps/csm-portal/backend/internal/sftpgo/client.go
@@ -372,6 +372,41 @@ func (c *Client) UploadBytes(ctx context.Context, shareID, storageKey string, da
 	return nil
 }
 
+// RemoveFile deletes one stored file, addressed by its storage key, via
+// SFTPGo's DELETE /api/v2/user/files?path=... endpoint, authenticated as the
+// caller via accessToken (minted by MintToken). Used only for best-effort
+// rollback cleanup: when a multi-step flow (see
+// internal/handler.InlineImageProcessor) fails after some bytes were already
+// uploaded, the orphaned objects are removed so a rolled-back operation
+// leaves neither metadata rows nor stray files behind. The endpoint's
+// path/query shape matches SFTPGo's published OpenAPI spec but has NOT been
+// verified against a live instance for this change — callers treat a failure
+// here as log-and-continue, never as fatal, so a shape mismatch degrades to
+// an orphaned file plus an error log rather than a broken request path.
+func (c *Client) RemoveFile(ctx context.Context, accessToken, storageKey string) error {
+	endpoint := c.baseURL + "/api/v2/user/files?path=" + url.QueryEscape(storageKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("sftpgo: build file-delete request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("sftpgo: file-delete request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("sftpgo: read file-delete response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return &apierror.Error{StatusCode: resp.StatusCode, Body: truncate(body)}
+	}
+	return nil
+}
+
 // truncate bounds body to maxErrBodyBytes for inclusion on an *apierror.Error.
 func truncate(body []byte) string {
 	if len(body) > maxErrBodyBytes {

--- a/apps/csm-portal/backend/internal/sftpgo/client.go
+++ b/apps/csm-portal/backend/internal/sftpgo/client.go
@@ -88,15 +88,28 @@ func NewClient(cfg Config) *Client {
 }
 
 // refuseInsecureRedirect is an http.Client.CheckRedirect override that
-// refuses to follow any redirect whose target is not HTTPS. Go's default
+// refuses to follow any redirect whose target is not HTTPS or whose origin
+// (scheme://host) differs from the ORIGINAL request's origin. Go's default
 // CheckRedirect copies the Authorization header onto a same-host redirect,
 // which would silently leak this client's bearer token (see MintToken,
-// CreateShare) over cleartext on an HTTPS-to-HTTP downgrade redirect —
-// something a compromised or misconfigured SFTPGo instance, or a
-// man-in-the-middle, could trigger without this check.
+// CreateShare) over cleartext on an HTTPS-to-HTTP downgrade redirect; and a
+// 307/308 redirect to a different HTTPS origin would forward whatever the
+// request carries — for UploadBytes's TUS calls that is the share-id
+// credential in Upload-Metadata plus the PATCH body's uploaded bytes — to a
+// host this client was never configured to trust. Either is something a
+// compromised or misconfigured SFTPGo instance, or a man-in-the-middle,
+// could trigger without this check. The origin comparison is against
+// via[0].URL (the request this client originally issued), not the previous
+// hop, so a chain of redirects cannot walk the request off-origin.
 func refuseInsecureRedirect(req *http.Request, via []*http.Request) error {
 	if req.URL.Scheme != "https" {
 		return fmt.Errorf("sftpgo: refusing to follow redirect to non-https URL %q", req.URL.Redacted())
+	}
+	if len(via) > 0 {
+		origin := via[0].URL
+		if req.URL.Scheme != origin.Scheme || req.URL.Host != origin.Host {
+			return fmt.Errorf("sftpgo: refusing to follow redirect to foreign origin %q (original origin %s://%s)", req.URL.Redacted(), origin.Scheme, origin.Host)
+		}
 	}
 	return nil
 }
@@ -116,12 +129,19 @@ func (c *Client) do(req *http.Request, opDesc string) ([]byte, http.Header, erro
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		// Read at most one byte past the truncation limit — enough for
+		// truncate to keep its excerpt — so an arbitrarily large upstream
+		// error body is never buffered in full.
+		errBody, err := io.ReadAll(io.LimitReader(resp.Body, maxErrBodyBytes+1))
+		if err != nil {
+			return nil, nil, fmt.Errorf("sftpgo: read %s response: %w", opDesc, err)
+		}
+		return nil, nil, &apierror.Error{StatusCode: resp.StatusCode, Body: truncate(errBody)}
+	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, fmt.Errorf("sftpgo: read %s response: %w", opDesc, err)
-	}
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, nil, &apierror.Error{StatusCode: resp.StatusCode, Body: truncate(body)}
 	}
 	return body, resp.Header, nil
 }

--- a/apps/csm-portal/backend/internal/sftpgo/client.go
+++ b/apps/csm-portal/backend/internal/sftpgo/client.go
@@ -101,6 +101,31 @@ func refuseInsecureRedirect(req *http.Request, via []*http.Request) error {
 	return nil
 }
 
+// do executes req and returns the full response body plus the response
+// headers — the shared request/response path every Client method routes
+// through, mirroring the do helpers on this backend's other upstream clients
+// (internal/entity, internal/scim, internal/updates). A transport failure or
+// body-read failure is wrapped with opDesc; any non-2xx status is mapped to
+// an *apierror.Error carrying a truncated body excerpt. The headers are
+// returned because some SFTPGo responses carry their result there rather
+// than in the body (CreateShare's X-Object-Id, UploadBytes's TUS Location).
+func (c *Client) do(req *http.Request, opDesc string) ([]byte, http.Header, error) {
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("sftpgo: %s request: %w", opDesc, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("sftpgo: read %s response: %w", opDesc, err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, nil, &apierror.Error{StatusCode: resp.StatusCode, Body: truncate(body)}
+	}
+	return body, resp.Header, nil
+}
+
 // BaseURL returns the configured REST API base URL, verbatim — handed back
 // to the FE by AttachmentStorageHandler.MintUploadToken as the host it
 // should call directly for the upload itself.
@@ -133,18 +158,9 @@ func (c *Client) MintToken(ctx context.Context, email, jwtAssertion string) (*To
 	}
 	req.SetBasicAuth(email, jwtAssertion)
 
-	resp, err := c.http.Do(req)
+	body, _, err := c.do(req, "token")
 	if err != nil {
-		return nil, fmt.Errorf("sftpgo: token request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("sftpgo: read token response: %w", err)
-	}
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, &apierror.Error{StatusCode: resp.StatusCode, Body: truncate(body)}
+		return nil, err
 	}
 
 	var tok Token
@@ -214,18 +230,9 @@ func (c *Client) CreateShare(ctx context.Context, accessToken, storageKey string
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 
-	resp, err := c.http.Do(req)
+	body, header, err := c.do(req, "share")
 	if err != nil {
-		return "", fmt.Errorf("sftpgo: share request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("sftpgo: read share response: %w", err)
-	}
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return "", &apierror.Error{StatusCode: resp.StatusCode, Body: truncate(body)}
+		return "", err
 	}
 
 	// SFTPGo has historically returned the created object's id via the
@@ -233,7 +240,7 @@ func (c *Client) CreateShare(ctx context.Context, accessToken, storageKey string
 	// empirically against a real instance in a prior session. The JSON body
 	// is only a fallback here and has NOT been independently re-verified for
 	// this change.
-	if id := resp.Header.Get("X-Object-Id"); id != "" {
+	if id := header.Get("X-Object-Id"); id != "" {
 		return id, nil
 	}
 
@@ -312,17 +319,9 @@ func (c *Client) UploadBytes(ctx context.Context, shareID, storageKey string, da
 	createReq.Header.Set("Upload-Length", strconv.Itoa(len(data)))
 	createReq.Header.Set("Upload-Metadata", uploadMetadata)
 
-	createResp, err := c.http.Do(createReq)
+	_, createHeader, err := c.do(createReq, "chunked-upload create")
 	if err != nil {
-		return fmt.Errorf("sftpgo: chunked-upload create request: %w", err)
-	}
-	createBody, err := io.ReadAll(createResp.Body)
-	createResp.Body.Close()
-	if err != nil {
-		return fmt.Errorf("sftpgo: read chunked-upload create response: %w", err)
-	}
-	if createResp.StatusCode < http.StatusOK || createResp.StatusCode >= http.StatusMultipleChoices {
-		return &apierror.Error{StatusCode: createResp.StatusCode, Body: truncate(createBody)}
+		return err
 	}
 
 	// The TUS spec returns the upload's URL via Location, which may be
@@ -332,7 +331,7 @@ func (c *Client) UploadBytes(ctx context.Context, shareID, storageKey string, da
 	// SFTPGo instance redirecting the upload elsewhere is exactly the risk
 	// the frontend's uploadFileViaTus guards against with the same check).
 	uploadURL := createEndpoint
-	if location := createResp.Header.Get("Location"); location != "" {
+	if location := createHeader.Get("Location"); location != "" {
 		base, err := url.Parse(createEndpoint)
 		if err != nil {
 			return fmt.Errorf("sftpgo: parse chunked-upload create endpoint: %w", err)
@@ -357,17 +356,8 @@ func (c *Client) UploadBytes(ctx context.Context, shareID, storageKey string, da
 	patchReq.Header.Set("Content-Type", "application/offset+octet-stream")
 	patchReq.ContentLength = int64(len(data))
 
-	patchResp, err := c.http.Do(patchReq)
-	if err != nil {
-		return fmt.Errorf("sftpgo: chunked-upload PATCH request: %w", err)
-	}
-	patchBody, err := io.ReadAll(patchResp.Body)
-	patchResp.Body.Close()
-	if err != nil {
-		return fmt.Errorf("sftpgo: read chunked-upload PATCH response: %w", err)
-	}
-	if patchResp.StatusCode < http.StatusOK || patchResp.StatusCode >= http.StatusMultipleChoices {
-		return &apierror.Error{StatusCode: patchResp.StatusCode, Body: truncate(patchBody)}
+	if _, _, err := c.do(patchReq, "chunked-upload PATCH"); err != nil {
+		return err
 	}
 	return nil
 }
@@ -391,18 +381,8 @@ func (c *Client) RemoveFile(ctx context.Context, accessToken, storageKey string)
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return fmt.Errorf("sftpgo: file-delete request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("sftpgo: read file-delete response: %w", err)
-	}
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return &apierror.Error{StatusCode: resp.StatusCode, Body: truncate(body)}
+	if _, _, err := c.do(req, "file-delete"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/apps/csm-portal/backend/internal/sftpgo/client_test.go
+++ b/apps/csm-portal/backend/internal/sftpgo/client_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -371,5 +372,60 @@ func TestClientRefusesInsecureRedirect(t *testing.T) {
 	}
 	if downgradeHit {
 		t.Error("downgrade target received a request; CheckRedirect should have refused before dialing it (Authorization would have leaked over plain HTTP)")
+	}
+}
+
+func TestRemoveFileSendsCorrectRequestShape(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath, gotQueryPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQueryPath = r.URL.Query().Get("path")
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	storageKey := "/attachments/cases/case-1/att-1/report file.pdf"
+	if err := client.RemoveFile(context.Background(), "tok-123", storageKey); err != nil {
+		t.Fatalf("RemoveFile: %v", err)
+	}
+
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if gotPath != "/api/v2/user/files" {
+		t.Errorf("path = %q, want /api/v2/user/files", gotPath)
+	}
+	if gotQueryPath != storageKey {
+		t.Errorf("query path = %q, want %q (must round-trip through URL escaping unchanged)", gotQueryPath, storageKey)
+	}
+	if gotAuth != "Bearer tok-123" {
+		t.Errorf("Authorization = %q, want Bearer tok-123", gotAuth)
+	}
+}
+
+func TestRemoveFilePropagatesUpstreamError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"no such file"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	err := client.RemoveFile(context.Background(), "tok-123", "/attachments/missing")
+	var apiErr *apierror.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v, want *apierror.Error", err)
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode = %d, want 404", apiErr.StatusCode)
 	}
 }

--- a/apps/csm-portal/backend/internal/sftpgo/client_test.go
+++ b/apps/csm-portal/backend/internal/sftpgo/client_test.go
@@ -375,6 +375,157 @@ func TestClientRefusesInsecureRedirect(t *testing.T) {
 	}
 }
 
+// TestClientRefusesCrossOriginRedirectOnTUSCreate proves a TUS create (POST
+// /api/v2/shares-chunked-uploads) redirected to a DIFFERENT HTTPS origin is
+// refused before the foreign host is ever dialed — a 307/308 there would
+// forward the Upload-Metadata header, whose share_id is the entire upload
+// credential, to a host this client was never configured to trust.
+func TestClientRefusesCrossOriginRedirectOnTUSCreate(t *testing.T) {
+	t.Parallel()
+
+	foreignHit := false
+	foreignSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		foreignHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer foreignSrv.Close()
+
+	tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// HTTPS-to-HTTPS, but a different origin: the scenario the
+		// same-origin check in refuseInsecureRedirect exists to block.
+		http.Redirect(w, r, foreignSrv.URL+"/api/v2/shares-chunked-uploads", http.StatusTemporaryRedirect)
+	}))
+	defer tlsSrv.Close()
+
+	client := NewClient(Config{BaseURL: tlsSrv.URL})
+	client.http.Transport = tlsSrv.Client().Transport
+
+	err := client.UploadBytes(context.Background(), "share-abc", "/attachments/x/img.png", []byte("payload"), "image/png")
+	if err == nil {
+		t.Fatal("UploadBytes: expected an error refusing the cross-origin redirect, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to follow redirect to foreign origin") {
+		t.Errorf("UploadBytes error = %v, want it to mention refusing the foreign-origin redirect", err)
+	}
+	if foreignHit {
+		t.Error("foreign origin received a request; CheckRedirect should have refused before dialing it (Upload-Metadata's share_id would have leaked)")
+	}
+}
+
+// TestClientRefusesCrossOriginRedirectOnTUSPatch is the PATCH-leg twin of the
+// create-leg test above: the create succeeds on the configured origin, then
+// the PATCH carrying the file bytes is redirected to a different HTTPS origin
+// and must be refused before that host sees the body.
+func TestClientRefusesCrossOriginRedirectOnTUSPatch(t *testing.T) {
+	t.Parallel()
+
+	foreignHit := false
+	foreignSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		foreignHit = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer foreignSrv.Close()
+
+	tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			w.Header().Set("Location", "/api/v2/shares-chunked-uploads/upload-1")
+			w.WriteHeader(http.StatusCreated)
+		case http.MethodPatch:
+			http.Redirect(w, r, foreignSrv.URL+"/api/v2/shares-chunked-uploads/upload-1", http.StatusTemporaryRedirect)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer tlsSrv.Close()
+
+	client := NewClient(Config{BaseURL: tlsSrv.URL})
+	client.http.Transport = tlsSrv.Client().Transport
+
+	err := client.UploadBytes(context.Background(), "share-abc", "/attachments/x/img.png", []byte("payload"), "image/png")
+	if err == nil {
+		t.Fatal("UploadBytes: expected an error refusing the cross-origin redirect, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to follow redirect to foreign origin") {
+		t.Errorf("UploadBytes error = %v, want it to mention refusing the foreign-origin redirect", err)
+	}
+	if foreignHit {
+		t.Error("foreign origin received a request; CheckRedirect should have refused before dialing it (the PATCH body's bytes would have leaked)")
+	}
+}
+
+// TestClientFollowsSameOriginRedirect proves the same-origin check does not
+// over-block: an HTTPS redirect to a different path on the SAME origin is
+// still followed, on both the TUS create and PATCH legs.
+func TestClientFollowsSameOriginRedirect(t *testing.T) {
+	t.Parallel()
+
+	var patchLanded bool
+	var mux http.ServeMux
+	mux.HandleFunc("POST /api/v2/shares-chunked-uploads", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/relocated-create", http.StatusTemporaryRedirect)
+	})
+	mux.HandleFunc("POST /relocated-create", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "/api/v2/shares-chunked-uploads/upload-1")
+		w.WriteHeader(http.StatusCreated)
+	})
+	mux.HandleFunc("PATCH /api/v2/shares-chunked-uploads/upload-1", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/relocated-patch", http.StatusTemporaryRedirect)
+	})
+	mux.HandleFunc("PATCH /relocated-patch", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "payload" {
+			t.Errorf("redirected PATCH body = %q, want %q", body, "payload")
+		}
+		patchLanded = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	tlsSrv := httptest.NewTLSServer(&mux)
+	defer tlsSrv.Close()
+
+	client := NewClient(Config{BaseURL: tlsSrv.URL})
+	client.http.Transport = tlsSrv.Client().Transport
+
+	if err := client.UploadBytes(context.Background(), "share-abc", "/attachments/x/img.png", []byte("payload"), "image/png"); err != nil {
+		t.Fatalf("UploadBytes: %v (a same-origin redirect must still be followed)", err)
+	}
+	if !patchLanded {
+		t.Error("redirected PATCH target was never reached")
+	}
+}
+
+// TestDoTruncatesHugeErrorBody proves a non-2xx response with an arbitrarily
+// large body surfaces as an *apierror.Error whose Body excerpt is bounded at
+// maxErrBodyBytes — the client reads only just past the limit rather than
+// buffering the whole thing.
+func TestDoTruncatesHugeErrorBody(t *testing.T) {
+	t.Parallel()
+
+	huge := strings.Repeat("x", 1<<20) // 1 MiB, far past maxErrBodyBytes
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, huge)
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	_, err := client.MintToken(context.Background(), "jane.doe@example.com", "raw-jwt")
+	var apiErr *apierror.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v, want *apierror.Error", err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want 500", apiErr.StatusCode)
+	}
+	if len(apiErr.Body) != maxErrBodyBytes {
+		t.Errorf("len(Body) = %d, want exactly %d (truncated)", len(apiErr.Body), maxErrBodyBytes)
+	}
+	if apiErr.Body != huge[:maxErrBodyBytes] {
+		t.Errorf("Body = %q, want the first %d bytes of the upstream body", apiErr.Body, maxErrBodyBytes)
+	}
+}
+
 func TestRemoveFileSendsCorrectRequestShape(t *testing.T) {
 	t.Parallel()
 

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1205,6 +1205,15 @@ export interface BeAttachmentUploadTokenRequest {
   mimeType: string;
   sizeBytes: number;
   description?: string | null;
+  /**
+   * Reference entity type for the attachment being minted. Optional; the BE
+   * defaults to `"case"` when omitted. Only `"case"` is actually supported by
+   * direct-upload storage today — `"change_request"`/`"incident"` are
+   * authorized but rejected with a deterministic 422, so the webapp routes
+   * those two through the legacy base64 path instead of calling this
+   * endpoint at all.
+   */
+  referenceType?: BeReferenceType;
 }
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.test.tsx
@@ -138,6 +138,7 @@ describe("usePostCsmCaseAttachment", () => {
       mimeType: FILE.type,
       sizeBytes: FILE.size,
       description: null,
+      referenceType: "case",
     });
 
     expect(uploadFileViaTusMock).toHaveBeenCalledTimes(1);
@@ -211,6 +212,36 @@ describe("usePostCsmCaseAttachment", () => {
     });
     await waitFor(() => expect(result.current.uploadProgress).toBeNull());
   });
+
+  it.each(["change_request", "incident"] as const)(
+    "flag on, referenceType %s: skips the mint endpoint and uses the legacy base64 path",
+    async (referenceType) => {
+      sftpgoFlag.enabled = true;
+      postMock.mockResolvedValue({});
+
+      const { result } = renderHook(() => usePostCsmCaseAttachment(), {
+        wrapper,
+      });
+
+      await act(() =>
+        result.current.mutateAsync({
+          caseId: "case-1",
+          file: FILE,
+          uploadedBy: "Jane Doe",
+          referenceType,
+        }),
+      );
+
+      expect(uploadFileViaTusMock).not.toHaveBeenCalled();
+      expect(postMock).toHaveBeenCalledTimes(1);
+      const [path, payload] = postMock.mock.calls[0];
+      expect(path).toBe("/attachments");
+      expect(payload.referenceType).toBe(referenceType);
+      expect(typeof payload.file).toBe("string");
+      expect(payload.file.startsWith("data:")).toBe(true);
+      expect(result.current.uploadProgress).toBeNull();
+    },
+  );
 });
 
 describe("useDownloadCsmCaseAttachment", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
@@ -139,15 +139,21 @@ export type PostCsmCaseAttachmentResult = UseMutationResult<
  * Upload a file attachment to a reference entity.
  *
  * Two mutually exclusive paths, gated on the signed-in user's
- * `sftpgoAttachmentStorageEnabled` flag (`GET /users/me`):
- *  - Off (default, unchanged): the file is sent as a base64 data URI in a
- *    single `POST /attachments`.
- *  - On: `POST /cases/{id}/attachments/upload-token` registers the
- *    attachment's metadata (in "pending" status) and mints a write-scoped
- *    SFTPGo share; the file's bytes then go straight from the browser to
- *    SFTPGo via that share (mirroring `uploadProgress`); finally
- *    `POST /cases/{id}/attachments/{attachmentId}/confirm` transitions the
- *    row to "complete".
+ * `sftpgoAttachmentStorageEnabled` flag (`GET /users/me`) AND on
+ * `referenceType`:
+ *  - Off, or `referenceType` is `"change_request"`/`"incident"`: the file is
+ *    sent as a base64 data URI in a single `POST /attachments`. Direct-upload
+ *    storage only supports `"case"` today — the BE authorizes but then
+ *    rejects change-request/incident mint requests with a deterministic 422,
+ *    so those two reference types always take this path regardless of the
+ *    flag.
+ *  - On, and `referenceType` is `"case"` (or absent): `POST
+ *    /cases/{id}/attachments/upload-token` registers the attachment's
+ *    metadata (in "pending" status) and mints a write-scoped SFTPGo share;
+ *    the file's bytes then go straight from the browser to SFTPGo via that
+ *    share (mirroring `uploadProgress`); finally `POST
+ *    /cases/{id}/attachments/{attachmentId}/confirm` transitions the row to
+ *    "complete".
  *
  * The confirm/create response is a thin ack either way, so the list is
  * refetched on success to hydrate the new entry from search.
@@ -177,7 +183,10 @@ export function usePostCsmCaseAttachment(): PostCsmCaseAttachmentResult {
       const name = input.name?.trim() || input.file.name;
       const type = input.file.type || "application/octet-stream";
 
-      if (sftpgoEnabled) {
+      // Direct-upload storage only supports "case" today; change-request and
+      // incident uploads always fall through to the legacy base64 path below,
+      // regardless of the flag.
+      if (sftpgoEnabled && referenceType === "case") {
         setUploadProgress(0);
         try {
           const tokenRequest: BeAttachmentUploadTokenRequest = {
@@ -185,6 +194,7 @@ export function usePostCsmCaseAttachment(): PostCsmCaseAttachmentResult {
             mimeType: type,
             sizeBytes: input.file.size,
             description: input.description?.trim() || null,
+            referenceType,
           };
           const tokenResponse = await api.post<
             BeAttachmentUploadTokenRequest,

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -4512,11 +4512,11 @@ type AttachmentDetails struct {
 	ReferenceID string `json:"referenceId"`
 	// ReferenceType identifies which entity type ReferenceID points at (see
 	// ReferenceType). Always populated for CSM-native (Postgres) data source
-	// attachments; empty when the backing data source's attachment-details
-	// lookup does not report a reference type. Callers authorizing access per
-	// referenced resource must treat an empty value as unknown and fail
-	// closed.
-	ReferenceType ReferenceType `json:"referenceType,omitempty"`
+	// attachments; nil (JSON null) when the backing data source's
+	// attachment-details lookup does not report a reference type. Callers
+	// authorizing access per referenced resource must treat a nil value as
+	// unknown and fail closed.
+	ReferenceType *ReferenceType `json:"referenceType"`
 	Name          string        `json:"name"`
 	Type          string        `json:"type"`
 	SizeBytes     int           `json:"sizeBytes"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2397,10 +2397,10 @@ type CreateAttachmentRequest struct {
 
 // AttachmentDetail holds the core fields returned after creating an attachment.
 type AttachmentDetail struct {
-	ID          string    `json:"id"`
-	SizeBytes   int       `json:"sizeBytes"`
-	CreatedOn   time.Time `json:"createdOn"`
-	CreatedBy   string    `json:"createdBy"`
+	ID        string    `json:"id"`
+	SizeBytes int       `json:"sizeBytes"`
+	CreatedOn time.Time `json:"createdOn"`
+	CreatedBy string    `json:"createdBy"`
 	// DownloadURL is nil for a CSM-native (Postgres) data source attachment:
 	// this service holds no download location for it, only its storage_key --
 	// resolving storage_key to an actual download location is the downstream
@@ -4506,19 +4506,25 @@ type CaseFeedback struct {
 // metadata plus its base64-encoded file content. Note ServiceNow's
 // attachment-details lookup does not resolve the uploader to a UserReference
 // the way the search/comment paths do (only those two carry a createdByUser
-// object) — CreatedBy is a bare string here, and there is no ReferenceType in
-// the upstream response at all, so it is deliberately not modeled below.
+// object) — CreatedBy is a bare string here.
 type AttachmentDetails struct {
-	ID          string    `json:"id"`
-	ReferenceID string    `json:"referenceId"`
-	Name        string    `json:"name"`
-	Type        string    `json:"type"`
-	SizeBytes   int       `json:"sizeBytes"`
-	Description *string   `json:"description"`
-	CreatedBy   string    `json:"createdBy"`
-	CreatedOn   time.Time `json:"createdOn"`
-	DownloadURL *string   `json:"downloadUrl"`
-	PreviewURL  *string   `json:"previewUrl"`
+	ID          string `json:"id"`
+	ReferenceID string `json:"referenceId"`
+	// ReferenceType identifies which entity type ReferenceID points at (see
+	// ReferenceType). Always populated for CSM-native (Postgres) data source
+	// attachments; empty when the backing data source's attachment-details
+	// lookup does not report a reference type. Callers authorizing access per
+	// referenced resource must treat an empty value as unknown and fail
+	// closed.
+	ReferenceType ReferenceType `json:"referenceType,omitempty"`
+	Name          string        `json:"name"`
+	Type          string        `json:"type"`
+	SizeBytes     int           `json:"sizeBytes"`
+	Description   *string       `json:"description"`
+	CreatedBy     string        `json:"createdBy"`
+	CreatedOn     time.Time     `json:"createdOn"`
+	DownloadURL   *string       `json:"downloadUrl"`
+	PreviewURL    *string       `json:"previewUrl"`
 	// Content is nil for CSM-native (Postgres) data source attachments: this
 	// service holds no bytes for them -- see CaseService.GetCaseAttachmentContent.
 	// Always non-nil for ServiceNow-sourced attachments.

--- a/entity-service/internal/service/case_attachment_service_test.go
+++ b/entity-service/internal/service/case_attachment_service_test.go
@@ -469,8 +469,8 @@ func TestCaseService_GetAttachmentByID_ReturnsStorageKeyNotContent(t *testing.T)
 	if details.ReferenceID != testCaseID {
 		t.Fatalf("expected referenceId %q, got %q", testCaseID, details.ReferenceID)
 	}
-	if details.ReferenceType != domain.ReferenceTypeCase {
-		t.Fatalf("expected referenceType %q, got %q", domain.ReferenceTypeCase, details.ReferenceType)
+	if details.ReferenceType == nil || *details.ReferenceType != domain.ReferenceTypeCase {
+		t.Fatalf("expected referenceType %q, got %v", domain.ReferenceTypeCase, details.ReferenceType)
 	}
 }
 

--- a/entity-service/internal/service/case_attachment_service_test.go
+++ b/entity-service/internal/service/case_attachment_service_test.go
@@ -466,6 +466,12 @@ func TestCaseService_GetAttachmentByID_ReturnsStorageKeyNotContent(t *testing.T)
 	if details.CreatedBy != "jane.doe@example.com" {
 		t.Fatalf("expected createdBy email, got %q", details.CreatedBy)
 	}
+	if details.ReferenceID != testCaseID {
+		t.Fatalf("expected referenceId %q, got %q", testCaseID, details.ReferenceID)
+	}
+	if details.ReferenceType != domain.ReferenceTypeCase {
+		t.Fatalf("expected referenceType %q, got %q", domain.ReferenceTypeCase, details.ReferenceType)
+	}
 }
 
 // TestCaseService_GetAttachmentByID_NotFound proves a missing attachment

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -831,19 +831,20 @@ func (s *caseService) GetAttachmentByID(ctx context.Context, id string) (domain.
 	}
 
 	return domain.AttachmentDetails{
-		ID:          a.ID,
-		ReferenceID: a.ReferenceID,
-		Name:        a.Name,
-		Type:        a.Type,
-		SizeBytes:   a.SizeBytes,
-		Description: a.Description,
-		CreatedBy:   createdBy,
-		CreatedOn:   a.CreatedOn,
-		DownloadURL: a.DownloadURL,
-		PreviewURL:  a.PreviewURL,
-		Content:     nil,
-		StorageKey:  a.StorageKey,
-		Status:      a.Status,
+		ID:            a.ID,
+		ReferenceID:   a.ReferenceID,
+		ReferenceType: a.ReferenceType,
+		Name:          a.Name,
+		Type:          a.Type,
+		SizeBytes:     a.SizeBytes,
+		Description:   a.Description,
+		CreatedBy:     createdBy,
+		CreatedOn:     a.CreatedOn,
+		DownloadURL:   a.DownloadURL,
+		PreviewURL:    a.PreviewURL,
+		Content:       nil,
+		StorageKey:    a.StorageKey,
+		Status:        a.Status,
 	}, nil
 }
 

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -833,7 +833,7 @@ func (s *caseService) GetAttachmentByID(ctx context.Context, id string) (domain.
 	return domain.AttachmentDetails{
 		ID:            a.ID,
 		ReferenceID:   a.ReferenceID,
-		ReferenceType: a.ReferenceType,
+		ReferenceType: &a.ReferenceType,
 		Name:          a.Name,
 		Type:          a.Type,
 		SizeBytes:     a.SizeBytes,

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -2872,9 +2872,10 @@ func (s *snCaseService) GetAttachmentByID(ctx context.Context, id string) (domai
 		return domain.AttachmentDetails{}, fmt.Errorf("sn get attachment: parse createdOn %q: %w", snResp.CreatedOn, err)
 	}
 
-	// ReferenceType is left empty: the upstream attachment-details response
-	// carries no reference type (see snAttachmentDetails), and there is no
-	// way to derive one from the id alone. Callers must fail closed on it.
+	// ReferenceType is left nil (serialized as JSON null): the upstream
+	// attachment-details response carries no reference type (see
+	// snAttachmentDetails), and there is no way to derive one from the id
+	// alone. Callers must fail closed on it.
 	return domain.AttachmentDetails{
 		ID:          sysidToUUID(snResp.ID),
 		ReferenceID: sysidToUUID(snResp.ReferenceID),

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -2872,6 +2872,9 @@ func (s *snCaseService) GetAttachmentByID(ctx context.Context, id string) (domai
 		return domain.AttachmentDetails{}, fmt.Errorf("sn get attachment: parse createdOn %q: %w", snResp.CreatedOn, err)
 	}
 
+	// ReferenceType is left empty: the upstream attachment-details response
+	// carries no reference type (see snAttachmentDetails), and there is no
+	// way to derive one from the id alone. Callers must fail closed on it.
 	return domain.AttachmentDetails{
 		ID:          sysidToUUID(snResp.ID),
 		ReferenceID: sysidToUUID(snResp.ReferenceID),

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -12098,7 +12098,7 @@ components:
         as a base64 data URI. For a CSM-native (Postgres) data source attachment, content is
         always "" and storageKey is populated instead: this service holds no bytes for that
         data source, so content must be resolved externally via storageKey.
-      required: [id, referenceId, name, type, sizeBytes, createdBy, createdOn, content]
+      required: [id, referenceId, referenceType, name, type, sizeBytes, createdBy, createdOn, content]
       properties:
         id:
           type: string

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -12107,13 +12107,14 @@ components:
           type: string
           format: uuid
         referenceType:
+          nullable: true
           allOf:
             - $ref: '#/components/schemas/ReferenceType'
           description: >
             The entity type referenceId points at. Always populated for CSM-native
-            (Postgres) data source attachments; omitted when the backing data source's
+            (Postgres) data source attachments; null when the backing data source's
             attachment-details lookup does not report a reference type. Callers
-            authorizing access per referenced resource must treat an absent value as
+            authorizing access per referenced resource must treat a null value as
             unknown and fail closed.
         name:
           type: string

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -12107,9 +12107,14 @@ components:
           type: string
           format: uuid
         referenceType:
+          type: string
           nullable: true
-          allOf:
-            - $ref: '#/components/schemas/ReferenceType'
+          enum:
+            - case
+            - conversation
+            - change_request
+            - deployment
+            - incident
           description: >
             The entity type referenceId points at. Always populated for CSM-native
             (Postgres) data source attachments; null when the backing data source's

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -12106,6 +12106,15 @@ components:
         referenceId:
           type: string
           format: uuid
+        referenceType:
+          allOf:
+            - $ref: '#/components/schemas/ReferenceType'
+          description: >
+            The entity type referenceId points at. Always populated for CSM-native
+            (Postgres) data source attachments; omitted when the backing data source's
+            attachment-details lookup does not report a reference type. Callers
+            authorizing access per referenced resource must treat an absent value as
+            unknown and fail closed.
         name:
           type: string
         type:


### PR DESCRIPTION
Fixes three issues found in review of #1636, targeting `dev-app-csm-portal` so the merge to `main` lands clean.

## 1. Fail-closed authorization on attachment shares (security)

`CreateAttachmentShare`'s read-access check gated on `meta.ReferenceType == "case"`, but the entity-service attachment-details response carried no `referenceType`, so the check never fired: any authenticated user could mint a passwordless public share URL for any attachment UUID.

- **entity-service**: attachment details now return `referenceType` (additive, optional; always populated on the CSM-native data source, empty when the backing data source cannot report one). openapi updated additively.
- **backend**: share creation is fail-closed — empty or unrecognised reference type → 404; `case` → case read check; `change_request`/`incident` → the same access gate their detail endpoints apply.

## 2. Reference-type-aware upload-token minting

With the direct-upload storage flag on, change-request and incident attachment uploads failed with a confusing 404: the webapp always hit `POST /cases/{id}/attachments/upload-token`, and the backend hard-coded `ReferenceType: "case"`.

- **backend**: the mint request accepts an optional additive `referenceType` (default `case`, existing callers unchanged). `case` flows as before with the real type persisted; `change_request`/`incident` are authorized first, then get a deterministic 422 — direct-upload storage cannot persist those types yet (attachment storage is case-scoped), so no row and no storage call is made.
- **webapp**: with the flag on, case uploads mint tokens (now sending `referenceType`); change-request/incident uploads route through the existing base64 upload path, which fully works for them. Restores CR/incident attachment uploads under the flag.

Making direct-upload storage work for CR/incident attachments needs case-scoped storage widened at the entity layer — tracked separately.

## 3. Safe inline-image upload ordering

Inline-image attachments were created with status `complete` before bytes were uploaded; a mid-sequence failure left durable rows pointing at nonexistent files, and rollback deleted rows but never uploaded bytes (orphans on multi-image partial failure).

- **backend**: the inline-image path now follows the browser path's sequence — create row `pending` → create share → upload bytes → confirm `complete`. Rollback runs on a non-cancellable context and removes both the created rows and any already-uploaded objects (new storage-client `RemoveFile`), logging cleanup failures.

## Verification

- entity-service: `go build ./...`, `go vet ./...`, `go test ./...` — all pass.
- backend: `go build ./...`, `go vet ./...`, `go test ./...` — all pass, incl. 14 new/updated tests (fail-closed share denials, per-type mint authorization/422s, inline-image rollback of rows + bytes, cancelled-context rollback).
- webapp: `tsc`, eslint, `vitest` (9/9 incl. 2 new routing tests), production build — all pass.

Note: `attachment_storage_test.go` exceeds 300 diff lines (354) — test code accompanying the fixes above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Attachment details now include the referenced item type, or explicitly indicate when it is unknown.
  - Upload requests can specify whether an attachment belongs to a case, change request, or incident.

- **Bug Fixes**
  - Change-request and incident uploads use the standard upload flow when direct upload is unavailable.
  - Failed uploads now clean up incomplete records and stored files.
  - Unknown or missing reference types are rejected safely.
  - Cross-origin redirects are blocked during file transfers, and oversized error responses are handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->