### PR TITLE
fix(csm-portal): don't misroute case-tab create-X navigation as opening id=new

### DIFF
--- a/apps/csm-portal/webapp/src/context/case-tabs/caseRoutePatterns.test.ts
+++ b/apps/csm-portal/webapp/src/context/case-tabs/caseRoutePatterns.test.ts
@@ -63,6 +63,16 @@ describe("matchCaseLocation", () => {
   it("only takes the first path segment after the base as the id", () => {
     expect(matchCaseLocation("/cases/CS1/extra")).toEqual({ kind: "case", caseId: "CS1" });
   });
+
+  it("does not treat a sibling create route's 'new' segment as an id", () => {
+    expect(matchCaseLocation("/cases/new")).toBeUndefined();
+    expect(matchCaseLocation("/engagements/new")).toBeUndefined();
+    expect(matchCaseLocation("/announcements/new")).toBeUndefined();
+    expect(matchCaseLocation("/operations/service-requests/new")).toBeUndefined();
+    expect(matchCaseLocation("/security-center/security-reports/new")).toBeUndefined();
+    expect(matchCaseLocation("/operations/incidents/new")).toBeUndefined();
+    expect(matchCaseLocation("/operations/change-requests/new")).toBeUndefined();
+  });
 });
 
 describe("basePathForKind / pathForTab", () => {

--- a/apps/csm-portal/webapp/src/context/case-tabs/caseRoutePatterns.ts
+++ b/apps/csm-portal/webapp/src/context/case-tabs/caseRoutePatterns.ts
@@ -61,13 +61,26 @@ export function basePathForKind(kind: CaseRouteKind): string {
  * matching, deliberately independent of the app's real `<Routes>` tree so it
  * can also be used inside an isolated (non-real) router — see
  * `CaseTabIsolatedRouter`.
+ *
+ * `new` is never a real id here: every one of these bases also owns a
+ * sibling `<base>/new` create route in `App.tsx` (`cases/new`,
+ * `engagements/new`, `operations/incidents/new`, etc.). Without this
+ * exclusion, navigating to one of those create routes from inside an
+ * already-open case tab matched here first — `CaseTabIsolatedRouter`'s
+ * in-tab `navigate()` override treats any match as "open/activate a tab for
+ * this id" and never lets the real app router see the navigation at all, so
+ * the create page never mounts. Instead it opened a bogus tab for a record
+ * literally named "new", which fails to load (backend rejects "new" as an
+ * id) — reported as "Create incident from case" failing, but the same
+ * misroute hits every kind's create action once its originating case is
+ * open as a tab.
  */
 export function matchCaseLocation(pathname: string): CaseLocationMatch | undefined {
   for (const [base, kind] of ROUTE_KIND_BY_BASE) {
     if (pathname === base || pathname.startsWith(`${base}/`)) {
       const rest = pathname.slice(base.length + 1);
       const caseId = rest.split("/")[0];
-      if (caseId) return { kind, caseId };
+      if (caseId && caseId !== "new") return { kind, caseId };
     }
   }
   return undefined;


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Reported internally: "Create incident from case" (and, as this PR's investigation found, every other case-tab kind's "Create X from case" action) fails with a generic error whenever the originating case is open as an in-app tab — which is the default way cases open today. The error surfaced to users as a case-detail load failure rather than the create form appearing.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Make "Create incident/service request/change request from case" (and the standalone `.../new` create routes for every case-tab kind) navigate to the actual create form instead of being misrouted into opening a bogus tab.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Root cause: `matchCaseLocation()` in `caseRoutePatterns.ts` parses the path segment right after any case-tab route base (`/cases`, `/operations/incidents`, `/operations/change-requests`, `/operations/service-requests`, `/engagements`, `/announcements`, `/security-center/security-reports`) as that record's id, with no exclusion for the literal segment `"new"` — which is exactly the segment every one of those bases' own sibling create route uses (`cases/new`, `operations/incidents/new`, etc.). `CaseTabIsolatedRouter`'s in-tab `navigate()` override (active whenever the case you're acting from is open as a tab) treats any match from this function as "open/activate a tab for this id", intercepting the navigation before the real app router ever sees it — so instead of mounting the create form, it opened a tab for a record literally named "new", which then failed to load (the backend rejects `"new"` as an id).

Fix is a one-line exclusion: `matchCaseLocation()` now treats `"new"` as never a valid id, for all 7 kinds it covers, in one shared function.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, when I open a case (as a tab, the normal way) and use its "Create incident from case…" (or "Create service request…" / "Create change request…") action, I land on the create form pre-filled with the case as parent, instead of hitting an error.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed a bug where creating an incident, service request, or change request from an open case's action menu failed with a load error instead of opening the create form.

## Documentation
N/A — no user-facing behavior change beyond fixing the broken action; no doc currently describes this failure mode.

## Training
N/A — no training content covers this internal routing mechanism.

## Certification
N/A — no certification exam content is affected by this internal bug fix.

## Marketing
N/A — internal bug fix, not a new feature.

## Automation tests
 - Unit tests
   > Added a regression test in `caseRoutePatterns.test.ts` covering all 7 case-tab kinds' `/new` collision (`matchCaseLocation("/operations/incidents/new")` etc. now correctly return `undefined`). Full webapp suite (251 files, 2587 tests) passes with no regressions.
 - Integration tests
   > Manually reproduced the failure live on staging (case open in a tab, "Create incident from case…"), confirmed via network capture the exact failing request and error body, then verified the fix's logic against that trace. No automated integration/e2e test added — this repo's Playwright e2e suite doesn't currently cover the case-tabs mechanism.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React codebase, FindSecurityBugs is a Java tool and doesn't apply here.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new sample code introduced.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data or schema migration involved; this is a pure client-side routing fix.

## Test environment
Verified via `pnpm run test` (Vitest, jsdom) and `pnpm exec eslint` locally; live repro/verification against the staging CSM portal deployment in Chrome.

## Learning
Traced the failure from a live network capture (the actual failing request and its error body) back through the case-tabs feature's in-tab navigation override, rather than assuming the originally-reported "cloud data source" framing was the root cause — it wasn't; the bug is data-source-independent and affects every case-tab kind's create action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed case navigation so create pages with `/new` paths load correctly instead of being treated as case-detail pages.
  - Updated routing behavior across supported case-related paths to prevent `"new"` from being interpreted as a case ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->