### PR TITLE
[CSM Portal] Fix reply draft lost when switching case-detail tabs

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.test.tsx
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { useState } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -27,7 +28,9 @@ vi.mock("@api/backend/client", () => ({
   useBackendApi: () => ({ post: vi.fn() }),
 }));
 
-import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
+import CsmCaseCommentInput, {
+  type CommentAttachmentDraft,
+} from "@features/csm-cases/components/CsmCaseCommentInput";
 
 // This component isn't under test here; stub it to a plain textarea (same
 // technique EditCaseDetailsDialog.test.tsx uses for the same dependency).
@@ -231,5 +234,114 @@ describe("CsmCaseCommentInput — drag-and-drop attachments", () => {
 
     fireEvent.dragEnter(composer, { dataTransfer: { types: ["text/plain"], files: [] } });
     expect(screen.queryByText("Drop files to attach")).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Stands in for the real parent (`CsmCaseDetailPage`), which lifts the draft
+ * out of this component so it survives the Activities tab body unmounting on
+ * a tab switch and remounting on switch-back. `mounted` toggles
+ * `CsmCaseCommentInput` itself, the same way the page conditionally renders
+ * the tab body — the draft state below lives in this harness the whole time,
+ * exactly as it would in the parent page.
+ */
+function DraftLiftingHarness({
+  onSubmit = vi.fn(),
+}: {
+  onSubmit?: (
+    html: string,
+    internal: boolean,
+    attachments: CommentAttachmentDraft[],
+  ) => Promise<unknown> | void;
+}) {
+  const [mounted, setMounted] = useState(true);
+  const [html, setHtml] = useState("");
+  const [attachments, setAttachments] = useState<CommentAttachmentDraft[]>([]);
+  const [internal, setInternal] = useState(false);
+  const [sourceMode, setSourceMode] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setMounted((m) => !m)}>
+        toggle tab
+      </button>
+      {mounted && (
+        <CsmCaseCommentInput
+          onSubmit={onSubmit}
+          draftHtml={html}
+          onDraftHtmlChange={setHtml}
+          draftAttachments={attachments}
+          onDraftAttachmentsChange={setAttachments}
+          draftInternal={internal}
+          onDraftInternalChange={setInternal}
+          draftSourceMode={sourceMode}
+          onDraftSourceModeChange={setSourceMode}
+        />
+      )}
+    </>
+  );
+}
+
+describe("CsmCaseCommentInput — lifted draft state survives unmount/remount", () => {
+  it("keeps typed text after the composer unmounts and remounts (e.g. a tab switch)", () => {
+    render(<DraftLiftingHarness />);
+
+    fireEvent.change(screen.getByLabelText("comment-editor"), {
+      target: { value: "a reply in progress" },
+    });
+    expect(screen.getByLabelText("comment-editor")).toHaveValue(
+      "a reply in progress",
+    );
+
+    // Simulate switching to another case-detail tab and back.
+    fireEvent.click(screen.getByRole("button", { name: "toggle tab" }));
+    expect(screen.queryByLabelText("comment-editor")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "toggle tab" }));
+
+    expect(screen.getByLabelText("comment-editor")).toHaveValue(
+      "a reply in progress",
+    );
+  });
+
+  it("keeps a staged attachment after unmount/remount", () => {
+    render(<DraftLiftingHarness />);
+    const composer = screen.getByTestId("csm-comment-composer");
+
+    fireEvent.drop(composer, fileDrop([makeFile("draft.txt", 100)]));
+    expect(screen.getByTestId("attachment-count")).toHaveTextContent("1");
+
+    fireEvent.click(screen.getByRole("button", { name: "toggle tab" }));
+    fireEvent.click(screen.getByRole("button", { name: "toggle tab" }));
+
+    expect(screen.getByTestId("attachment-count")).toHaveTextContent("1");
+  });
+
+  it("keeps the internal-note toggle state after unmount/remount", () => {
+    render(<DraftLiftingHarness />);
+
+    fireEvent.click(screen.getByRole("switch", { name: /Internal note/i }));
+    expect(
+      screen.getByRole("switch", { name: /Internal note/i }),
+    ).toBeChecked();
+
+    fireEvent.click(screen.getByRole("button", { name: "toggle tab" }));
+    fireEvent.click(screen.getByRole("button", { name: "toggle tab" }));
+
+    expect(
+      screen.getByRole("switch", { name: /Internal note/i }),
+    ).toBeChecked();
+  });
+
+  it("clears the lifted draft on a successful submit", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<DraftLiftingHarness onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText("comment-editor"), {
+      target: { value: "send this" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Send to customer/ }));
+
+    await screen.findByText("Ctrl/Cmd + Enter to send.");
+    expect(screen.getByLabelText("comment-editor")).toHaveValue("");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -93,6 +93,22 @@ interface CsmCaseCommentInputProps {
   isResumingWork?: boolean;
   /** Focus the editor as soon as it mounts (e.g. when the composer opens). */
   autoFocus?: boolean;
+  /**
+   * Draft state, lifted to the parent so it survives this component
+   * unmounting (e.g. the case-detail page hides the Activities tab body on
+   * tab switch). All four are optional and independently controllable; any
+   * omitted pair falls back to this component's own local state, so callers
+   * that don't need cross-unmount persistence (e.g. the incident/change
+   * request detail pages) are unaffected.
+   */
+  draftHtml?: string;
+  onDraftHtmlChange?: (html: string) => void;
+  draftAttachments?: CommentAttachmentDraft[];
+  onDraftAttachmentsChange?: (attachments: CommentAttachmentDraft[]) => void;
+  draftInternal?: boolean;
+  onDraftInternalChange?: (internal: boolean) => void;
+  draftSourceMode?: boolean;
+  onDraftSourceModeChange?: (sourceMode: boolean) => void;
 }
 
 /** Stable identity for an attached File, used to dedupe re-picked files. */
@@ -114,6 +130,57 @@ function isEmpty(html: string): boolean {
   return text.length === 0;
 }
 
+/**
+ * A single piece of state that's either controlled by the parent (value +
+ * onChange both supplied) or managed locally (either omitted) — same
+ * "value"/"onChange" convention as a controlled `<input>`, but supporting a
+ * `setState`-style functional updater since several call sites below update
+ * off the previous value (e.g. toggling, appending an attachment).
+ *
+ * The returned setter has a **stable identity across renders**, exactly like
+ * `useState`'s own setter — several callers below memoize with an empty
+ * `useCallback` dep array, which would silently close over a stale value if
+ * the setter itself weren't stable (current value/mode are read from refs at
+ * call time instead of from the closure).
+ *
+ * `defaultValue` only seeds the local fallback's initial state; it isn't
+ * re-read on every render (mirrors `useState`'s own initial-value semantics).
+ */
+function useDraftState<T>(
+  controlledValue: T | undefined,
+  onChange: ((value: T) => void) | undefined,
+  defaultValue: T,
+): [T, (updater: T | ((prev: T) => T)) => void] {
+  const [localValue, setLocalValue] = useState<T>(defaultValue);
+  const isControlled = controlledValue !== undefined && onChange !== undefined;
+  const value = isControlled ? controlledValue : localValue;
+
+  // Refs are synced via effect (not written during render) so this stays
+  // compliant with the "no ref mutation during render" rule — the setter
+  // below is only ever invoked from event handlers, which always run after
+  // the effect for the render that produced them, so it never observes a
+  // stale value.
+  const valueRef = useRef(value);
+  const isControlledRef = useRef(isControlled);
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    valueRef.current = value;
+    isControlledRef.current = isControlled;
+    onChangeRef.current = onChange;
+  });
+
+  const setValue = useCallback((updater: T | ((prev: T) => T)) => {
+    const next =
+      typeof updater === "function"
+        ? (updater as (prev: T) => T)(valueRef.current)
+        : updater;
+    if (isControlledRef.current) onChangeRef.current?.(next);
+    else setLocalValue(next);
+  }, []);
+
+  return [value, setValue];
+}
+
 export default function CsmCaseCommentInput({
   onSubmit,
   disabled = false,
@@ -122,19 +189,37 @@ export default function CsmCaseCommentInput({
   onResumeWork,
   isResumingWork = false,
   autoFocus = false,
+  draftHtml,
+  onDraftHtmlChange,
+  draftAttachments,
+  onDraftAttachmentsChange,
+  draftInternal,
+  onDraftInternalChange,
+  draftSourceMode,
+  onDraftSourceModeChange,
 }: CsmCaseCommentInputProps): JSX.Element {
-  const [html, setHtml] = useState<string>("");
+  const [html, setHtml] = useDraftState(draftHtml, onDraftHtmlChange, "");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [sourceMode, setSourceMode] = useState(false);
+  const [sourceMode, setSourceMode] = useDraftState(
+    draftSourceMode,
+    onDraftSourceModeChange,
+    false,
+  );
   // When customer replies are blocked, the only allowed entry is an internal
   // work note, so start in work-note mode and (below) lock the toggle there.
-  const [internal, setInternal] = useState<boolean>(
-    () => !!publicCommentDisabledReason,
+  const [internal, setInternal] = useDraftState(
+    draftInternal,
+    onDraftInternalChange,
+    !!publicCommentDisabledReason,
   );
   const [maximized, setMaximized] = useState(false);
   // Files attached to this comment; uploaded to the case on send.
-  const [attachments, setAttachments] = useState<CommentAttachmentDraft[]>([]);
+  const [attachments, setAttachments] = useDraftState<CommentAttachmentDraft[]>(
+    draftAttachments,
+    onDraftAttachmentsChange,
+    [],
+  );
   const [attachModalOpen, setAttachModalOpen] = useState(false);
 
   const onAttachmentClick = useCallback(() => setAttachModalOpen(true), []);
@@ -146,10 +231,10 @@ export default function CsmCaseCommentInput({
       }
       return [...prev, { file, name }];
     });
-  }, []);
+  }, [setAttachments]);
   const onAttachmentRemove = useCallback((index: number) => {
     setAttachments((prev) => prev.filter((_, i) => i !== index));
-  }, []);
+  }, [setAttachments]);
   const onPasteError = useCallback((reason: "size" | "type") => {
     setError(
       reason === "type"
@@ -232,7 +317,7 @@ export default function CsmCaseCommentInput({
           )}.`
         : null,
     );
-  }, []);
+  }, [setAttachments]);
 
   const onDrop = useCallback(
     (e: DragEvent) => {
@@ -320,7 +405,9 @@ export default function CsmCaseCommentInput({
   }, [
     disabled,
     html,
+    setHtml,
     attachments,
+    setAttachments,
     internal,
     publicCommentDisabledReason,
     onSubmit,
@@ -335,7 +422,7 @@ export default function CsmCaseCommentInput({
   const publicReplyLocked = !!publicCommentDisabledReason;
   useEffect(() => {
     if (publicReplyLocked && !internal) setInternal(true);
-  }, [publicReplyLocked, internal]);
+  }, [publicReplyLocked, internal, setInternal]);
 
   // One reason, shown once. When resuming would unlock public replies, the
   // quick-fix next to Internal note covers it (with the actionable link) —
@@ -354,7 +441,7 @@ export default function CsmCaseCommentInput({
       // hand-edited) HTML as its initial value.
       if (!nextSource) setEditorMountKey((k) => k + 1);
     },
-    [],
+    [setSourceMode],
   );
 
   return (

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -706,6 +706,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
     setPrevCaseId(caseId);
     setFeedback(null);
     setComposerOpen(false);
+    // The lifted composer draft (see clearComposerDraft above) is per-case: a
+    // draft left over from the previous case must not appear — or be
+    // submittable — against the newly opened one.
+    clearComposerDraft();
     setAssignOpen(false);
     setResolutionDialog(null);
     setSeverityOpen(false);

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -84,7 +84,9 @@ import {
   useDeleteCsmCaseAttachment,
   useGetCsmCaseAttachmentPreviewSource,
 } from "@features/csm-cases/api/useCsmCaseAttachments";
-import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
+import CsmCaseCommentInput, {
+  type CommentAttachmentDraft,
+} from "@features/csm-cases/components/CsmCaseCommentInput";
 import CaseActionBar, {
   canAcknowledge,
 } from "@features/csm-cases/components/CaseActionBar";
@@ -621,6 +623,23 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // this case's tab from the tab strip can confirm first — see the hook's
   // own doc comment for what this signal does and doesn't guarantee.
   useReportCaseTabDraft(caseId, composerOpen);
+  // The reply composer's draft content, lifted out of CsmCaseCommentInput so
+  // it survives switching to another case-detail tab and back — the
+  // Activities tab body below (and the composer inside it) fully unmounts
+  // while a different tab is active. Cleared explicitly on Cancel and on a
+  // successful submit; a tab switch alone must not touch this.
+  const [draftHtml, setDraftHtml] = useState("");
+  const [draftAttachments, setDraftAttachments] = useState<
+    CommentAttachmentDraft[]
+  >([]);
+  const [draftInternal, setDraftInternal] = useState(false);
+  const [draftSourceMode, setDraftSourceMode] = useState(false);
+  const clearComposerDraft = useCallback(() => {
+    setDraftHtml("");
+    setDraftAttachments([]);
+    setDraftInternal(false);
+    setDraftSourceMode(false);
+  }, []);
   const [assignOpen, setAssignOpen] = useState(false);
   const [linkCaseOpen, setLinkCaseOpen] = useState(false);
   const [linkIncidentOpen, setLinkIncidentOpen] = useState(false);
@@ -2244,7 +2263,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   size="small"
                   variant="text"
                   color="inherit"
-                  onClick={() => setComposerOpen(false)}
+                  onClick={() => {
+                    setComposerOpen(false);
+                    clearComposerDraft();
+                  }}
                 >
                   Cancel
                 </Button>
@@ -2256,6 +2278,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 onResumeWork={() => onAction({ secondary: "toggle_work_state" })}
                 isResumingWork={patchCase.isPending}
                 autoFocus
+                draftHtml={draftHtml}
+                onDraftHtmlChange={setDraftHtml}
+                draftAttachments={draftAttachments}
+                onDraftAttachmentsChange={setDraftAttachments}
+                draftInternal={draftInternal}
+                onDraftInternalChange={setDraftInternal}
+                draftSourceMode={draftSourceMode}
+                onDraftSourceModeChange={setDraftSourceMode}
                 onSubmit={async (bodyHtml, internal, commentAttachments) => {
                   if (!caseId) return;
                   // Post the comment only when there's text; an attachment-only
@@ -2283,9 +2313,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
                       uploadedBy: engineerName,
                     });
                   }
-                  // Collapse only on success; on error the input keeps its
-                  // draft + files and surfaces the failure.
+                  // Collapse and clear the draft only on success; on error the
+                  // input keeps its draft + files and surfaces the failure.
                   setComposerOpen(false);
+                  clearComposerDraft();
                 }}
               />
             </Card>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

On the CSM Portal's Case Details page, a CS engineer drafting a reply on the Activity Stream tab loses that draft (text, attachments, internal-note flag, source-mode toggle) if they switch to another case-detail tab (Time Cards, Call Requests, etc.) and back, since the Activity Stream tab body fully unmounts on tab switch. Resolves a corresponding CSM Portal tracking issue (tracked separately, not linked here).

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

The reply draft now survives switching away from and back to the Activity Stream tab within the same case-detail session. It is cleared only on an explicit Cancel or a successful submit, never merely by switching tabs.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

`CsmCaseCommentInput` previously held its draft (`html`, `attachments`, `internal`, `sourceMode`) entirely in local `useState`, discarded whenever the component unmounted. This PR lifts that state up to `CsmCaseDetailPage` (the same pattern already used for the composer's open/closed flag) and passes it down as controlled value/onChange props via a new `useDraftState` helper hook, which falls back to local state when the props are omitted. That fallback keeps the composer's other callers (`CsmIncidentDetailPage`, `CsmChangeRequestDetailPage`) unaffected. `CsmCaseDetailPage` clears the lifted draft on Cancel and on a successful submit.

No UI change — this is a state-management fix only, no visual diff.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, when I start drafting a reply on a case and need to check another tab (e.g. Time Cards) before finishing it, I expect my draft to still be there when I come back to Activity Stream.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed: a drafted case reply is no longer lost when switching between case-detail tabs.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — no user-facing behavior/flow change, only a bug fix to existing behavior; the in-app help topic already describes the composer without documenting the (buggy) data-loss case.

## Training
N/A — no training content references this flow.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal bug fix, not a marketable feature.

## Automation tests
 - Unit tests
   > Added 4 new tests in `CsmCaseCommentInput.test.tsx` using a harness that mounts/unmounts the component (mirroring the tab-switch unmount) to verify the draft text, attachment, and internal-note toggle survive, and that a successful submit clears the lifted draft. All pre-existing tests in this file and in `CsmCaseDetailPage.test.tsx` (36 tests) still pass.
 - Integration tests
   > None added — no integration test harness exists for this flow; covered by the unit-level unmount/remount simulation above, which directly exercises the reported bug scenario.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A - TypeScript/React codebase, not a Java target for this tool
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema/data migration involved.

## Test environment
Verified with `tsc -b --force` (clean) and `eslint` (no new warnings) on the changed files, plus `vitest` unit tests as described above, in the standard Node/Vite dev toolchain for this webapp. Manual browser verification against a running dev server was not performed in this environment; unit-level unmount/remount tests directly simulate the reported tab-switch scenario.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Reused this component's existing "lift state to parent, pass as controlled props" pattern (already applied to the composer's open/closed flag) rather than introducing a new state-management approach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comment drafts now persist when switching between case-detail tabs.
  * Draft text, attachments, internal-note status, and source mode are preserved when returning to a composer.
  * Drafts are cleared when cancelled or after a successful submission.
  * Drafts are reset when navigating to a different case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->