### PR TITLE
feat(csm-portal): support marking/recalling a case's workaround

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -339,6 +339,13 @@ export interface BeCaseView {
    * so a materially changed case has to be acknowledged afresh.
    */
   acknowledgedBy?: BeAssignedEngineerRef | null;
+  /**
+   * When the case's workaround was marked provided, or `null` until marked (and
+   * cleared again on recall). Pauses the case's Workaround SLA clock while set.
+   */
+  workaroundProvidedOn?: string | null;
+  /** The CS engineer who marked the workaround as provided, or `null` until marked. */
+  workaroundProvidedBy?: BeAssignedEngineerRef | null;
   account?: BeCaseAccountRef;
   project?: BeEntityRef;
   /** Nullable: ServiceNow-sourced cases may have no deployment / product. */
@@ -698,6 +705,7 @@ interface BeCaseUpdateNever {
   product?: never;
   publicTicket?: never;
   acknowledge?: never;
+  workaroundProvided?: never;
 }
 
 /**
@@ -798,6 +806,12 @@ export type BeCaseUpdatePayload =
    * `alreadyAcknowledged: true` with whoever claimed it first.
    */
   | (Omit<BeCaseUpdateNever, "acknowledge"> & { acknowledge: true })
+  /**
+   * Mark (`true`) or recall (`false`) the case's workaround (ServiceNow only).
+   * Marking it stamps the signed-in engineer as the provider and pauses the
+   * case's Workaround SLA clock; recalling clears both.
+   */
+  | (Omit<BeCaseUpdateNever, "workaroundProvided"> & { workaroundProvided: boolean })
   /**
    * Places the case on hold in the backing data source's staged auto-closure
    * sequence until this ISO date-time (ServiceNow only). The raw

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -109,6 +109,13 @@ function detailFromBeCase(
           email: c.acknowledgedBy.email ?? undefined,
         }
       : undefined,
+    workaroundProvidedOn: c.workaroundProvidedOn ?? undefined,
+    workaroundProvidedBy: c.workaroundProvidedBy
+      ? {
+          name: c.workaroundProvidedBy.name?.trim() || (c.workaroundProvidedBy.email ?? "—"),
+          email: c.workaroundProvidedBy.email ?? undefined,
+        }
+      : undefined,
     assignee,
     assigneeName,
     assigneeEmail,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/usePatchCsmCase.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/usePatchCsmCase.ts
@@ -31,8 +31,9 @@ import type {
  * Update a case via `PATCH /cases/{id}` — state transitions, priority changes,
  * work sub-state (`workState`), assignee (`assigneeEmail`), watch list
  * (`watchList`), parent/related-case links (`parentId` / `relatedCaseId`),
- * subject/description/deployment/deployed-product edits, or an auto-closure
- * hold (`autocloseHoldUntil`). The backend requires **exactly one** of those
+ * subject/description/deployment/deployed-product edits, marking/recalling
+ * the workaround (`workaroundProvided`), or an auto-closure hold
+ * (`autocloseHoldUntil`). The backend requires **exactly one** of those
  * fields per call, so callers must not combine them.
  * The response is `BeUpdateCaseResponse` ({ message, case }), but on success we
  * ignore the body and invalidate this case's detail query and the cross-project

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -871,7 +871,7 @@ describe("acknowledge action", () => {
   });
 });
 
-describe("CaseActionBar — Provide / Recall workaround (digiops-cs#2956)", () => {
+describe("CaseActionBar — Provide / Recall workaround", () => {
   it("shows 'Provide workaround' and dispatches toggle_workaround_provided when unset", () => {
     const onAction = vi.fn();
     render(

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -870,3 +870,54 @@ describe("acknowledge action", () => {
     expect(screen.getByRole("button", { name: /acknowledge/i })).toBeDisabled();
   });
 });
+
+describe("CaseActionBar — Provide / Recall workaround (digiops-cs#2956)", () => {
+  it("shows 'Provide workaround' and dispatches toggle_workaround_provided when unset", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={{ ...BASE_CASE, workaroundProvidedOn: undefined }}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /provide workaround/i });
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).toHaveBeenCalledWith({
+      secondary: "toggle_workaround_provided",
+    });
+  });
+
+  it("shows 'Recall workaround' once the workaround is marked provided", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={{
+          ...BASE_CASE,
+          workaroundProvidedOn: "2026-09-02T17:11:47Z",
+        }}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /recall workaround/i });
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).toHaveBeenCalledWith({
+      secondary: "toggle_workaround_provided",
+    });
+  });
+
+  it("disables the menu item once the case is closed", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar caseDetail={caseInState("closed", [])} onAction={onAction} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /provide workaround/i });
+    expect(item).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -42,7 +42,9 @@ import {
   Pencil,
   Play,
   Send,
+  Undo2,
   User,
+  Wrench,
 } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import type {
@@ -281,6 +283,31 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
       label: ongoing ? "Pause work" : "Resume work",
       icon: ongoing ? <PauseCircle size={16} /> : <Play size={16} />,
       divider: true,
+    });
+  }
+
+  // Mark / recall the case's workaround. Pauses the case's Workaround SLA
+  // clock while set; recalling clears it. Not assignee-gated (unlike
+  // pause/resume work above) -- any engineer working the case can mark or
+  // recall it. Blocked once the case is closed, same as every other write
+  // action below.
+  {
+    const caseClosedForWorkaround = caseDetail.state === "closed";
+    items.push({
+      key: "toggle_workaround_provided",
+      label: caseDetail.workaroundProvidedOn
+        ? "Recall workaround"
+        : "Provide workaround",
+      icon: caseDetail.workaroundProvidedOn ? (
+        <Undo2 size={16} />
+      ) : (
+        <Wrench size={16} />
+      ),
+      divider: true,
+      disabled: caseClosedForWorkaround,
+      tooltip: caseClosedForWorkaround
+        ? "This case is closed — it's read-only."
+        : undefined,
     });
   }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1205,6 +1205,34 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
+      // Mark / recall the case's workaround via PATCH { workaroundProvided }.
+      // A single-field toggle, same shape as the plain "Pause work" branch
+      // above — no conflict check needed (unlike resuming work).
+      if (action.secondary === "toggle_workaround_provided") {
+        const providing = !data?.workaroundProvidedOn;
+        patchCase.mutate(
+          { workaroundProvided: providing },
+          {
+            onSuccess: () =>
+              setFeedback({
+                message: providing
+                  ? "Workaround marked as provided — the Workaround SLA clock is paused."
+                  : "Workaround recalled.",
+                severity: "success",
+                sticky: false,
+              }),
+            onError: (err) =>
+              showError(
+                providing
+                  ? "Could not mark the workaround as provided. Please try again."
+                  : "Could not recall the workaround. Please try again.",
+                err,
+              ),
+          },
+        );
+        return;
+      }
+
       // Request update opens the reminder-template dialog; the POST happens
       // in onRequestUpdate once a stage (or custom message) is confirmed.
       if (action.secondary === "request_update") {

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -537,6 +537,14 @@ export interface CsmCaseDetail extends CsmCaseRow {
    * severity changes or it is reopened, so it can become absent again.
    */
   acknowledgedBy?: { name: string; email?: string };
+  /**
+   * When the case's workaround was marked provided (ISO date-time), or absent
+   * until marked (and cleared again on recall). Pauses the case's Workaround
+   * SLA clock while set.
+   */
+  workaroundProvidedOn?: string;
+  /** The engineer who marked the workaround as provided. Absent until marked. */
+  workaroundProvidedBy?: { name: string; email?: string };
   /** Category of issue reported, when set (e.g. "total_outage", "question"). */
   issueType?: BeCaseIssueType;
   /**

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1275,9 +1275,16 @@ type CaseView struct {
 	// backing data source when the case's type or severity changes or it is
 	// reopened, so that a materially changed case has to be re-acknowledged.
 	AcknowledgedBy *AssignedEngineerRef `json:"acknowledgedBy"`
-	ParentCase     *CaseNumberRef       `json:"parentCase"`
-	RelatedCase    *CaseNumberRef       `json:"relatedCase"`
-	AccountDetails *AccountRef          `json:"account"`
+	// WorkaroundProvidedOn is when the case's workaround was marked provided, null
+	// until marked (and cleared again on recall). Pauses the case's Workaround SLA
+	// clock in the backing data source while set (ServiceNow data source only).
+	WorkaroundProvidedOn *time.Time `json:"workaroundProvidedOn"`
+	// WorkaroundProvidedBy is the engineer who marked the workaround as provided,
+	// null until marked.
+	WorkaroundProvidedBy *AssignedEngineerRef `json:"workaroundProvidedBy"`
+	ParentCase           *CaseNumberRef       `json:"parentCase"`
+	RelatedCase          *CaseNumberRef       `json:"relatedCase"`
+	AccountDetails       *AccountRef          `json:"account"`
 	// LinkedServiceRequests lists any service-request cases whose parent points to this
 	// case. Populated on every case detail response, not just high-severity cases.
 	LinkedServiceRequests []LinkedServiceRequestRef `json:"linkedServiceRequests"`
@@ -1780,6 +1787,12 @@ type UpdateCaseRequest struct {
 	// it cannot be combined with any other field in the same request. Requires an
 	// elevated support role (ServiceNow data source only).
 	Acknowledge *bool `json:"acknowledge"`
+	// WorkaroundProvided marks (true) or recalls (false) the case's workaround.
+	// Unlike Acknowledge, both true and false are meaningful and accepted -- this
+	// is a toggle, not a one-way claim. Marking it stamps the calling engineer as
+	// the provider and pauses the case's Workaround SLA clock in the backing data
+	// source; recalling clears both (ServiceNow data source only).
+	WorkaroundProvided *bool `json:"workaroundProvided"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.
@@ -1843,6 +1856,11 @@ type UpdatedCase struct {
 	// request set it or found it already set. Present only when the update set
 	// acknowledge.
 	AcknowledgedBy *AssignedEngineerRef `json:"acknowledgedBy,omitempty"`
+	// WorkaroundProvidedOn/WorkaroundProvidedBy are not echoed here: ServiceNow's
+	// Update Case response only ever returns {id, updatedOn, updatedBy} for a plain
+	// field write like this one (same as Subject/Description/the fix-ETA fields
+	// above, none of which echo back either) -- the caller re-reads the case detail
+	// to see the new value, same as for those.
 }
 
 // CaseVariable is one answered question on a service request: Name is the

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -43,31 +43,36 @@ type snCasesResponse struct {
 }
 
 type snCase struct {
-	ID                    string                      `json:"id"`
-	InternalID            string                      `json:"internalId"`
-	Number                string                      `json:"number"`
-	Title                 string                      `json:"title"`
-	Description           string                      `json:"description"`
-	CreatedOn             string                      `json:"createdOn"`
-	UpdatedOn             *string                     `json:"updatedOn"`
-	CreatedBy             string                      `json:"createdBy"`
-	CreatedByFullName     string                      `json:"createdByFullName"`
-	Project               snCaseProjectRef            `json:"project"`
-	Deployment            snCaseEntityRef             `json:"deployment"`
-	DeployedProduct       snCaseDeployedProduct       `json:"deployedProduct"`
-	Product               *snCaseEntityRef            `json:"product"`
-	State                 *snCaseState                `json:"state"`
-	WorkState             *snCaseLabel                `json:"workState"`
-	Severity              *snCaseLabel                `json:"severity"`
-	IssueType             *snCaseIssueType            `json:"issueType"`
-	EngagementType        *snCaseLabel                `json:"engagementType"`
-	CaseType              *snCaseEntityRef            `json:"caseType"`
-	Catalog               *snCaseEntityRef            `json:"catalog"`
-	CatalogItem           *snCaseEntityRef            `json:"catalogItem"`
-	AssignedTeam          *snCaseEntityRef            `json:"assignedTeam"`
-	Conversation          *snCaseEntityRef            `json:"conversation"`
-	AssignedEngineer      *snAssignedEngineerRef      `json:"assignedEngineer"`
-	AcknowledgedBy        *snAssignedEngineerRef      `json:"acknowledgedBy"`
+	ID                string                 `json:"id"`
+	InternalID        string                 `json:"internalId"`
+	Number            string                 `json:"number"`
+	Title             string                 `json:"title"`
+	Description       string                 `json:"description"`
+	CreatedOn         string                 `json:"createdOn"`
+	UpdatedOn         *string                `json:"updatedOn"`
+	CreatedBy         string                 `json:"createdBy"`
+	CreatedByFullName string                 `json:"createdByFullName"`
+	Project           snCaseProjectRef       `json:"project"`
+	Deployment        snCaseEntityRef        `json:"deployment"`
+	DeployedProduct   snCaseDeployedProduct  `json:"deployedProduct"`
+	Product           *snCaseEntityRef       `json:"product"`
+	State             *snCaseState           `json:"state"`
+	WorkState         *snCaseLabel           `json:"workState"`
+	Severity          *snCaseLabel           `json:"severity"`
+	IssueType         *snCaseIssueType       `json:"issueType"`
+	EngagementType    *snCaseLabel           `json:"engagementType"`
+	CaseType          *snCaseEntityRef       `json:"caseType"`
+	Catalog           *snCaseEntityRef       `json:"catalog"`
+	CatalogItem       *snCaseEntityRef       `json:"catalogItem"`
+	AssignedTeam      *snCaseEntityRef       `json:"assignedTeam"`
+	Conversation      *snCaseEntityRef       `json:"conversation"`
+	AssignedEngineer  *snAssignedEngineerRef `json:"assignedEngineer"`
+	AcknowledgedBy    *snAssignedEngineerRef `json:"acknowledgedBy"`
+	// WorkaroundProvidedOn/WorkaroundProvidedBy mirror AcknowledgedBy's shape:
+	// populated on the Choreo GET /cases/{id} response, null until the workaround
+	// is marked provided (and cleared again on recall).
+	WorkaroundProvidedOn  *string                     `json:"workaroundProvidedOn"`
+	WorkaroundProvidedBy  *snAssignedEngineerRef      `json:"workaroundProvidedBy"`
 	ParentCase            *snCaseRef                  `json:"parentCase"`
 	RelatedCase           *snCaseRef                  `json:"relatedCase"`
 	Account               *snCaseAccount              `json:"account"`
@@ -931,6 +936,16 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 	if c.AcknowledgedBy != nil {
 		cv.AcknowledgedBy = &domain.AssignedEngineerRef{ID: sysidToUUID(c.AcknowledgedBy.ID), Name: c.AcknowledgedBy.Name, Email: c.AcknowledgedBy.Email}
 	}
+	if c.WorkaroundProvidedOn != nil && *c.WorkaroundProvidedOn != "" {
+		workaroundProvidedOn, err := parseSNDateTime(ctx, "sn get case", "workaroundProvidedOn", *c.WorkaroundProvidedOn)
+		if err != nil {
+			return domain.CaseView{}, fmt.Errorf("sn get case: parse workaroundProvidedOn %q: %w", *c.WorkaroundProvidedOn, err)
+		}
+		cv.WorkaroundProvidedOn = &workaroundProvidedOn
+	}
+	if c.WorkaroundProvidedBy != nil {
+		cv.WorkaroundProvidedBy = &domain.AssignedEngineerRef{ID: sysidToUUID(c.WorkaroundProvidedBy.ID), Name: c.WorkaroundProvidedBy.Name, Email: c.WorkaroundProvidedBy.Email}
+	}
 	if c.ParentCase != nil {
 		cv.ParentCase = &domain.CaseNumberRef{ID: sysidToUUID(c.ParentCase.ID), Number: c.ParentCase.Number, Type: snParentCaseTypeToDomain(c.ParentCase.Type)}
 	}
@@ -1301,6 +1316,10 @@ type snUpdateCasePayload struct {
 	AddPublicComment *bool   `json:"addPublicComment,omitempty"`
 	Product          *string `json:"product,omitempty"`
 	PublicTicket     *string `json:"publicTicket,omitempty"`
+	// WorkaroundProvided marks (true) or recalls (false) the case's workaround
+	// (u_workaround_provided/u_workaround_provided_by). Same combinable pathway as
+	// the fix-ETA fields above -- not mutually exclusive with anything.
+	WorkaroundProvided *bool `json:"workaroundProvided,omitempty"`
 }
 
 // snResolutionStates are the state keys that allow resolution fields.
@@ -1524,9 +1543,12 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if req.PublicTicket != nil {
 		combinableCount++
 	}
+	if req.WorkaroundProvided != nil {
+		combinableCount++
+	}
 	const fieldList = "state, severity, workState, watchList, assigneeEmail, parentId, acknowledge, type, " +
 		"relatedCaseId, autocloseHoldUntil, subject, description, deploymentId, deployedProductId, " +
-		"bestCaseFixEta, mostLikelyFixEta, or worstCaseFixEta"
+		"bestCaseFixEta, mostLikelyFixEta, worstCaseFixEta, or workaroundProvided"
 	if exclusiveCount == 0 && combinableCount == 0 {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of " + fieldList + " must be provided"}
 	}
@@ -1800,6 +1822,9 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		payload.AddPublicComment = req.AddPublicComment
 		payload.Product = req.Product
 		payload.PublicTicket = req.PublicTicket
+	}
+	if req.WorkaroundProvided != nil {
+		payload.WorkaroundProvided = req.WorkaroundProvided
 	}
 
 	raw, err := s.client.Patch(ctx, "/cases/"+uuidToSysid(req.ID), token, payload)

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5142,11 +5142,15 @@ components:
       type: object
       description: |
         Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`,
-        `acknowledge`, `type`, `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta` must be
-        provided. The single exception is `severity`, which may accompany `type` and is
-        required when `type` is `case`.
-        `watchList`, `assigneeEmail`, `bestCaseFixEta`, `mostLikelyFixEta`, and
-        `worstCaseFixEta` are supported only for the ServiceNow data source.
+        `acknowledge`, `type`, or the combinable group (`bestCaseFixEta`, `mostLikelyFixEta`,
+        `worstCaseFixEta`, `workaroundProvided`) must be provided. The single exception is
+        `severity`, which may accompany `type` and is required when `type` is `case`.
+        The combinable group has no cross-field side effects, so any non-empty subset of its
+        four fields may be sent together in one request (e.g. all three fix-ETA estimates plus
+        `workaroundProvided` in the same call) — they must not be combined with any of the
+        exclusive fields above, though.
+        `watchList`, `assigneeEmail`, and the whole combinable group are supported only for the
+        ServiceNow data source.
         `resolutionCode`, `cause`, and `closeNotes` are optional and may only be provided alongside
         `state` when the state is `closed` or `solution_proposed`.
         `type` transfers the case to another type and is supported only for the ServiceNow
@@ -5165,9 +5169,11 @@ components:
         - required: [assigneeEmail]
         - required: [acknowledge]
         - required: [type]
-        - required: [bestCaseFixEta]
-        - required: [mostLikelyFixEta]
-        - required: [worstCaseFixEta]
+        - anyOf:
+            - required: [bestCaseFixEta]
+            - required: [mostLikelyFixEta]
+            - required: [worstCaseFixEta]
+            - required: [workaroundProvided]
       properties:
         state:
           type: string

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5322,6 +5322,12 @@ components:
           description: >-
             Internal-only worst-case fix-commitment date (date-only, YYYY-MM-DD), visible
             to CSM engineers only (ServiceNow only).
+        workaroundProvided:
+          type: boolean
+          description: >-
+            Mark (true) or recall (false) the case's workaround. Stamps the calling
+            engineer as the provider and pauses the case's Workaround SLA clock while
+            set; recalling clears both (ServiceNow only).
 
     UpdateCaseResponse:
       type: object
@@ -6171,6 +6177,18 @@ components:
             Engineer who acknowledged the case, or null if nobody has. Cleared by the
             backing data source when the case's type or severity changes or it is
             reopened, so a materially changed case has to be acknowledged again.
+        workaroundProvidedOn:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            When the case's workaround was marked provided, or null until marked (and
+            cleared again on recall). Pauses the case's Workaround SLA clock while set
+            (ServiceNow only).
+        workaroundProvidedBy:
+          nullable: true
+          $ref: '#/components/schemas/AssignedEngineerRef'
+          description: Engineer who marked the workaround as provided, or null until marked.
         parentCase:
           nullable: true
           $ref: '#/components/schemas/CaseNumberRef'


### PR DESCRIPTION
## Purpose
There is currently no way for a CS engineer to mark a case's workaround as provided (or recall it) from the CSM portal. The backing data source already tracks this as a timestamp + provider event that pauses the case's Workaround SLA clock, but the CSM portal's case contract never exposed it.

## Goals
Let a CS engineer mark or recall a case's workaround from the case detail page's action menu, and see the current state reflected there.

## Approach
- `entity-service`: `UpdateCaseRequest` gets `workaroundProvided *bool`; `CaseView` gets `WorkaroundProvidedOn *time.Time` / `WorkaroundProvidedBy *AssignedEngineerRef`. Threaded through `sn_case_service.go`'s request/response mappers, following the same pattern as the existing acknowledgement and fix-ETA fields. `openapi.yaml` updated.
- `csm-portal/backend` (BFF): no changes needed — `PatchCase`/`GetCase` are raw passthroughs.
- `csm-portal/webapp`: `BeCaseUpdatePayload`/`BeCaseView` gain the new field/fields; `CsmCaseDetail` and its mapper (`useGetCsmCaseDetail.ts`) surface them; `CaseActionBar.tsx` adds a "Provide workaround" / "Recall workaround" secondary action (disabled once the case is closed); `CsmCaseDetailPage.tsx` wires the click to the existing `usePatchCsmCase` mutation, mirroring the existing "Pause/Resume work" single-field-PATCH pattern.
- A corresponding entity-service change in a separately tracked private repo has already been made and verified against the real backing data source.

## User stories
As a CS engineer, I can mark a case's workaround as provided (pausing the Workaround SLA) and recall that if needed, from the case detail page.

## Release note
Cases can now have their workaround marked as provided (or recalled) from the case detail page's action menu.

## Documentation
N/A for this PR — the CSM portal `/help` topic update will follow once this ships, per the user-guide-freshness convention already in place for this feature area.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal CS-engineer workflow addition, not a marketed feature.

## Automation tests
- Unit tests
  > `CaseActionBar.test.tsx`: 3 new tests (shows "Provide workaround" and dispatches when unset, shows "Recall workaround" and dispatches when set, disabled on a closed case). `go build ./...` and `gofmt` clean on the entity-service changes; no existing entity-service Go tests were broken.
- Integration tests
  > Full `apps/csm-portal/webapp` test suite (711 tests across 60 files) passes; `tsc -b --noEmit` and `eslint .` clean (2 pre-existing unrelated warnings only).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — Go/TypeScript changes, not Java; this plugin doesn't apply.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
A corresponding entity-service change exists in a separately tracked private repo (already merged/verified against the real backing data source before this PR was opened).

## Migrations (if applicable)
N/A — no data migration; existing cases simply have both new fields unset until marked.

## Test environment
Node/pnpm per `apps/csm-portal/webapp/package.json` engines; Go per `entity-service/go.mod`. Verified via `pnpm run test`, `pnpm exec tsc -b --noEmit`, `pnpm run lint`, `go build ./...`.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to mark a case’s workaround as provided or recall it from the More menu.
  * Displays when and by whom a workaround was provided.
  * Marking a workaround pauses its SLA clock; recalling it resumes tracking.
  * Workaround actions are unavailable for closed cases.
  * The feature is supported for ServiceNow cases.
* **Documentation**
  * Updated case update guidance to include workaround and related-case actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->