### PR TITLE
[CSM Portal] Document Hold auto-closure's work-note behavior

### DIFF
--- a/apps/csm-portal/webapp/src/features/help/content/support.md
+++ b/apps/csm-portal/webapp/src/features/help/content/support.md
@@ -111,6 +111,12 @@ preview of the exact wording that will be posted) or write a custom message inst
 offered while the case is **Awaiting info** or has a **Solution proposed**, since those are the
 states where a reply from the customer is actually expected.
 
+**Hold auto-closure…**, also in the case's **More** menu, exempts a case from the automated
+auto-closure sequence until the date you pick. Setting or extending the hold automatically
+posts an internal note in the timeline recording the hold and its date, so anyone on the case
+can see when a hold was set or moved — resending the same date (e.g. an accidental re-submit)
+doesn't post a duplicate note.
+
 ## Attachments
 
 Click an image or PDF attachment to preview it: images open inline in a dialog; PDFs open in a


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Follow-up to the auto-closure hold work-note fix (merged in #1648): that PR added a new user-visible behavior (an internal note posted to the case timeline on hold set/extend) with no corresponding update to the in-app help.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Document the new behavior in the `/help` Support topic so CS engineers know to expect it.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Added a short paragraph under the "Comments" section of `apps/csm-portal/webapp/src/features/help/content/support.md`, alongside the existing "Request update…" paragraph (same menu, same pattern), describing that "Hold auto-closure…" posts an internal timeline note and that resending the same date doesn't duplicate it.

## User stories
> Summary of user stories addressed by this change>

As a CS engineer reading the in-app help, I want to know that setting/extending an auto-closure hold leaves a record in the timeline, so the help doc matches what I'll actually see.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Docs only — no behavior change.

## Documentation
N/A — this PR is the documentation change.

## Training
N/A

## Certification
N/A — no certification exam content covers this.

## Marketing
N/A — internal help content.

## Automation tests
 - Unit tests
   > N/A — Markdown content change, no logic to test.
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Markdown-only change
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
#1648 (the feature this documents)

## Migrations (if applicable)
N/A

## Test environment
N/A — Markdown content, verified by reading the rendered `/help` page.

## Learning
N/A
