### PR TITLE
[CSM Portal] Fix unresponsive Back button in Case view

### DIFF
--- a/apps/csm-portal/webapp/src/features/case-tabs/CaseTabsIntegration.test.tsx
+++ b/apps/csm-portal/webapp/src/features/case-tabs/CaseTabsIntegration.test.tsx
@@ -53,8 +53,10 @@ type StubSection = (typeof STUB_SECTIONS)[number];
 
 function StubCaseDetailPage() {
   const override = useCaseRouteOverride();
+  const routedNavigate = useNavigate();
   const { caseId: routedCaseId } = useParams();
   const caseId = override?.caseId ?? routedCaseId;
+  const navigate = override?.navigate ?? routedNavigate;
   // A fake "still loading" -> "loaded" transition, matching a real
   // `useGetCsmCaseDetail` query — the label should appear once this
   // resolves, without needing the user to switch tabs away and back.
@@ -74,6 +76,10 @@ function StubCaseDetailPage() {
       <div data-testid="stub-page-section">{section}</div>
       <button onClick={() => setLabel(`Label for ${caseId}`)}>resolve-label</button>
       <button onClick={() => setSection("activities")}>go-to-activities-{caseId}</button>
+      {/* Same shape as `CsmCaseDetailPage`'s own Back button: navigates via
+          whichever `navigate` is in scope (the tab override's, when this
+          instance is an open tab) to a bare non-case route. */}
+      <button onClick={() => navigate("/cases")}>stub-back-button</button>
     </div>
   );
 }
@@ -332,6 +338,66 @@ describe("case tabs — real BrowserRouter integration", () => {
       openCaseIds.includes(id),
     ).length;
     expect(survivingOriginalCount).toBe(MAX_OPEN_CASE_TABS - 1);
+  });
+
+  // Regression test for a reported "Back button in Case view is
+  // unresponsive" bug: clicking Back from an open case TAB used to do
+  // nothing at all, because `CaseTabIsolatedRouter`'s `navigate` only
+  // handled staying on the same case (in-place update) or switching to a
+  // DIFFERENT case (open/activate a tab) — a target that isn't a case route
+  // at all (the case list, the dashboard, ...) fell into the "same case"
+  // branch by default and only updated this tab's own LOCAL override state,
+  // never the real router. `CaseTabsContentHost` decides whether to show
+  // this tab's content at all by comparing the REAL `location.pathname`
+  // against a case-route match, so the real URL — and the visible content —
+  // never changed: from the user's point of view, the click did nothing.
+  it("bug 3 — the Back button from an open case tab actually leaves the case, reaching the real router", async () => {
+    // Isolation from the tests above, which also open real tabs
+    // (`CaseTabsProvider` persists open tabs to sessionStorage — see its own
+    // doc comment) — without this, a leftover tab set (e.g. the cap-eviction
+    // test's own MAX_OPEN_CASE_TABS tabs) could evict CS0001 before this
+    // test ever gets to click its Back button.
+    sessionStorage.clear();
+    function AppWithCaseList() {
+      window.history.pushState({}, "", "/cases/CS0001");
+      return (
+        <BrowserRouter>
+          <ErrorBannerProvider>
+            <CaseTabsBehaviorProvider>
+              <CaseTabsProvider>
+                <CaseTabStripBar />
+                <CaseTabsContentHost />
+                <Routes>
+                  <Route path="/cases" element={<div>stub-case-list</div>} />
+                  <Route path="/cases/:caseId" element={<CaseDetailRouteSync kind="case" />} />
+                </Routes>
+              </CaseTabsProvider>
+            </CaseTabsBehaviorProvider>
+          </ErrorBannerProvider>
+        </BrowserRouter>
+      );
+    }
+    render(<AppWithCaseList />);
+    await waitFor(() =>
+      expect(screen.getByTestId("stub-page-case-id")).toHaveTextContent("CS0001"),
+    );
+
+    fireEvent.click(screen.getByText("stub-back-button"));
+
+    // The real URL actually moved...
+    await waitFor(() => expect(window.location.pathname).toBe("/cases"));
+    // ...the list view is what's now showing...
+    await waitFor(() => expect(screen.getByText("stub-case-list")).toBeInTheDocument());
+    // ...the case tab's own content is hidden (kept mounted in the
+    // background per `CaseTabIsolatedRouter`'s keep-alive design, not
+    // unmounted or showing on top of the list)...
+    const tabPanel = screen.getByTestId("stub-page-case-id").closest(
+      '[data-testid^="case-tab-panel-"]',
+    );
+    expect(tabPanel).toHaveAttribute("hidden");
+    // ...but the tab itself is still open, ready to be reactivated — Back
+    // doesn't close it.
+    expect(screen.getByText("CS0001")).toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/case-tabs/components/CaseTabIsolatedRouter.tsx
+++ b/apps/csm-portal/webapp/src/features/case-tabs/components/CaseTabIsolatedRouter.tsx
@@ -28,6 +28,7 @@ import { useCaseTabsControllerRef } from "@context/case-tabs/CaseTabsContext";
 import { CaseRouteOverrideProvider } from "@context/case-tabs/CaseRouteOverrideContext";
 import type { CaseRouteKind, CaseTabState } from "@context/case-tabs/caseTabsTypes";
 import { tabElementId, tabPanelElementId } from "@features/case-tabs/utils/tabElementIds";
+import { useNavTransition } from "@hooks/useNavTransition";
 
 function toHref(to: To): string {
   if (typeof to === "string") return to;
@@ -72,8 +73,9 @@ export interface CaseTabIsolatedRouterProps {
  * present in context.
  *
  * In-page navigation (the misrouted-case redirect, the dashless-id repair in
- * `useNormalizedIdParam`, ...) is intercepted by the `navigate` function
- * passed through the override rather than reaching the real browser history:
+ * `useNormalizedIdParam`, the header's own Back button, ...) is intercepted
+ * by the `navigate` function passed through the override rather than
+ * reaching the real browser history:
  *   - if it resolves to the SAME caseId this tab represents, the tab's own
  *     `path`/`kind` are updated in place (`updateTabPath`) — covers the
  *     redirect/repair cases, and keeps this tab's identity stable.
@@ -86,6 +88,18 @@ export interface CaseTabIsolatedRouterProps {
  *     one — avoiding the need to ever change a tab's React key mid-life
  *     (which would force a real remount and defeat the point of this
  *     component).
+ *   - if it doesn't resolve to a case route AT ALL — leaving the case
+ *     entirely, e.g. the page's own Back button returning to the case list/
+ *     dashboard, or a "create new" shortcut — it must reach the REAL router,
+ *     not just this tab's local override state: `CaseTabsContentHost` decides
+ *     whether to show this tab's content at all by comparing the REAL
+ *     `location.pathname` against a case-route match, so updating only the
+ *     override's internal `pathname` here left the real URL (and so that
+ *     visibility check) completely unchanged — Back looked unresponsive
+ *     because, from the real router's point of view, nothing had moved. The
+ *     tab itself is left open (not closed) so it's still available to
+ *     reactivate from the tab strip, matching how leaving a case via the
+ *     pinned "current location" tab or the app nav already behaves.
  *
  * The active tab's real-URL sync (so a reload/bookmark on `/cases/:id`
  * still works — see this feature's design notes) is owned by the caller
@@ -151,6 +165,8 @@ export default function CaseTabIsolatedRouter({
   // ever retargeting this one — so `tab.caseId` never changes here either.
   // Safe to close over both directly in the memo below (with the lint
   // suppression that implies) instead of keeping them in refs.
+  const realNavigate = useNavTransition();
+
   const navigate = useMemo(() => {
     return (to: To | number, options?: NavigateOptions): void => {
       if (typeof to === "number") {
@@ -163,17 +179,26 @@ export default function CaseTabIsolatedRouter({
       const search = href.includes("?") ? `?${href.split("?")[1]?.split("#")[0]}` : "";
       const hash = href.includes("#") ? `#${href.split("#")[1]}` : "";
       const match = matchCaseLocation(pathname);
-      if (!match || match.caseId === tab.caseId) {
-        setRouteState((prev) => ({
+      if (!match) {
+        // Leaving this case entirely (e.g. the page's own Back button, or a
+        // "create new" shortcut) — this MUST reach the real router. See this
+        // component's own doc comment above for why updating only the local
+        // override state here left Back looking completely unresponsive:
+        // `CaseTabsContentHost` gates this tab's visibility on the REAL
+        // `location.pathname`, which never moved otherwise. The tab stays
+        // open in the background (not closed) for the strip to reactivate.
+        realNavigate(to, options);
+        return;
+      }
+      if (match.caseId === tab.caseId) {
+        setRouteState(() => ({
           pathname,
           search,
           hash,
-          kind: match?.kind ?? prev.kind,
+          kind: match.kind,
           state: options?.state,
         }));
-        if (match) {
-          controllerRef.current.updateTabPath(tab.id, match.kind, href);
-        }
+        controllerRef.current.updateTabPath(tab.id, match.kind, href);
         return;
       }
       // Different case referenced from inside this tab: open/activate it as
@@ -182,8 +207,10 @@ export default function CaseTabIsolatedRouter({
     };
     // Stable for the lifetime of this tab instance — reads the latest
     // controller via `controllerRef` rather than depending on it directly.
+    // `realNavigate` (from `useNavTransition`) is itself stable for the
+    // lifetime of the app, so including it doesn't defeat that.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [realNavigate]);
 
   const overrideValue = useMemo(
     () => ({


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Resolves a corresponding CSM Portal tracking issue for: the Back button in the Case detail view was unresponsive — clicking it did nothing.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Make the Back button (and any other navigation leaving the current case, e.g. a "create new" shortcut) actually navigate away from the case, back to the dashboard or the filtered list the user came from.

## Approach
> Describe how you are implementing the solutions.

Each open case tab renders behind an isolated `navigate()` override (`CaseTabIsolatedRouter`) so in-tab redirects/repairs don't leak into real browser history. That override only handled two cases: staying on the same case, or switching to a different case tab. A navigation target that isn't a case route at all (Back to dashboard/list) fell into the "same case" branch by default and only updated the tab's own local state — the real router's `location.pathname` never moved, so `CaseTabsContentHost` kept showing the case tab's content. From the user's perspective, Back did nothing.

Fix: `navigate()` now checks whether the target resolves to a case route first; if not, it forwards to the real router (`useNavTransition`) instead of touching only local override state. The tab itself stays open in the tab strip (not closed), consistent with how leaving a case via other paths already behaves.

## User stories
> Summary of user stories addressed by this change

As a CS engineer viewing a case, clicking Back returns me to the dashboard or the filtered case list I came from.

## Release note
Fix: the Back button in the Case detail view is now responsive and correctly returns to the previous view.

## Documentation
N/A — internal navigation bug fix, no user-facing behavior change beyond restoring intended behavior.

## Training
N/A

## Certification
N/A — no exam-relevant behavior change.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Added a regression test (`CaseTabsIntegration.test.tsx`) that renders the real `CaseTabsProvider`/`CaseTabIsolatedRouter`/`CaseTabsContentHost` wiring and asserts clicking Back actually changes `window.location.pathname` and renders the list route. Verified the test fails without the fix and passes with it.
 - Integration tests
   > Full existing suite re-run: 251 test files / 2587 tests, all passing.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, not a JVM component
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Verified via `tsc -b`, `eslint`, and `vitest run` in `apps/csm-portal/webapp`. Live browser click-through against a running local stack was not performed (no local topology stood up for this fix); the added integration test exercises the production component wiring as a proxy.

## Learning
Traced the bug by following the Back button's `onClick` down through `CsmCaseDetailPage` into the tab-scoped `navigate` override in `CaseTabIsolatedRouter`, and found the visibility gate in `CaseTabsContentHost` compares against the real router location, not the tab's local override state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation from case tabs so Back buttons and “create new” actions update the actual application route.
  * Ensured returning to the case list hides retained case-tab content while keeping the case tab available for later access.
  * Preserved tab-specific navigation when moving between pages within the same case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->