### PR TITLE
[CSM Portal] Record a work note when an auto-closure hold is set

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -1107,6 +1107,25 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// The auto-closure hold work note (below) must only fire for an actual change in
+	// the hold date, not for a retry or a no-op PATCH that resends the existing value —
+	// otherwise every duplicate request pollutes the case's activity feed with an
+	// identical note. Read the prior value before the PATCH; after it, the case
+	// already reflects the new value and there'd be nothing to diff against.
+	var priorHoldDate string
+	if patchErr == nil && patch.AutocloseHoldUntil != nil {
+		if current, err := h.entity.GetCase(r.Context(), caseID); err != nil {
+			slog.WarnContext(r.Context(), "entity GetCase failed reading prior autoclose hold date; proceeding without dedup", "userID", user.UserID, "caseID", caseID, "err", err)
+		} else {
+			var currentCase struct {
+				AutoclosureStateTime *string `json:"autoclosureStateTime"`
+			}
+			if err := json.Unmarshal(current, &currentCase); err == nil && currentCase.AutoclosureStateTime != nil {
+				priorHoldDate = formatHoldDate(*currentCase.AutoclosureStateTime)
+			}
+		}
+	}
+
 	result, err := h.entity.PatchCase(r.Context(), caseID, body)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity PatchCase failed", "userID", user.UserID, "caseID", caseID, "err", err)
@@ -1117,13 +1136,32 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	// Setting/extending the auto-closure hold has no visible trail of its own on the
 	// case (unlike the legacy ticketing UI's equivalent action, which records a work
 	// note). Record one here so CS engineers can see when a hold was set/extended and
-	// until when. Best-effort: the hold PATCH above already succeeded and must not be
-	// rolled back or fail the request just because this secondary write-note fails.
-	if patchErr == nil && patch.AutocloseHoldUntil != nil {
-		h.recordAutocloseHoldWorkNote(r.Context(), user, caseID, *patch.AutocloseHoldUntil)
+	// until when. Best-effort and fire-and-forget: the hold PATCH above already
+	// succeeded, so this secondary write must not delay the response or fail/roll back
+	// the request if it errors. Detached from the request context (which is canceled
+	// once the handler returns) and bounded by its own timeout instead.
+	if patchErr == nil && patch.AutocloseHoldUntil != nil && formatHoldDate(*patch.AutocloseHoldUntil) != priorHoldDate {
+		holdUntil := *patch.AutocloseHoldUntil
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			h.recordAutocloseHoldWorkNote(ctx, user, caseID, holdUntil)
+		}()
 	}
 
 	writeJSON(w, http.StatusOK, result)
+}
+
+// formatHoldDate renders an auto-closure hold timestamp (RFC3339, as sent by the
+// FE or read back from the entity service) as the date-only form CS engineers see
+// in the UI and in the work note, since the hold is date-granularity. Falls back
+// to the raw input when it doesn't parse, so an already-invalid value is not
+// silently dropped from the comparison/note.
+func formatHoldDate(raw string) string {
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return t.Format("2006-01-02")
+	}
+	return raw
 }
 
 // recordAutocloseHoldWorkNote adds an internal work note documenting an
@@ -1132,12 +1170,7 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 // logged, never surfaced to the caller, since the primary hold PATCH already
 // succeeded by the time this runs.
 func (h *CaseHandler) recordAutocloseHoldWorkNote(ctx context.Context, user *middleware.UserInfo, caseID, holdUntil string) {
-	displayDate := holdUntil
-	if t, err := time.Parse(time.RFC3339, holdUntil); err == nil {
-		displayDate = t.Format("2006-01-02")
-	}
-
-	note := "Please note that this case is on-hold until " + displayDate +
+	note := "Please note that this case is on-hold until " + formatHoldDate(holdUntil) +
 		", hence it will not go through the auto closure process. It will be eligible " +
 		"for auto-closure again after this date passes, or if the case state is changed " +
 		"to 'Waiting on WSO2'."

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -27,6 +27,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
 )
@@ -1076,10 +1077,12 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 
 	// Validate state transition and workState guard before forwarding to the entity service.
 	var patch struct {
-		State     *string `json:"state"`
-		WorkState *string `json:"workState"`
+		State              *string `json:"state"`
+		WorkState          *string `json:"workState"`
+		AutocloseHoldUntil *string `json:"autocloseHoldUntil"`
 	}
-	if err := json.Unmarshal(body, &patch); err == nil && (patch.State != nil || patch.WorkState != nil) {
+	patchErr := json.Unmarshal(body, &patch)
+	if patchErr == nil && (patch.State != nil || patch.WorkState != nil) {
 		current, err := h.entity.GetCase(r.Context(), caseID)
 		if err != nil {
 			slog.ErrorContext(r.Context(), "entity GetCase failed during state validation", "userID", user.UserID, "caseID", caseID, "err", err)
@@ -1111,7 +1114,46 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Setting/extending the auto-closure hold has no visible trail of its own on the
+	// case (unlike the legacy ticketing UI's equivalent action, which records a work
+	// note). Record one here so CS engineers can see when a hold was set/extended and
+	// until when. Best-effort: the hold PATCH above already succeeded and must not be
+	// rolled back or fail the request just because this secondary write-note fails.
+	if patchErr == nil && patch.AutocloseHoldUntil != nil {
+		h.recordAutocloseHoldWorkNote(r.Context(), user, caseID, *patch.AutocloseHoldUntil)
+	}
+
 	writeJSON(w, http.StatusOK, result)
+}
+
+// recordAutocloseHoldWorkNote adds an internal work note documenting an
+// auto-closure hold set/extension, mirroring the work note the legacy
+// ticketing UI's equivalent action used to write. Best-effort: failures are
+// logged, never surfaced to the caller, since the primary hold PATCH already
+// succeeded by the time this runs.
+func (h *CaseHandler) recordAutocloseHoldWorkNote(ctx context.Context, user *middleware.UserInfo, caseID, holdUntil string) {
+	displayDate := holdUntil
+	if t, err := time.Parse(time.RFC3339, holdUntil); err == nil {
+		displayDate = t.Format("2006-01-02")
+	}
+
+	note := "Please note that this case is on-hold until " + displayDate +
+		", hence it will not go through the auto closure process. It will be eligible " +
+		"for auto-closure again after this date passes, or if the case state is changed " +
+		"to 'Waiting on WSO2'."
+
+	body, err := json.Marshal(map[string]string{
+		"type":    "work_note",
+		"content": note,
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to build autoclose hold work note body", "userID", user.UserID, "caseID", caseID, "err", err)
+		return
+	}
+
+	if _, err := h.entity.CreateCaseComment(ctx, caseID, body); err != nil {
+		slog.WarnContext(ctx, "failed to record autoclose hold work note", "userID", user.UserID, "caseID", caseID, "err", err)
+	}
 }
 
 // GetCase handles GET /cases/{id}.

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -1117,10 +1117,19 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 		if current, err := h.entity.GetCase(r.Context(), caseID); err != nil {
 			slog.WarnContext(r.Context(), "entity GetCase failed reading prior autoclose hold date; proceeding without dedup", "userID", user.UserID, "caseID", caseID, "err", err)
 		} else {
+			// autoclosureStateTime is only "the hold date" while the case is actually
+			// ON_HOLD — for every other autoclosureStep it's when that other stage next
+			// advances, a value unrelated to any hold. Without gating on the step, the
+			// very first hold on a case (whose autoclosureStateTime already holds some
+			// unrelated staged-advance date matching the FE's pre-filled picker default)
+			// gets misread as "unchanged" and its note silently skipped.
 			var currentCase struct {
+				AutoclosureStep      *string `json:"autoclosureStep"`
 				AutoclosureStateTime *string `json:"autoclosureStateTime"`
 			}
-			if err := json.Unmarshal(current, &currentCase); err == nil && currentCase.AutoclosureStateTime != nil {
+			if err := json.Unmarshal(current, &currentCase); err == nil &&
+				currentCase.AutoclosureStep != nil && *currentCase.AutoclosureStep == "ON_HOLD" &&
+				currentCase.AutoclosureStateTime != nil {
 				priorHoldDate = formatHoldDate(*currentCase.AutoclosureStateTime)
 			}
 		}
@@ -1138,12 +1147,16 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	// note). Record one here so CS engineers can see when a hold was set/extended and
 	// until when. Best-effort and fire-and-forget: the hold PATCH above already
 	// succeeded, so this secondary write must not delay the response or fail/roll back
-	// the request if it errors. Detached from the request context (which is canceled
-	// once the handler returns) and bounded by its own timeout instead.
+	// the request if it errors. context.WithoutCancel keeps the request-scoped values
+	// the entity client needs (x-user-id-token, correlation id) while detaching from
+	// the request's own cancellation, which fires as soon as the handler returns —
+	// a bare context.Background() would drop those values and the note would reach
+	// the entity service unattributed.
 	if patchErr == nil && patch.AutocloseHoldUntil != nil && formatHoldDate(*patch.AutocloseHoldUntil) != priorHoldDate {
 		holdUntil := *patch.AutocloseHoldUntil
+		detached := context.WithoutCancel(r.Context())
 		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			ctx, cancel := context.WithTimeout(detached, 15*time.Second)
 			defer cancel()
 			h.recordAutocloseHoldWorkNote(ctx, user, caseID, holdUntil)
 		}()

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1418,17 +1419,62 @@ func TestPatchCase(t *testing.T) {
 		}
 	})
 
+	t.Run("autocloseHoldUntil PATCH work note survives the request context being canceled after the handler returns", func(t *testing.T) {
+		// The work note is recorded from a goroutine detached (via
+		// context.WithoutCancel) from the request context, which is canceled as soon
+		// as the handler returns. A regression back to a plain child context (or to
+		// context.Background(), which would silently drop the caller's identity
+		// instead) should be caught here: this asserts the context the async call
+		// actually receives is not Done at the moment it's used, even after the
+		// request's own context has since been canceled. The error is captured
+		// synchronously inside the mock, not read back afterwards from the test
+		// goroutine — reading it later would race against the WithTimeout context's
+		// own deferred cleanup cancel(), which is unrelated to request detachment.
+		ctxDone := make(chan struct{})
+		var gotErr error
+		client := &mockEntityCaseClient{
+			patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+				return []byte(`{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","autoclosureStep":"ON_HOLD","autoclosureStateTime":"2026-08-01T00:00:00Z"}}`), nil
+			},
+			createCaseCommentFn: func(ctx context.Context, _ string, _ []byte) ([]byte, error) {
+				gotErr = ctx.Err()
+				close(ctxDone)
+				return []byte(`{"id":"wn-1"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		reqCtx, cancel := context.WithCancel(context.Background())
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"autocloseHoldUntil":"2026-08-01T00:00:00Z"}`)).WithContext(reqCtx))
+		r.SetPathValue("id", testCaseID)
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+		assertStatus(t, w, http.StatusOK)
+
+		// Simulate the request finishing (connection torn down) right after the
+		// handler returns, before the async work note has necessarily run.
+		cancel()
+
+		select {
+		case <-ctxDone:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected CreateCaseComment to be called")
+		}
+		if gotErr != nil {
+			t.Errorf("work-note context was already canceled (%v) once the request context was — it must be detached", gotErr)
+		}
+	})
+
 	t.Run("autocloseHoldUntil PATCH does not record a duplicate work note when the hold date is unchanged", func(t *testing.T) {
-		commentCalled := false
+		var commentCalled atomic.Bool
 		client := &mockEntityCaseClient{
 			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
-				return []byte(`{"id":"` + testCaseID + `","autoclosureStateTime":"2026-08-01T00:00:00Z"}`), nil
+				return []byte(`{"id":"` + testCaseID + `","autoclosureStep":"ON_HOLD","autoclosureStateTime":"2026-08-01T00:00:00Z"}`), nil
 			},
 			patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
 				return []byte(`{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","autoclosureStep":"ON_HOLD","autoclosureStateTime":"2026-08-01T00:00:00Z"}}`), nil
 			},
 			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
-				commentCalled = true
+				commentCalled.Store(true)
 				return []byte(`{"id":"wn-1"}`), nil
 			},
 		}
@@ -1441,8 +1487,42 @@ func TestPatchCase(t *testing.T) {
 		assertStatus(t, w, http.StatusOK)
 		// Give a would-be goroutine a moment to run; there should be none to wait for.
 		time.Sleep(100 * time.Millisecond)
-		if commentCalled {
+		if commentCalled.Load() {
 			t.Error("expected no work note for a PATCH that resends the existing hold date")
+		}
+	})
+
+	t.Run("autocloseHoldUntil PATCH records a work note on the first hold, even if autoclosureStateTime already held an unrelated staged-advance date", func(t *testing.T) {
+		// A case not currently on hold can still carry a non-nil autoclosureStateTime
+		// (e.g. when its autoclosureStep is FIRST_COMMENT) that happens to match the
+		// FE's pre-filled hold-date picker default. The dedup check must gate on
+		// autoclosureStep == ON_HOLD, not merely on the date matching, or this — the
+		// default "open dialog, accept the pre-filled date, click Hold" path — would
+		// wrongly be treated as a no-op and its note dropped.
+		commentCalled := make(chan struct{})
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"id":"` + testCaseID + `","autoclosureStep":"FIRST_COMMENT","autoclosureStateTime":"2026-08-01T00:00:00Z"}`), nil
+			},
+			patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+				return []byte(`{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","autoclosureStep":"ON_HOLD","autoclosureStateTime":"2026-08-01T00:00:00Z"}}`), nil
+			},
+			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				close(commentCalled)
+				return []byte(`{"id":"wn-1"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"autocloseHoldUntil":"2026-08-01T00:00:00Z"}`)))
+		r.SetPathValue("id", testCaseID)
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		select {
+		case <-commentCalled:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected CreateCaseComment to be called for the first hold, despite a matching prior autoclosureStateTime")
 		}
 	})
 
@@ -1466,13 +1546,13 @@ func TestPatchCase(t *testing.T) {
 	})
 
 	t.Run("PATCH without autocloseHoldUntil does not record a work note", func(t *testing.T) {
-		commentCalled := false
+		var commentCalled atomic.Bool
 		client := &mockEntityCaseClient{
 			patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
 				return []byte(`{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","subject":"New subject text"}}`), nil
 			},
 			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
-				commentCalled = true
+				commentCalled.Store(true)
 				return []byte(`{"id":"wn-1"}`), nil
 			},
 		}
@@ -1483,7 +1563,7 @@ func TestPatchCase(t *testing.T) {
 		h.PatchCase(w, r)
 
 		assertStatus(t, w, http.StatusOK)
-		if commentCalled {
+		if commentCalled.Load() {
 			t.Error("expected CreateCaseComment not to be called when autocloseHoldUntil is absent from the PATCH")
 		}
 	})

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1364,6 +1364,96 @@ func TestPatchCase(t *testing.T) {
 		}
 	})
 
+	t.Run("autocloseHoldUntil PATCH also records a work note documenting the hold", func(t *testing.T) {
+		var (
+			commentCaseID string
+			commentBody   []byte
+			commentCalled bool
+		)
+		client := &mockEntityCaseClient{
+			patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+				return []byte(`{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","autoclosureStep":"ON_HOLD","autoclosureStateTime":"2026-08-01T00:00:00Z"}}`), nil
+			},
+			createCaseCommentFn: func(_ context.Context, caseID string, body []byte) ([]byte, error) {
+				commentCalled = true
+				commentCaseID = caseID
+				commentBody = body
+				return []byte(`{"id":"wn-1"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"autocloseHoldUntil":"2026-08-01T00:00:00Z"}`)))
+		r.SetPathValue("id", testCaseID)
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+
+		if !commentCalled {
+			t.Fatal("expected CreateCaseComment to be called after a successful autocloseHoldUntil PATCH")
+		}
+		if commentCaseID != testCaseID {
+			t.Errorf("comment posted against caseID %q, want %q", commentCaseID, testCaseID)
+		}
+
+		var note struct {
+			Type    string `json:"type"`
+			Content string `json:"content"`
+		}
+		if err := json.Unmarshal(commentBody, &note); err != nil {
+			t.Fatalf("decode comment body: %v; raw: %s", err, commentBody)
+		}
+		if note.Type != "work_note" {
+			t.Errorf("comment type = %q, want %q", note.Type, "work_note")
+		}
+		wantContent := "Please note that this case is on-hold until 2026-08-01, hence it will not go through the auto closure process. It will be eligible for auto-closure again after this date passes, or if the case state is changed to 'Waiting on WSO2'."
+		if note.Content != wantContent {
+			t.Errorf("comment content = %q, want %q", note.Content, wantContent)
+		}
+	})
+
+	t.Run("autocloseHoldUntil PATCH still succeeds when the work-note comment call fails", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+				return []byte(`{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","autoclosureStep":"ON_HOLD","autoclosureStateTime":"2026-08-01T00:00:00Z"}}`), nil
+			},
+			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				return nil, errors.New("entity service unavailable")
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"autocloseHoldUntil":"2026-08-01T00:00:00Z"}`)))
+		r.SetPathValue("id", testCaseID)
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("PATCH without autocloseHoldUntil does not record a work note", func(t *testing.T) {
+		commentCalled := false
+		client := &mockEntityCaseClient{
+			patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+				return []byte(`{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","subject":"New subject text"}}`), nil
+			},
+			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				commentCalled = true
+				return []byte(`{"id":"wn-1"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"subject":"New subject text"}`)))
+		r.SetPathValue("id", testCaseID)
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		if commentCalled {
+			t.Error("expected CreateCaseComment not to be called when autocloseHoldUntil is absent from the PATCH")
+		}
+	})
+
 	t.Run("GetCase failure during state validation is mapped correctly", func(t *testing.T) {
 		for _, tc := range upstreamErrorsGeneric("Failed to retrieve current case state.") {
 			t.Run(tc.name, func(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1368,16 +1368,18 @@ func TestPatchCase(t *testing.T) {
 		var (
 			commentCaseID string
 			commentBody   []byte
-			commentCalled bool
 		)
+		commentCalled := make(chan struct{})
 		client := &mockEntityCaseClient{
+			// No prior autoclosureStateTime (getCaseFn unset -> default "{}"), so the
+			// new hold date always counts as a change here.
 			patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
 				return []byte(`{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","autoclosureStep":"ON_HOLD","autoclosureStateTime":"2026-08-01T00:00:00Z"}}`), nil
 			},
 			createCaseCommentFn: func(_ context.Context, caseID string, body []byte) ([]byte, error) {
-				commentCalled = true
 				commentCaseID = caseID
 				commentBody = body
+				close(commentCalled)
 				return []byte(`{"id":"wn-1"}`), nil
 			},
 		}
@@ -1389,7 +1391,11 @@ func TestPatchCase(t *testing.T) {
 
 		assertStatus(t, w, http.StatusOK)
 
-		if !commentCalled {
+		// The work note is recorded fire-and-forget in a goroutine so it never delays
+		// the PATCH response; wait for it (bounded) rather than asserting immediately.
+		select {
+		case <-commentCalled:
+		case <-time.After(2 * time.Second):
 			t.Fatal("expected CreateCaseComment to be called after a successful autocloseHoldUntil PATCH")
 		}
 		if commentCaseID != testCaseID {
@@ -1409,6 +1415,34 @@ func TestPatchCase(t *testing.T) {
 		wantContent := "Please note that this case is on-hold until 2026-08-01, hence it will not go through the auto closure process. It will be eligible for auto-closure again after this date passes, or if the case state is changed to 'Waiting on WSO2'."
 		if note.Content != wantContent {
 			t.Errorf("comment content = %q, want %q", note.Content, wantContent)
+		}
+	})
+
+	t.Run("autocloseHoldUntil PATCH does not record a duplicate work note when the hold date is unchanged", func(t *testing.T) {
+		commentCalled := false
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"id":"` + testCaseID + `","autoclosureStateTime":"2026-08-01T00:00:00Z"}`), nil
+			},
+			patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+				return []byte(`{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","autoclosureStep":"ON_HOLD","autoclosureStateTime":"2026-08-01T00:00:00Z"}}`), nil
+			},
+			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				commentCalled = true
+				return []byte(`{"id":"wn-1"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"autocloseHoldUntil":"2026-08-01T00:00:00Z"}`)))
+		r.SetPathValue("id", testCaseID)
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		// Give a would-be goroutine a moment to run; there should be none to wait for.
+		time.Sleep(100 * time.Millisecond)
+		if commentCalled {
+			t.Error("expected no work note for a PATCH that resends the existing hold date")
 		}
 	})
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

A CS engineer reported that setting/extending an auto-closure hold on a case has no visible trail in the CSM portal — the legacy ticketing UI's equivalent action used to add a work note with the hold date, but the CSM portal's "Hold auto-closure…" flow only updates the underlying fields silently.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

When a case's `autocloseHoldUntil` field is set/extended via `PATCH /cases/{id}`, the backend now also records an internal work note documenting the hold and its date, matching the wording the legacy ticketing UI already produces for the same action — so CS engineers get parity, not a new UX pattern.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Backend-only (BFF) change, no API contract or entity-service changes:
- `internal/handler/cases.go`: `PatchCase` now checks for `autocloseHoldUntil` in the request body, and on a successful PATCH calls a new helper, `recordAutocloseHoldWorkNote`, which reuses the existing `CreateCaseComment` entity-service call (already used for case commenting) with `{"type":"work_note", "content": "..."}`.
- The comment write is best-effort: if it fails, it's logged (`slog.WarnContext`) and swallowed — the primary hold PATCH, which already succeeded, is never rolled back or failed because of a secondary write.
- No UI changes; the note surfaces through the existing case Activities/comments feed.

Deliberately implemented at the BFF layer rather than in the Go entity-service/ServiceNow adapter, since entity-service's SN-specific case logic won't carry forward to the Postgres-native rewrite — this keeps the fix portable.

## User stories
> Summary of user stories addressed by this change>

As a CS engineer, when I put a case on hold from auto-closure, I want a record of that action (and the date) in the case's activity so I and others can tell whether/when a hold was extended, without having to check the raw field value.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Setting or extending a case's auto-closure hold now records an internal note documenting the hold and its date.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — no dedicated help-doc topic exists for the "Hold auto-closure" action today; the change is additive behavior on an already-undocumented flow.

## Training
N/A — no training content references this internal ticketing action.

## Certification
N/A — no certification exam content covers this internal case-management action.

## Marketing
N/A — internal case-management behavior, not customer-facing.

## Automation tests
 - Unit tests
   > Added 3 subtests to `TestPatchCase` in `internal/handler/cases_test.go`: (1) a work note is recorded with the expected content when `autocloseHoldUntil` is set, (2) the hold PATCH still succeeds if the work-note comment call fails, (3) no note is recorded for PATCH requests that don't touch `autocloseHoldUntil`.
 - Integration tests
   > None added — no local stack / entity-service integration test harness exercised for this change; covered at the unit level via a mocked entity client.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go codebase, not a JVM target FindSecurityBugs applies to
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Verified with `go build ./...` and `go test ./...` in `apps/csm-portal/backend` (Go, macOS/Darwin dev environment). No browser/DB-specific testing needed — backend-only change with mocked entity client in tests.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case auto-closure holds now automatically generate an internal work note showing the hold date.
  * Updating a hold remains successful even if recording the work note fails.
* **Bug Fixes**
  * Work notes are no longer created when a case update does not include an auto-closure hold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->