### PR TITLE
[CSM Portal] Add self-subscribe Follow/Unfollow to the Watchers tab

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
@@ -344,6 +344,82 @@ describe("WatchersWidget", () => {
       screen.getByRole("combobox", { name: /add a watcher/i }),
     ).toBeDisabled();
   });
+
+  describe("self-subscribe", () => {
+    it("omits the Follow/Unfollow control when no currentUserId is supplied", () => {
+      renderWithRouter(
+        <WatchersWidget entityKind="case" watchers={WATCHERS} onReplace={vi.fn()} />,
+      );
+      expect(
+        screen.queryByRole("button", { name: /^follow case updates$/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /^unfollow case updates$/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows Follow when the signed-in engineer isn't a watcher, and adds them on click", () => {
+      const onReplace = vi.fn();
+      // Neither fixture watcher is flagged `isMe` here — CANDIDATE_ID (the
+      // signed-in engineer in this test) isn't on the list at all, matching
+      // how the caller would populate `isMe` for a real not-yet-following user.
+      renderWithRouter(
+        <WatchersWidget
+          entityKind="case"
+          watchers={ONE_WATCHER}
+          onReplace={onReplace}
+          currentUserId={CANDIDATE_ID}
+        />,
+      );
+      expect(
+        screen.queryByRole("button", { name: /^unfollow case updates$/i }),
+      ).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /^follow case updates$/i }));
+      expect(onReplace).toHaveBeenCalledWith([WATCHER_ONE_ID, CANDIDATE_ID], "add");
+    });
+
+    it("shows Unfollow when the signed-in engineer is already a watcher and not auto-added, and removes them on click", () => {
+      const onReplace = vi.fn();
+      renderWithRouter(
+        <WatchersWidget
+          entityKind="case"
+          watchers={WATCHERS}
+          onReplace={onReplace}
+          currentUserId={WATCHER_TWO_ID}
+        />,
+      );
+      expect(
+        screen.queryByRole("button", { name: /^follow case updates$/i }),
+      ).not.toBeInTheDocument();
+      const button = screen.getByRole("button", { name: /^unfollow case updates$/i });
+      expect(button).not.toHaveAttribute("aria-disabled");
+      fireEvent.click(button);
+      expect(onReplace).toHaveBeenCalledWith([WATCHER_ONE_ID], "remove");
+    });
+
+    it("blocks Unfollow, with the reason reachable by assistive tech, when the caller reports an auto-added membership (e.g. the case's assignee)", () => {
+      const onReplace = vi.fn();
+      renderWithRouter(
+        <WatchersWidget
+          entityKind="case"
+          watchers={WATCHERS}
+          onReplace={onReplace}
+          currentUserId={WATCHER_TWO_ID}
+          autoWatchingReason="You're on this case's watch list as its assigned engineer."
+        />,
+      );
+      const button = screen.getByRole("button", { name: /^unfollow case updates$/i });
+      expect(button).toHaveAttribute("aria-disabled", "true");
+      const reason = document.getElementById(
+        button.getAttribute("aria-describedby") ?? "",
+      );
+      expect(reason).toHaveTextContent(
+        "You're on this case's watch list as its assigned engineer.",
+      );
+      fireEvent.click(button);
+      expect(onReplace).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe("AttachmentsWidget — preview affordance", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -533,7 +533,10 @@ export function WatchersWidget({
   const reasonId = useId();
   const followReasonId = useId();
   const watcherIds = useMemo(() => watchers.map((w) => w.id), [watchers]);
-  const isFollowing = watchers.some((w) => w.isMe);
+  // Keyed on the UUID, not `isMe`: both page callers derive `isMe` from an
+  // email match, which is unreliable when email data is missing, whereas
+  // `currentUserId` is the same UUID the watch list itself is keyed by.
+  const isFollowing = !!currentUserId && watcherIds.includes(currentUserId);
 
   // Below the floor the record type allows, removal isn't expressible at all
   // (see WATCH_LIST_RULES), so the control is blocked with the reason rather

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -28,6 +28,8 @@ import {
 import {
   Activity,
   ArrowUpRight,
+  Bell,
+  BellOff,
   Building,
   CheckCircle,
   ClipboardList,
@@ -492,6 +494,8 @@ export function WatchersWidget({
   onRefresh,
   isRefreshing,
   refreshedAt,
+  currentUserId,
+  autoWatchingReason,
 }: {
   /** Which record's watch list this is. Drives the copy and the rules. */
   entityKind: WatchedEntityKind;
@@ -509,16 +513,34 @@ export function WatchersWidget({
   onRefresh?: () => void;
   isRefreshing?: boolean;
   refreshedAt?: number;
+  /**
+   * Platform UUID of the signed-in engineer. Drives the self-subscribe
+   * Follow/Unfollow control: without it there is no id to add on Follow, so
+   * the button is omitted entirely rather than rendered disabled.
+   */
+  currentUserId?: string;
+  /**
+   * Non-empty when the signed-in engineer is on this watch list only because
+   * of an automatic, role-based add (e.g. they're the record's assigned
+   * engineer) rather than having chosen to self-subscribe. The widget has no
+   * visibility into role assignment, so the caller supplies this; when set,
+   * Unfollow is blocked with this as the reason, same treatment as
+   * {@link removalBlockedReason} above.
+   */
+  autoWatchingReason?: string;
 }): JSX.Element {
   const rules = WATCH_LIST_RULES[entityKind];
   const reasonId = useId();
+  const followReasonId = useId();
   const watcherIds = useMemo(() => watchers.map((w) => w.id), [watchers]);
+  const isFollowing = watchers.some((w) => w.isMe);
 
   // Below the floor the record type allows, removal isn't expressible at all
   // (see WATCH_LIST_RULES), so the control is blocked with the reason rather
   // than firing a request that is known to be rejected.
   const belowFloorAfterRemoval = watchers.length <= rules.minWatchers;
   const removalBlockedReason = belowFloorAfterRemoval ? rules.minWatchersReason : "";
+  const unfollowBlockedReason = autoWatchingReason || removalBlockedReason;
 
   const addWatcher = useCallback(
     (userId: string) => {
@@ -542,6 +564,21 @@ export function WatchersWidget({
     [onReplace, isSaving, belowFloorAfterRemoval, watcherIds],
   );
 
+  // Self-subscribe: the same add/remove path as the per-watcher controls
+  // below, just always targeting the signed-in engineer's own id rather than
+  // a picked-from-search or a listed watcher.
+  const onFollowClick = useCallback(() => {
+    if (currentUserId) addWatcher(currentUserId);
+  }, [addWatcher, currentUserId]);
+  const onUnfollowClick = useCallback(() => {
+    if (!currentUserId || unfollowBlockedReason) return;
+    if (!onReplace || isSaving) return;
+    onReplace(
+      watcherIds.filter((id) => id !== currentUserId),
+      "remove",
+    );
+  }, [currentUserId, unfollowBlockedReason, onReplace, isSaving, watcherIds]);
+
   return (
     <WidgetCard
       title="Watchers"
@@ -557,6 +594,56 @@ export function WatchersWidget({
         )
       }
     >
+      {onReplace && currentUserId && (
+        <Box sx={{ mb: 1.5 }}>
+          {isFollowing ? (
+            <Tooltip title={unfollowBlockedReason}>
+              {/* aria-disabled, not disabled, so the reason stays reachable
+                  via aria-describedby — same reasoning as the per-watcher
+                  remove control below. */}
+              <span>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<BellOff size={14} />}
+                  aria-disabled={!!unfollowBlockedReason || isSaving || undefined}
+                  aria-describedby={unfollowBlockedReason ? followReasonId : undefined}
+                  onClick={onUnfollowClick}
+                  sx={{ opacity: unfollowBlockedReason ? 0.6 : 1 }}
+                >
+                  {`Unfollow ${rules.noun} updates`}
+                </Button>
+              </span>
+            </Tooltip>
+          ) : (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<Bell size={14} />}
+              disabled={isSaving}
+              onClick={onFollowClick}
+            >
+              {`Follow ${rules.noun} updates`}
+            </Button>
+          )}
+          {unfollowBlockedReason && (
+            <Box
+              component="span"
+              id={followReasonId}
+              sx={{
+                position: "absolute",
+                width: 1,
+                height: 1,
+                overflow: "hidden",
+                clip: "rect(0 0 0 0)",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {unfollowBlockedReason}
+            </Box>
+          )}
+        </Box>
+      )}
       {watchers.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           {`No one is watching this ${rules.noun}.`}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -70,6 +70,15 @@ const showErrorMock = vi.fn();
 vi.mock("@context/error-banner/ErrorBannerContext", () => ({
   useErrorBanner: () => ({ showError: showErrorMock }),
 }));
+const CURRENT_USER_ID = "00000000-0000-0000-0000-00000000000c";
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({
+    user: { id: CURRENT_USER_ID, email: "jane.doe@example.com" },
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
 vi.mock("@context/success-banner/SuccessBannerContext", () => ({
   useSuccessBanner: () => ({ showSuccess: vi.fn() }),
 }));

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -49,6 +49,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
 import { useLocation } from "react-router";
 import { useGetCsmCaseDetail } from "@features/csm-cases/api/useGetCsmCaseDetail";
+import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import {
   usePatchCsmCase,
   usePatchCsmCaseById,
@@ -343,6 +344,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // route/location for the app as a whole. Without it, every background
   // tab's `useParams`/`useLocation` would resolve to whatever route is
   // CURRENTLY on-screen, not the case this particular instance represents.
+  // The signed-in engineer's platform UUID — the id the watch list's write
+  // side is keyed by — so the Watchers tab can self-subscribe/unsubscribe.
+  const { user: currentUser } = useCurrentUser();
   const routedCaseId = useNormalizedIdParam("caseId");
   const routedNavigate = useNavTransition();
   const routedLocation = useLocation();
@@ -2543,6 +2547,17 @@ export default function CsmCaseDetailPage(): JSX.Element {
             onRefresh={() => void refetchCaseDetail()}
             isRefreshing={isFetchingCaseDetail}
             refreshedAt={caseDetailUpdatedAt}
+            currentUserId={currentUser?.id}
+            // The account manager / technical owner are also auto-added to a
+            // case's watch list, but that data isn't on this response (see
+            // detailFromBeCase's account-ref comment) — only the assignee
+            // check is expressible without a new fetch, so Unfollow stays
+            // available to an AM/TO watcher until that's plumbed through.
+            autoWatchingReason={
+              c.assigneeIsMe
+                ? "You're on this case's watch list as its assigned engineer."
+                : undefined
+            }
           />
         </Box>
       )}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
@@ -60,6 +60,17 @@ vi.mock("@features/csm-operations/api/usePatchIncident", () => ({
 vi.mock("@context/error-banner/ErrorBannerContext", () => ({
   useErrorBanner: () => ({ showError: showErrorMock }),
 }));
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({
+    user: { id: "00000000-0000-0000-0000-00000000000c", email: "jane.doe@example.com" },
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({
+  useIdTokenClaims: () => ({ email: "jane.doe@example.com", name: "Jane Doe" }),
+}));
 vi.mock("@features/csm-operations/api/useCsmIncidentComments", () => ({
   useGetCsmIncidentComments: () => ({ data: [] }),
   usePostCsmIncidentComment: () => ({ isPending: false, mutate: vi.fn() }),

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -37,7 +37,9 @@ import { useLocation } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 import { useGetIncident } from "@features/csm-operations/api/useGetIncident";
 import { usePatchIncident } from "@features/csm-operations/api/usePatchIncident";
@@ -209,6 +211,11 @@ export default function CsmIncidentDetailPage(): JSX.Element {
     Extract<BeIncidentState, "RESOLVED" | "CLOSED"> | null
   >(null);
   const engineerName = useEngineerDisplayName();
+  // Signed-in engineer's platform UUID (self-subscribe writes) and email
+  // (matching a watch-list entry to "me"), same pair the case detail page
+  // uses for its own watch list.
+  const { user: currentUser } = useCurrentUser();
+  const currentUserEmail = useIdTokenClaims()?.email;
 
   const { data: comments } = useGetCsmIncidentComments(id);
   const { data: activityAudit } = useGetCsmIncidentActivities(id);
@@ -234,15 +241,18 @@ export default function CsmIncidentDetailPage(): JSX.Element {
   // The read model's entries already carry the platform user UUID the write
   // side is keyed by, so the widget can compute a replacement list straight
   // from what is on screen.
-  const watchList = useMemo(
-    () =>
-      (data?.watchList ?? []).map((w) => ({
+  const watchList = useMemo(() => {
+    const myEmail = currentUserEmail?.toLowerCase();
+    return (data?.watchList ?? []).map((w) => {
+      const email = w.email || undefined;
+      return {
         id: w.id,
         name: w.name || w.email,
-        email: w.email || undefined,
-      })),
-    [data?.watchList],
-  );
+        email,
+        isMe: !!email && !!myEmail && email.toLowerCase() === myEmail,
+      };
+    });
+  }, [data?.watchList, currentUserEmail]);
 
   const recordView = useRecordRecentView();
   useEffect(() => {
@@ -728,6 +738,11 @@ export default function CsmIncidentDetailPage(): JSX.Element {
           watchers={watchList}
           onReplace={onReplaceWatchers}
           isSaving={patchIncident.isPending}
+          currentUserId={currentUser?.id}
+          // No `autoWatchingReason`: the incident read model's `assignedTo`
+          // carries only id/name (no email), so — unlike the case page —
+          // there's no reliable signal here for "watching only because
+          // auto-assigned" without a new fetch. Unfollow stays available.
         />
       )}
 

--- a/apps/csm-portal/webapp/src/features/help/content/operations.md
+++ b/apps/csm-portal/webapp/src/features/help/content/operations.md
@@ -81,7 +81,9 @@ From the detail page a CS engineer can:
   and notes, since those are required by the backing system for those two
   transitions.
 - **Edit** the incident's fields.
-- Manage the **watch list** (add or remove watchers).
+- Manage the **watch list** (add or remove watchers). A **Follow incident
+  updates** / **Unfollow incident updates** button on the Watchers tab also
+  lets you add or remove yourself with one click.
 - Add comments (public or internal) and upload/download attachments, with
   inline preview for supported attachment types.
 

--- a/apps/csm-portal/webapp/src/features/help/content/support.md
+++ b/apps/csm-portal/webapp/src/features/help/content/support.md
@@ -83,6 +83,17 @@ request** action is disabled in both places: closed cases are read-only.
 Service requests aren't available on every project. If the selected project isn't eligible,
 the create form shows a warning and blocks submission.
 
+## Watchers
+
+The **Watchers** tab lists everyone notified on updates to the case, and lets you add or
+remove people (a case must always keep at least one watcher, so the last one can't be
+removed).
+
+If you're not on the list, a **Follow case updates** button adds you with one click. If
+you're already watching, it becomes **Unfollow case updates** to take yourself off the list —
+unless you were added automatically as the case's assigned engineer, in which case Unfollow is
+disabled with a tooltip explaining why.
+
 ## Comments
 
 The comment composer at the bottom of the timeline sends either a public reply visible to the


### PR DESCRIPTION
## Purpose
The Watchers tab on a case/incident only supported adding/removing watchers via a search picker or a remove control on each existing watcher's own row. A CS engineer who wants to follow a case's own updates had no quick self-subscribe/unsubscribe action.

## Goals
Let an engineer add or remove themselves from a case's or incident's watch list with a single click from the Watchers tab, without needing to search for their own name.

## Approach
Adds a "Follow case updates" / "Unfollow case updates" button (worded per entity type, e.g. "Follow incident updates" on the incident detail page) to `WatchersWidget`'s Watchers tab:
- Shown only when the caller supplies the signed-in engineer's platform id (`currentUserId`); omitted entirely otherwise, same as the widget already does for other controls that need an id it isn't given.
- "Follow" fires the existing full-list-replace add path with the current user's id.
- "Unfollow" fires the same remove path, but is blocked (aria-disabled, with a tooltip and an aria-describedby reason, exactly like the existing "can't remove a case's last watcher" control) when either:
  - removing would put the case below its minimum-watcher floor, or
  - the caller reports (via a new `autoWatchingReason` prop) that the engineer is on the list only because of an automatic, role-based add.
- On the case detail page, that auto-added check compares the signed-in user to the case's assigned engineer (a field already on the response). The account-manager / technical-owner equivalent isn't implemented: that data isn't present on the case detail response today, and adding a new fetch just for this was out of scope for this change, so an AM/TO watcher currently still sees an enabled Unfollow button. Flagging this as a known gap for a follow-up.
- On the incident detail page, the read model's assignee reference carries no email, so there's no reliable "is the signed-in engineer the assignee" signal available without a new fetch either; Unfollow is always available there for now.
- Also added an `isMe` computation to the incident watch-list mapping (it wasn't previously computed there), so "already following" detection works for incidents too, matching how the case detail page already does it.

No screenshot: this is a small pair of new buttons using the same MUI `Button`/icon style already used elsewhere on the page; happy to add one if useful for review.

## User stories
As a CS engineer, I want to follow or unfollow a case or incident's updates with one click from its Watchers tab, so I don't have to search for my own name in the watcher picker or hunt for my own row to remove myself.

## Release note
Added a one-click Follow/Unfollow control to the Watchers tab on case and incident detail pages.

## Documentation
Updated the in-app `/help` topics for Support (new "Watchers" section) and Operations (incident actions list) to describe the new button. No external product documentation exists for this surface.

## Training
N/A — no training content repository changes needed for this UI-only addition.

## Certification
N/A — no certification exam content is affected by this change.

## Marketing
N/A — internal CS-engineer tooling only, not a customer-facing or marketed feature.

## Automation tests
 - Unit tests
   > Added `describe("self-subscribe", ...)` cases under `WatchersWidget` in `CaseDetailWidgets.test.tsx`: Follow shown + adds the current user when not yet a watcher; Unfollow shown + removes the current user when already a watcher and not auto-added; Unfollow blocked (aria-disabled, reason reachable via aria-describedby) when the caller reports an auto-added membership; control omitted entirely when no `currentUserId` is supplied. Also updated the `CurrentUserContext`/`useIdTokenClaims` mocks in `CsmCaseDetailPage.test.tsx` and `CsmIncidentDetailPage.test.tsx` so those page-level suites keep passing with the new hook usage.
 - Integration tests
   > None added; no integration test suite exists for this surface today.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — this is a TypeScript/React frontend change; FindSecurityBugs is a JVM tool and doesn't apply here.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample app changes.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data model or schema change.

## Test environment
`npx tsc -b` and the full `vitest` suite (251 files / 2590 tests) run locally on macOS/Node with the versions pinned in `package.json`/`pnpm-lock.yaml`; no browser-specific testing needed for this change.

## Learning
N/A — straightforward extension of an existing widget's established add/remove pattern; no new research or libraries involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Follow/Unfollow controls to case and incident Watchers tabs.
  * Users can add or remove themselves from update notifications.
  * Unfollow may be unavailable when automatic watching or minimum-watcher rules apply, with an accessible explanation.
  * Watcher status now identifies the signed-in engineer.
* **Documentation**
  * Updated support and incident guidance with self-following and watcher-management instructions.
* **Tests**
  * Added coverage for Follow/Unfollow behavior, restrictions, and current-user scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->