### PR TITLE
[Entity-Service] move case back to Waiting on WSO2 on a customer reply

### DIFF
--- a/entity-service/.env.example
+++ b/entity-service/.env.example
@@ -75,7 +75,7 @@ SERVICENOW_INTEGRATION_SERVICE_SCOPES=<SERVICENOW_INTEGRATION_SERVICE_SCOPES>
 #
 # CUSTOMER_ROLES is a comma-separated list of ServiceNow role names whose
 # presence on a case comment's resolved author marks that comment as a
-# customer reply — moving the case back to "Work In Progress" when it
+# customer reply — moving the case back to "Waiting on WSO2" when it
 # arrives while the case is "Awaiting Info"/"Solution Proposed" (see
 # internal/service/sn_case_service.go's applyCustomerReplyStateTransition).
 # Deliberately no committed default, same reasoning as SUPPORT_ENGINEER_ROLE

--- a/entity-service/.env.example
+++ b/entity-service/.env.example
@@ -73,6 +73,16 @@ SERVICENOW_INTEGRATION_SERVICE_SCOPES=<SERVICENOW_INTEGRATION_SERVICE_SCOPES>
 # still register and can still breach normally either way.
 # SUPPORT_ENGINEER_ROLE=
 #
+# CUSTOMER_ROLES is a comma-separated list of ServiceNow role names whose
+# presence on a case comment's resolved author marks that comment as a
+# customer reply — moving the case back to "Work In Progress" when it
+# arrives while the case is "Awaiting Info"/"Solution Proposed" (see
+# internal/service/sn_case_service.go's applyCustomerReplyStateTransition).
+# Deliberately no committed default, same reasoning as SUPPORT_ENGINEER_ROLE
+# above. Left unset, that function simply can't confirm customer-authorship
+# and skips (logged) — nothing else about comment creation is affected.
+# CUSTOMER_ROLES=
+#
 # No CSM portal base URL config here: this service only publishes the fact
 # that a case/incident was created — it does not build any portal link.
 # incident.created's "Open in Portal" button target is built by

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -455,7 +455,7 @@ customer-visible comment arrives while the case is `Awaiting Info`/
 `CUSTOMER_ROLES` (same role-lookup mechanism as `applyResponseSLAOnComment`,
 just checked against a list instead of a single role — an organisation can
 have more than one customer-facing role), this calls `s.UpdateCase` with
-`State: WorkInProgress` **in-process**, not a second, separate ServiceNow
+`State: WaitingOnWSO2` **in-process**, not a second, separate ServiceNow
 PATCH — reusing `UpdateCase`'s own `publishStatusChanged` and
 `applyCaseStateSLAEffects` calls entirely rather than duplicating either.
 `applyCaseStateSLAEffects`'s `default` case (any state other than
@@ -469,7 +469,7 @@ when `s.publisher` is nil).
 **KNOWN GAP**: the read (this function's own `GetCaseByID`) and the write
 (`UpdateCase`'s PATCH) are not atomic — a case moved to some other state
 (e.g. closed) in that window still gets unconditionally set back to
-`Work In Progress`. Not unique to this function: every `UpdateCase` caller
+`Waiting on WSO2`. Not unique to this function: every `UpdateCase` caller
 that sets `State`/`Severity`/`AssigneeEmail` has the same read-then-PATCH
 race, since ServiceNow is the sole source of truth (no local row/version)
 and the Choreo integration's PATCH has no conditional-update mechanism

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -466,6 +466,17 @@ nothing else in `CreateCaseComment`'s flow surfaces it (`publishCommentAdded`
 fetches one for its own purpose but never shares it, and is itself skipped
 when `s.publisher` is nil).
 
+**KNOWN GAP**: the read (this function's own `GetCaseByID`) and the write
+(`UpdateCase`'s PATCH) are not atomic — a case moved to some other state
+(e.g. closed) in that window still gets unconditionally set back to
+`Work In Progress`. Not unique to this function: every `UpdateCase` caller
+that sets `State`/`Severity`/`AssigneeEmail` has the same read-then-PATCH
+race, since ServiceNow is the sole source of truth (no local row/version)
+and the Choreo integration's PATCH has no conditional-update mechanism
+(ETag/version/`sys_mod_count`) to close it with. Fixing this needs that
+integration to expose one first — a cross-team dependency, not addressed
+here.
+
 ## Scheduled task runs
 
 `scheduled_task_run` (migration `000013`, `internal/domain/entity.go`'s

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -51,6 +51,8 @@ A failed Event Hub publish is logged instead of recorded — see
 | `EVENT_HUB_CONNECTION_STRING` | no* | — | Event Hub namespace Shared Access Policy connection string. *Required once `EVENT_HUB_BROKER` is set |
 | `EVENT_HUB_TOPIC` | no* | — | Event Hub (Kafka topic) name. *Required once `EVENT_HUB_BROKER` is set |
 | `EVENT_PUBLISHING_ENABLED` | no | `false` | Must be `"true"` for `EventPublisherService` to actually get constructed, even with `EVENT_HUB_BROKER` fully configured — a separate safe-by-default kill switch |
+| `SUPPORT_ENGINEER_ROLE` | no | — | ServiceNow role name whose presence on a case comment's resolved author completes the case's "response" SLA clock — see "SLA clocks" below |
+| `CUSTOMER_ROLES` | no | — | Comma-separated ServiceNow role names whose presence on a case comment's resolved author marks a customer reply — see `applyCustomerReplyStateTransition` in "SLA clocks" below |
 
 `CSM_TEAM_REGISTRY` and `CSM_USER_ROLES` are **not read here**. The team registry
 and the assignable-role allow-list are organisation vocabulary and live in the CSM
@@ -445,6 +447,24 @@ All three are deliberately **independent of `s.publisher`** except
 registration itself (inherently Kafka-based) — pause/resume/completion are
 pure in-process DB writes via `SLAClockService`, so a deployment without
 Event Hub configured must not lose them as a side effect of that.
+
+**`CreateCaseComment`** also calls `applyCustomerReplyStateTransition` —
+not itself an SLA-clock write, but it triggers one indirectly. When a
+customer-visible comment arrives while the case is `Awaiting Info`/
+`Solution Proposed`, from an author holding one of the configurable
+`CUSTOMER_ROLES` (same role-lookup mechanism as `applyResponseSLAOnComment`,
+just checked against a list instead of a single role — an organisation can
+have more than one customer-facing role), this calls `s.UpdateCase` with
+`State: WorkInProgress` **in-process**, not a second, separate ServiceNow
+PATCH — reusing `UpdateCase`'s own `publishStatusChanged` and
+`applyCaseStateSLAEffects` calls entirely rather than duplicating either.
+`applyCaseStateSLAEffects`'s `default` case (any state other than
+`AwaitingInfo`/`SolutionProposed`/`Closed`) is exactly the resume behavior
+this needs, so no new SLA-specific code was needed for that part at all.
+Requires its own `GetCaseByID` call to read the case's current state —
+nothing else in `CreateCaseComment`'s flow surfaces it (`publishCommentAdded`
+fetches one for its own purpose but never shares it, and is itself skipped
+when `s.publisher` is nil).
 
 ## Scheduled task runs
 

--- a/entity-service/README.md
+++ b/entity-service/README.md
@@ -151,6 +151,7 @@ rather than async.
 | `EVENT_HUB_TOPIC` | Event Hub (Kafka topic) name, e.g. `case-events` — must match `csm-notification-service`'s own `EVENT_HUB_TOPIC` (required once `EVENT_HUB_BROKER` is set) |
 | `EVENT_PUBLISHING_ENABLED` | Set to `true` to actually publish. Defaults to `false` — safe by default even with Event Hub fully configured (optional) |
 | `SUPPORT_ENGINEER_ROLE` | ServiceNow role name whose presence on a case comment's author completes the case's "response" SLA clock — see "SLA clocks" below. No default; unset means that specific completion path never fires (optional) |
+| `CUSTOMER_ROLES` | Comma-separated ServiceNow role names whose presence on a case comment's author marks it a customer reply — see "Customer reply state transition" below. No default; unset means that path never fires (optional) |
 
 ### SLA clocks
 
@@ -190,6 +191,16 @@ with `{"status": "reached"}` — the same endpoint "complete early" reuses to pr
 tiers at once, which is what suppresses a later spurious breach alert for an already-satisfied
 clock. On a genuine breach it sends a Google Chat card directly (not routed through this
 service).
+
+### Customer reply state transition
+
+When a customer-visible comment (not a work note) from a user holding one of the `CUSTOMER_ROLES`
+roles (looked up the same way as `SUPPORT_ENGINEER_ROLE`, via `SNUserService.SearchUsers` filtered
+by the comment author's email) arrives while the case is `Awaiting Info`/`Solution Proposed`,
+`sn_case_service.go`'s `applyCustomerReplyStateTransition` moves it back to `Work In Progress` — a
+customer reply means it's WSO2's turn to act again. Implemented as a plain in-process call to this
+service's own `UpdateCase`, not a separate ServiceNow PATCH — so it gets `case.status_changed`
+publishing and the SLA pause/resume side effects above for free, with no duplicated logic.
 
 ### Scheduled task runs
 

--- a/entity-service/README.md
+++ b/entity-service/README.md
@@ -197,7 +197,7 @@ service).
 When a customer-visible comment (not a work note) from a user holding one of the `CUSTOMER_ROLES`
 roles (looked up the same way as `SUPPORT_ENGINEER_ROLE`, via `SNUserService.SearchUsers` filtered
 by the comment author's email) arrives while the case is `Awaiting Info`/`Solution Proposed`,
-`sn_case_service.go`'s `applyCustomerReplyStateTransition` moves it back to `Work In Progress` — a
+`sn_case_service.go`'s `applyCustomerReplyStateTransition` moves it back to `Waiting on WSO2` — a
 customer reply means it's WSO2's turn to act again. Implemented as a plain in-process call to this
 service's own `UpdateCase`, not a separate ServiceNow PATCH — so it gets `case.status_changed`
 publishing and the SLA pause/resume side effects above for free, with no duplicated logic.

--- a/entity-service/internal/config/config.go
+++ b/entity-service/internal/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 )
 
 // DataSource identifies which backend the service reads from.
@@ -80,6 +81,21 @@ type Config struct {
 	// engineer-authorship and skips (logged) — not fatal, not required by
 	// Validate.
 	SupportEngineerRole string
+	// CustomerRoles is a comma-separated list of ServiceNow role names (see
+	// SUPPORT_ENGINEER_ROLE's own doc comment for the same
+	// organisation-specific-vocabulary reasoning — deliberately no
+	// committed default here either) whose presence on a case comment's
+	// resolved author marks that comment as a customer reply — see
+	// sn_case_service.go's applyCustomerReplyStateTransition, which moves
+	// the case back to Work In Progress when a customer replies while it's
+	// Awaiting Info/Solution Proposed. Left unset (or empty), that function
+	// can't confirm customer-authorship and skips (logged) — not fatal, not
+	// required by Validate. Coincidentally shares its name with an
+	// unrelated CUSTOMER_ROLES env var in
+	// integrations/csm-notification-service (notification-link routing,
+	// nothing to do with case state) — the two are read by separate
+	// processes/environments and don't interact.
+	CustomerRoles []string
 }
 
 // Load reads configuration from environment variables and returns a populated
@@ -105,6 +121,7 @@ func Load() *Config {
 		EventHubTopic:                            os.Getenv("EVENT_HUB_TOPIC"),
 		EventPublishingEnabled:                   os.Getenv("EVENT_PUBLISHING_ENABLED") == "true",
 		SupportEngineerRole:                      os.Getenv("SUPPORT_ENGINEER_ROLE"),
+		CustomerRoles:                            splitComma(os.Getenv("CUSTOMER_ROLES")),
 	}
 }
 
@@ -113,6 +130,23 @@ func getEnvOrDefault(key, defaultVal string) string {
 		return v
 	}
 	return defaultVal
+}
+
+// splitComma parses a comma-separated env var into a trimmed, non-empty
+// slice ("" for an unset/empty var, matching integrations/csm-notification-service's
+// own copy of this exact helper).
+func splitComma(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			result = append(result, t)
+		}
+	}
+	return result
 }
 
 // HasDatabase reports whether a Postgres connection is configured. It is the

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -198,7 +198,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) (http.Handler, service.Even
 	pgCaseSvc := service.NewCaseService(caseRepo, userRepo)
 	var activeCaseSvc service.CaseService
 	if cfg.DataSource == config.DataSourceServiceNow {
-		activeCaseSvc = service.NewServiceNowCaseService(serviceNowIntegrationServiceClient, pgCaseSvc, eventPublisher, slaClockService, snUserService, cfg.SupportEngineerRole)
+		activeCaseSvc = service.NewServiceNowCaseService(serviceNowIntegrationServiceClient, pgCaseSvc, eventPublisher, slaClockService, snUserService, cfg.SupportEngineerRole, cfg.CustomerRoles)
 	} else {
 		activeCaseSvc = pgCaseSvc
 	}

--- a/entity-service/internal/service/sn_attachment_get_update_test.go
+++ b/entity-service/internal/service/sn_attachment_get_update_test.go
@@ -66,7 +66,7 @@ func TestSNCaseService_GetAttachmentByID_HappyPath(t *testing.T) {
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	got, err := svc.GetAttachmentByID(contextWithUserIDToken("token"), attachmentUUID)
 	if err != nil {
@@ -112,7 +112,7 @@ func TestSNCaseService_GetAttachmentByID_RejectsUnparseableCreatedOn(t *testing.
 		_, _ = w.Write([]byte(`{"id":"` + testAttachmentSysid + `","createdOn":"2026-01-01T00:00:00Z"}`))
 	})
 
-	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	_, err := svc.GetAttachmentByID(contextWithUserIDToken("token"), sysidToUUID(testAttachmentSysid))
 	if err == nil {
@@ -129,7 +129,7 @@ func TestSNCaseService_GetAttachment_NotFound(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	_, err := svc.GetAttachmentByID(contextWithUserIDToken("token"), sysidToUUID(testAttachmentSysid))
 	var notFound *apierror.NotFoundError
@@ -144,7 +144,7 @@ func TestSNCaseService_GetAttachment_RejectsInvalidUUID(t *testing.T) {
 	client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatalf("unexpected call to backing service for an invalid attachment id")
 	}))
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	_, err := svc.GetAttachmentByID(contextWithUserIDToken("token"), "not-a-uuid")
 	var ve *apierror.ValidationError
@@ -182,7 +182,7 @@ func TestSNCaseService_UpdateAttachment_HappyPath(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.UpdateAttachmentRequest{
 		AttachmentID:  attachmentUUID,
@@ -290,7 +290,7 @@ func TestSNCaseService_UpdateAttachment_DescriptionThreeStates(t *testing.T) {
 			})
 
 			client := newTestSNClient(t, mux)
-			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 			if _, err := svc.UpdateAttachment(contextWithUserIDToken("token"), tc.req); err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -319,7 +319,7 @@ func TestSNCaseService_UpdateAttachment_ValidationErrors(t *testing.T) {
 	client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatalf("unexpected call to backing service for an invalid request")
 	}))
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	cases := []struct {
 		name string

--- a/entity-service/internal/service/sn_case_acknowledgement_test.go
+++ b/entity-service/internal/service/sn_case_acknowledgement_test.go
@@ -58,7 +58,7 @@ func TestSNCaseService_GetCaseByID_MapsAcknowledgedBy(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(newBody(`{"id": "` + ackSysid + `", "name": "Jane Doe", "email": "jane.doe@example.com"}`)))
 		})
-		svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+		svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 		cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
 		if err != nil {
@@ -85,7 +85,7 @@ func TestSNCaseService_GetCaseByID_MapsAcknowledgedBy(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(newBody(`null`)))
 		})
-		svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+		svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 		cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
 		if err != nil {
@@ -119,7 +119,7 @@ func TestSNCaseService_UpdateCase_AcknowledgeSendsTrueAndEchoesBack(t *testing.T
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	acknowledge := true
 	resp, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, Acknowledge: &acknowledge})
@@ -169,7 +169,7 @@ func TestSNCaseService_UpdateCase_AcknowledgeAlreadyAcknowledgedIsNotAnError(t *
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	acknowledge := true
 	resp, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, Acknowledge: &acknowledge})
@@ -232,7 +232,7 @@ func TestSNCaseService_UpdateCase_AcknowledgePublishesCaseAcknowledged(t *testin
 
 	client := newTestSNClient(t, mux)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	acknowledge := true
 	if _, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, Acknowledge: &acknowledge}); err != nil {
@@ -297,7 +297,7 @@ func TestSNCaseService_UpdateCase_AcknowledgeAlreadyAcknowledgedSkipsPublish(t *
 
 	client := newTestSNClient(t, mux)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	acknowledge := true
 	if _, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, Acknowledge: &acknowledge}); err != nil {
@@ -310,7 +310,7 @@ func TestSNCaseService_UpdateCase_AcknowledgeAlreadyAcknowledgedSkipsPublish(t *
 
 func TestSNCaseService_UpdateCase_AcknowledgeRejectsFalseAndCombinations(t *testing.T) {
 	client := newTestSNClient(t, http.NewServeMux())
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	acknowledgeTrue, acknowledgeFalse := true, false
 	subject := "new subject"

--- a/entity-service/internal/service/sn_case_aggregate_test.go
+++ b/entity-service/internal/service/sn_case_aggregate_test.go
@@ -62,7 +62,7 @@ func TestSNCaseService_AggregateCases_CallsAggregateEndpointAndMapsResponse(t *t
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
 
 	req := domain.AggregateCasesRequest{
@@ -136,7 +136,7 @@ func TestSNCaseService_AggregateCases_RejectsBadFilterFieldAndCombo(t *testing.T
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
 
 	t.Run("bad field name", func(t *testing.T) {

--- a/entity-service/internal/service/sn_case_attachment_test.go
+++ b/entity-service/internal/service/sn_case_attachment_test.go
@@ -52,7 +52,7 @@ func TestSNCaseService_GetAttachmentByID_StatusAndFields(t *testing.T) {
 		_, _ = w.Write([]byte(body))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	details, err := svc.GetAttachmentByID(contextWithUserIDToken("token"), sysidToUUID(testSNAttachmentSysid))
 	if err != nil {
@@ -90,7 +90,7 @@ func TestSNCaseService_CreateCaseAttachment_StatusComplete(t *testing.T) {
 		_, _ = w.Write([]byte(body))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	resp, err := svc.CreateCaseAttachment(contextWithUserIDToken("token"), domain.CreateAttachmentRequest{
 		ReferenceID:   sysidToUUID(testWLCaseSysid),

--- a/entity-service/internal/service/sn_case_group_search_test.go
+++ b/entity-service/internal/service/sn_case_group_search_test.go
@@ -147,7 +147,7 @@ func TestSNCaseService_SearchCases_GroupBy(t *testing.T) {
 			})
 		})
 
-		svc := NewServiceNowCaseService(newTestSNClient(t, h), nil, nil, noopSLAClockService{}, nil, "")
+		svc := NewServiceNowCaseService(newTestSNClient(t, h), nil, nil, noopSLAClockService{}, nil, "", nil)
 		resp, err := svc.SearchCases(contextWithUserIDToken("token"), domain.SearchCasesRequest{
 			GroupBy:    "state",
 			Pagination: domain.Pagination{Limit: 20, Offset: 0},
@@ -192,7 +192,7 @@ func TestSNCaseService_SearchCases_GroupBy(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(map[string]any{"cases": []map[string]any{}, "totalRecords": 1})
 		})
 
-		svc := NewServiceNowCaseService(newTestSNClient(t, h), nil, nil, noopSLAClockService{}, nil, "")
+		svc := NewServiceNowCaseService(newTestSNClient(t, h), nil, nil, noopSLAClockService{}, nil, "", nil)
 		_, err := svc.SearchCases(contextWithUserIDToken("token"), domain.SearchCasesRequest{
 			GroupBy:    "state",
 			Pagination: domain.Pagination{Limit: 20, Offset: 0},
@@ -207,7 +207,7 @@ func TestSNCaseService_SearchCases_GroupBy(t *testing.T) {
 			t.Error("no upstream call expected for an invalid groupBy")
 			w.WriteHeader(http.StatusInternalServerError)
 		})
-		svc := NewServiceNowCaseService(newTestSNClient(t, h), nil, nil, noopSLAClockService{}, nil, "")
+		svc := NewServiceNowCaseService(newTestSNClient(t, h), nil, nil, noopSLAClockService{}, nil, "", nil)
 		_, err := svc.SearchCases(contextWithUserIDToken("token"), domain.SearchCasesRequest{
 			GroupBy:    "tag",
 			Pagination: domain.Pagination{Limit: 20, Offset: 0},

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1403,6 +1403,26 @@ func (s *snCaseService) applyResponseSLAOnComment(ctx context.Context, req domai
 // current one (a race with some other concurrent state change) is a
 // harmless no-op there — see UpdateCase's own pre-PATCH equality check.
 //
+// KNOWN GAP: the read here (this function's own GetCaseByID) and the write
+// (the UpdateCase call below, which does its own separate GetCaseByID
+// purely to decide whether to publish case.status_changed — see that
+// function's own pre-PATCH block) are not atomic. If the case is moved to
+// some OTHER state (e.g. Closed) in the window between this function's read
+// and UpdateCase's PATCH, this still unconditionally sends
+// State: WorkInProgress — silently reopening a case that was just closed,
+// and resuming SLA clocks applyCaseStateSLAEffects had just paused for
+// Closed. This is not unique to this function: every UpdateCase caller that
+// sets State/Severity/AssigneeEmail (publishStatusChanged/
+// publishSeverityChanged/publishCaseAssigned's own pre-PATCH guards) has the
+// identical read-then-PATCH race window, since ServiceNow is this service's
+// sole source of truth (no local row/version to condition on) and
+// s.client.Patch has no optimistic-concurrency mechanism (no ETag/version/
+// sys_mod_count precondition) to send even if this function wanted one.
+// Closing this needs the underlying Choreo/ServiceNow integration to expose
+// a conditional update — a real, cross-team dependency, not a quick fix
+// here, so it's flagged rather than worked around with a partial guard that
+// wouldn't close the actual window anyway.
+//
 // Requires its own GetCaseByID call: nothing in CreateCaseComment's own flow
 // surfaces the case's current state today (publishCommentAdded fetches one
 // for its own, separate purpose, but never returns or shares it, and is

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -86,6 +86,11 @@ const applyResponseSLATimeout = 5 * time.Second
 // applyResponseSLATimeout.
 const applyCaseStateSLATimeout = 5 * time.Second
 
+// applyCustomerReplyTimeout bounds applyCustomerReplyStateTransition's own
+// GetCaseByID + author resolution + role lookup + UpdateCase calls — same
+// reasoning as applyResponseSLATimeout.
+const applyCustomerReplyTimeout = 5 * time.Second
+
 // watchListEmails extracts the non-empty emails from a case's watch list —
 // Recipients for every case.* event this file publishes is the case's
 // WatchList emails only (an explicit, deliberate decision — this service
@@ -838,12 +843,17 @@ type snCaseService struct {
 	slaClocks           SLAClockService
 	userSvc             SNUserService
 	supportEngineerRole string
+	// customerRoles backs applyCustomerReplyStateTransition — see that
+	// function's own doc comment and config.Config.CustomerRoles'. May be
+	// empty (unconfigured), treated the same "can't confirm authorship,
+	// skip" way supportEngineerRole == "" is.
+	customerRoles []string
 }
 
 // NewSNCaseService constructs a CaseService that delegates SearchCases to the
 // Choreo API and all write/read-by-id operations to pgFallback. publisher may
 // be nil (see snCaseService.publisher's doc comment).
-func NewServiceNowCaseService(client *integrationservice.Client, pgFallback CaseService, publisher EventPublisherService, slaClocks SLAClockService, userSvc SNUserService, supportEngineerRole string) CaseService {
+func NewServiceNowCaseService(client *integrationservice.Client, pgFallback CaseService, publisher EventPublisherService, slaClocks SLAClockService, userSvc SNUserService, supportEngineerRole string, customerRoles []string) CaseService {
 	return &snCaseService{
 		client:              client,
 		pgFallback:          pgFallback,
@@ -851,6 +861,7 @@ func NewServiceNowCaseService(client *integrationservice.Client, pgFallback Case
 		slaClocks:           slaClocks,
 		userSvc:             userSvc,
 		supportEngineerRole: supportEngineerRole,
+		customerRoles:       customerRoles,
 	}
 }
 
@@ -1377,6 +1388,79 @@ func (s *snCaseService) applyResponseSLAOnComment(ctx context.Context, req domai
 		if _, err := s.slaClocks.SetSLAClockTierReached(ctx, req.CaseID, slaClockTypeResponse, tier, domain.SetSLAClockTierRequest{Status: domain.SLATierStatusReached}); err != nil {
 			logSLAClockOpFailed(ctx, "sn create comment: mark response sla clock tier reached failed", req.CaseID, slaClockTypeResponse, err)
 		}
+	}
+}
+
+// applyCustomerReplyStateTransition moves a case back to Work In Progress
+// when a customer replies while it's Awaiting Info or Solution Proposed —
+// WSO2 was waiting on the customer, and a reply means it's WSO2's turn to
+// act again. A pure in-process call to s.UpdateCase (not a raw ServiceNow
+// PATCH of its own), so it gets publishStatusChanged/applyCaseStateSLAEffects
+// for free — in particular, applyCaseStateSLAEffects' own "any state other
+// than Awaiting Info/Solution Proposed/Closed resumes both Workaround and
+// Resolution" default case is exactly the right side effect here, with no
+// duplicated logic. Calling UpdateCase with a State equal to the case's
+// current one (a race with some other concurrent state change) is a
+// harmless no-op there — see UpdateCase's own pre-PATCH equality check.
+//
+// Requires its own GetCaseByID call: nothing in CreateCaseComment's own flow
+// surfaces the case's current state today (publishCommentAdded fetches one
+// for its own, separate purpose, but never returns or shares it, and is
+// itself skipped when s.publisher is nil — not something this can rely on).
+//
+// Same role-lookup mechanism as applyResponseSLAOnComment (this service has
+// no auth/identity layer of its own, so "is this comment's author a
+// customer" is answered by resolving the author and checking their
+// ServiceNow role via s.userSvc.SearchUsers), but against a configurable
+// LIST of roles (s.customerRoles, config.Config.CustomerRoles) rather than
+// a single one — an organisation can have more than one customer-facing
+// role. Skips entirely, rather than guessing, when s.customerRoles is empty
+// (unconfigured — see config.Config.CustomerRoles' own doc comment).
+func (s *snCaseService) applyCustomerReplyStateTransition(ctx context.Context, req domain.CreateCaseCommentRequest, commentID string) {
+	if req.Type != domain.CommentTypeComment || len(s.customerRoles) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, applyCustomerReplyTimeout)
+	defer cancel()
+
+	cv, err := s.GetCaseByID(ctx, req.CaseID)
+	if err != nil {
+		slog.ErrorContext(ctx, "sn create comment: customer reply state transition not evaluated, get case failed", "caseId", req.CaseID)
+		return
+	}
+	if cv.State != domain.CaseStateAwaitingInfo && cv.State != domain.CaseStateSolutionProposed {
+		return
+	}
+
+	author := s.resolveCommentAuthor(ctx, req.CaseID, commentID)
+	if author == nil || author.Email == "" {
+		slog.InfoContext(ctx, "sn create comment: customer reply state transition not evaluated, could not resolve comment author's email", "caseId", req.CaseID)
+		return
+	}
+
+	usersResp, err := s.userSvc.SearchUsers(ctx, domain.SearchUsersRequest{
+		Pagination: domain.Pagination{Limit: 1},
+		Filters:    domain.SearchUsersFilters{Emails: []string{author.Email}},
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "sn create comment: customer reply state transition not evaluated, user role lookup failed", "caseId", req.CaseID)
+		return
+	}
+
+	isCustomer := false
+	for _, u := range usersResp.Users {
+		if slices.ContainsFunc(u.Roles, func(r string) bool { return slices.Contains(s.customerRoles, r) }) {
+			isCustomer = true
+			break
+		}
+	}
+	if !isCustomer {
+		return
+	}
+
+	workInProgress := domain.CaseStateWorkInProgress
+	if _, err := s.UpdateCase(ctx, domain.UpdateCaseRequest{ID: req.CaseID, State: &workInProgress}); err != nil {
+		slog.ErrorContext(ctx, "sn create comment: move case to work in progress after customer reply failed", "caseId", req.CaseID)
 	}
 }
 
@@ -2010,6 +2094,7 @@ func (s *snCaseService) CreateCaseComment(ctx context.Context, req domain.Create
 	}
 	s.publishCommentAdded(ctx, req, result.Comment.ID)
 	s.applyResponseSLAOnComment(ctx, req, result.Comment.ID)
+	s.applyCustomerReplyStateTransition(ctx, req, result.Comment.ID)
 	return result, nil
 }
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1391,7 +1391,7 @@ func (s *snCaseService) applyResponseSLAOnComment(ctx context.Context, req domai
 	}
 }
 
-// applyCustomerReplyStateTransition moves a case back to Work In Progress
+// applyCustomerReplyStateTransition moves a case back to Waiting on WSO2
 // when a customer replies while it's Awaiting Info or Solution Proposed —
 // WSO2 was waiting on the customer, and a reply means it's WSO2's turn to
 // act again. A pure in-process call to s.UpdateCase (not a raw ServiceNow
@@ -1409,7 +1409,7 @@ func (s *snCaseService) applyResponseSLAOnComment(ctx context.Context, req domai
 // function's own pre-PATCH block) are not atomic. If the case is moved to
 // some OTHER state (e.g. Closed) in the window between this function's read
 // and UpdateCase's PATCH, this still unconditionally sends
-// State: WorkInProgress — silently reopening a case that was just closed,
+// State: WaitingOnWSO2 — silently reopening a case that was just closed,
 // and resuming SLA clocks applyCaseStateSLAEffects had just paused for
 // Closed. This is not unique to this function: every UpdateCase caller that
 // sets State/Severity/AssigneeEmail (publishStatusChanged/
@@ -1478,9 +1478,9 @@ func (s *snCaseService) applyCustomerReplyStateTransition(ctx context.Context, r
 		return
 	}
 
-	workInProgress := domain.CaseStateWorkInProgress
-	if _, err := s.UpdateCase(ctx, domain.UpdateCaseRequest{ID: req.CaseID, State: &workInProgress}); err != nil {
-		slog.ErrorContext(ctx, "sn create comment: move case to work in progress after customer reply failed", "caseId", req.CaseID)
+	waitingOnWSO2 := domain.CaseStateWaitingOnWSO2
+	if _, err := s.UpdateCase(ctx, domain.UpdateCaseRequest{ID: req.CaseID, State: &waitingOnWSO2}); err != nil {
+		slog.ErrorContext(ctx, "sn create comment: move case to waiting on wso2 after customer reply failed", "caseId", req.CaseID)
 	}
 }
 

--- a/entity-service/internal/service/sn_case_service_create_test.go
+++ b/entity-service/internal/service/sn_case_service_create_test.go
@@ -70,7 +70,7 @@ func TestSNCaseService_CreateCase_EngagementValidation(t *testing.T) {
 	}
 
 	// client is intentionally nil: every case must fail validation before touching it.
-	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -102,7 +102,7 @@ func TestSNCaseService_CreateCase_Engagement(t *testing.T) {
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	req := domain.CreateCaseRequest{
 		Type:                  "engagement",
 		ProjectID:             testProjectUUID,
@@ -160,7 +160,7 @@ func TestSNCaseService_CreateCase_DefaultCaseAliasNormalizesToCase(t *testing.T)
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	req := domain.CreateCaseRequest{
 		Type:              "default_case",
 		ProjectID:         testProjectUUID,
@@ -205,7 +205,7 @@ func TestSNCaseService_CreateCase_SecurityReportAnalysis_AttachmentsOptional(t *
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	req := domain.CreateCaseRequest{
 		Type:              "security_report_analysis",
 		ProjectID:         testProjectUUID,
@@ -246,7 +246,7 @@ func TestSNCaseService_CreateCase_AnnouncementValidation(t *testing.T) {
 	}
 
 	// client is intentionally nil: every case must fail validation before touching it.
-	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -279,7 +279,7 @@ func TestSNCaseService_CreateCase_Announcement(t *testing.T) {
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	req := domain.CreateCaseRequest{
 		Type:        "announcement",
 		ProjectID:   testProjectUUID,

--- a/entity-service/internal/service/sn_case_service_publish_test.go
+++ b/entity-service/internal/service/sn_case_service_publish_test.go
@@ -107,7 +107,7 @@ func TestSNCaseService_CreateCase_PublishesCaseCreated(t *testing.T) {
 
 	client := newTestCreateCaseClient(t, caseSysid, getCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.CreateCaseRequest{
 		Type:              "case",
@@ -198,7 +198,7 @@ func TestSNCaseService_CreateCase_SkipsPublishWhenNoWatchers(t *testing.T) {
 
 	client := newTestCreateCaseClient(t, caseSysid, getCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.CreateCaseRequest{
 		Type:              "case",
@@ -249,7 +249,7 @@ func TestSNCaseService_CreateCase_PublishFailureDoesNotFailCreateCase(t *testing
 
 	client := newTestCreateCaseClient(t, caseSysid, getCaseBody)
 	publisher := &mockEventPublisher{err: errors.New("event hub unreachable")}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.CreateCaseRequest{
 		Type:              "case",
@@ -292,7 +292,7 @@ func TestSNCaseService_CreateCase_NoPublisherConfigured(t *testing.T) {
 			"case": {"id": "` + caseSysid + `", "number": "CS0012001", "createdBy": "jane.doe@example.com", "createdOn": "2026-01-02 10:00:00", "state": {"id": 1, "label": "Open"}}
 		}`))
 	})
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.CreateCaseRequest{
 		Type:              "case",
@@ -379,7 +379,7 @@ func TestSNCaseService_CreateCaseComment_PublishesCommentAdded(t *testing.T) {
 
 	client := newTestCommentClient(t, getCaseBody, createCommentBody, searchCommentsBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.CreateCaseCommentRequest{
 		CaseID:  caseID,
@@ -481,7 +481,7 @@ func TestSNCaseService_CreateCaseComment_WorkNote_FiltersRecipientsToWso2Domain(
 
 	client := newTestCommentClient(t, getCaseBody, createCommentBody, searchCommentsBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.CreateCaseCommentRequest{
 		CaseID:  caseID,
@@ -552,7 +552,7 @@ func TestSNCaseService_CreateCaseComment_WorkNote_SkipsPublishWhenNoWso2Watchers
 
 	client := newTestCommentClient(t, getCaseBody, createCommentBody, searchCommentsBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.CreateCaseCommentRequest{
 		CaseID:  caseID,
@@ -598,7 +598,7 @@ func TestSNCaseService_CreateCaseComment_SkipsPublishWhenNoWatchers(t *testing.T
 
 	client := newTestCommentClient(t, getCaseBody, createCommentBody, `{"comments":[],"offset":0,"limit":20,"totalRecords":0}`)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.CreateCaseCommentRequest{CaseID: caseID, Type: domain.CommentTypeComment, Content: "hi"}
 	if _, err := svc.CreateCaseComment(contextWithUserIDToken("token"), req); err != nil {
@@ -647,7 +647,7 @@ func TestSNCaseService_CreateCaseComment_SkipsPublishWhenAuthorNameUnresolved(t 
 
 	client := newTestCommentClient(t, getCaseBody, createCommentBody, searchCommentsBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.CreateCaseCommentRequest{CaseID: caseID, Type: domain.CommentTypeComment, Content: "hi"}
 	if _, err := svc.CreateCaseComment(contextWithUserIDToken("token"), req); err != nil {
@@ -713,7 +713,7 @@ func TestSNCaseService_UpdateCase_PublishesStatusChanged(t *testing.T) {
 
 	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	newState := domain.CaseStateWorkInProgress
 	req := domain.UpdateCaseRequest{ID: caseID, State: &newState}
@@ -781,7 +781,7 @@ func TestSNCaseService_UpdateCase_SkipsPublishWhenNoWatchers(t *testing.T) {
 
 	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	newState := domain.CaseStateWorkInProgress
 	req := domain.UpdateCaseRequest{ID: caseID, State: &newState}
@@ -830,7 +830,7 @@ func TestSNCaseService_UpdateCase_SkipsPublishWhenStateUnchanged(t *testing.T) {
 
 	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	newState := domain.CaseStateWorkInProgress
 	req := domain.UpdateCaseRequest{ID: caseID, State: &newState}
@@ -878,7 +878,7 @@ func TestSNCaseService_UpdateCase_DoesNotPublishStatusChangedForOtherFields(t *t
 
 	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	assigneeEmail := "alex@example.com"
 	req := domain.UpdateCaseRequest{ID: caseID, AssigneeEmail: &assigneeEmail}
@@ -929,7 +929,7 @@ func TestSNCaseService_UpdateCase_PublishesCaseAssigned(t *testing.T) {
 
 	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	assigneeEmail := "alex@example.com"
 	req := domain.UpdateCaseRequest{ID: caseID, AssigneeEmail: &assigneeEmail}
@@ -1001,7 +1001,7 @@ func TestSNCaseService_UpdateCase_SkipsPublishCaseAssignedWhenNoWatchers(t *test
 
 	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	assigneeEmail := "alex@example.com"
 	req := domain.UpdateCaseRequest{ID: caseID, AssigneeEmail: &assigneeEmail}
@@ -1052,7 +1052,7 @@ func TestSNCaseService_UpdateCase_SkipsPublishCaseAssignedWhenAssigneeUnchanged(
 
 	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	assigneeEmail := "alex@example.com"
 	req := domain.UpdateCaseRequest{ID: caseID, AssigneeEmail: &assigneeEmail}

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -126,7 +126,7 @@ func TestSNCaseService_GetCaseByID_MapsWatchListAutoclosureAndTeams(t *testing.T
 		_, _ = w.Write([]byte(body))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
 	if err != nil {
@@ -230,7 +230,7 @@ func TestSNCaseService_GetCaseByID_MapsParentCaseType(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(newBody("incident")))
 		})
-		svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+		svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 		cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
 		if err != nil {
@@ -249,7 +249,7 @@ func TestSNCaseService_GetCaseByID_MapsParentCaseType(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(newBody("some_future_sn_class")))
 		})
-		svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+		svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 		cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
 		if err != nil {
@@ -289,7 +289,7 @@ func TestSNCaseService_GetCaseByID_MapsRelatedCaseType(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	})
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
 	if err != nil {
@@ -338,7 +338,7 @@ func TestSNCaseService_GetCaseByID_NestsProductUnderDeployedProduct(t *testing.T
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(newBody(`{"id": "` + dpSysid + `", "name": "WSO2 API Manager", "version": "4.5.0"}`)))
 		})
-		cv, err := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "").GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
+		cv, err := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil).GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -359,7 +359,7 @@ func TestSNCaseService_GetCaseByID_NestsProductUnderDeployedProduct(t *testing.T
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(newBody(`{"id": "", "name": "", "version": ""}`)))
 		})
-		cv, err := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "").GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
+		cv, err := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil).GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -401,7 +401,7 @@ func TestSNCaseService_GetCaseByID_BallerinaBlockedFieldsAbsent(t *testing.T) {
 		_, _ = w.Write([]byte(body))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
 	if err != nil {
@@ -487,7 +487,7 @@ func TestSNCaseService_UpdateCase_ExactlyOneFieldValidation(t *testing.T) {
 	}
 
 	// client is intentionally nil: every case must fail validation before touching it.
-	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -566,7 +566,7 @@ func TestSNCaseService_UpdateCase_NewSingleFieldVariants(t *testing.T) {
 				}`))
 			})
 
-			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 			resp, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -704,7 +704,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_ValidationErrors(t *testing.T) {
 		},
 	}
 
-	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "", nil)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req)
@@ -736,7 +736,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_Case(t *testing.T) {
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	// severity and issueType are both mandatory for this target: the backing data source
 	// selects Incident vs Query from the severity, and stores issue type on those records.
 	resp, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
@@ -772,7 +772,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_CaseRequiresSeverityAndIssueType(
 		t.Fatal("backing service must not be called for an incomplete transfer")
 		w.WriteHeader(http.StatusOK)
 	})
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	for name, req := range map[string]domain.UpdateCaseRequest{
 		"missing both":      {ID: testDeploymentUUID, Type: &typ},
@@ -793,7 +793,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_IssueTypeRejectedForOtherTargets(
 		t.Fatal("backing service must not be called for a mismatched transfer")
 		w.WriteHeader(http.StatusOK)
 	})
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	for _, typ := range []string{"engagement", "security_report_analysis"} {
 		t.Run(typ, func(t *testing.T) {
@@ -813,7 +813,7 @@ func TestSNCaseService_UpdateCase_IssueTypeWithoutTypeRejected(t *testing.T) {
 		t.Fatal("backing service must not be called")
 		w.WriteHeader(http.StatusOK)
 	})
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	if _, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
 		ID: testDeploymentUUID, IssueType: &issue,
 	}); err == nil {
@@ -837,7 +837,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_Engagement(t *testing.T) {
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
 		ID: testDeploymentUUID, Type: &typ, EngagementType: &engagement, EngagementPaymentType: &paymentType,
 	})
@@ -869,7 +869,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_SecurityReportAnalysis(t *testing
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
 		ID: testDeploymentUUID, Type: &typ,
 	})
@@ -898,7 +898,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_ServiceRequest(t *testing.T) {
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
 		ID:            testDeploymentUUID,
 		Type:          &typ,
@@ -943,7 +943,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_ServiceRequestRequiresVariables(t
 		w.WriteHeader(http.StatusOK)
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	// The backing data source requires at least one variable for a service request, exactly as
 	// it does at create time. A transfer with none would be rejected downstream, so reject it
 	// here rather than spending the round-trip.
@@ -965,7 +965,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_SeverityRejectedForOtherTargets(t
 		t.Fatal("backing service must not be called for a mismatched transfer")
 		w.WriteHeader(http.StatusOK)
 	})
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	tests := []struct {
 		name string
@@ -1029,7 +1029,7 @@ const (
 // --- UpdateCase: field-count union (including the internal fix-ETA date variants) ---
 
 func TestSNCaseService_UpdateCase_FieldCountValidation(t *testing.T) {
-	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "", nil)
 	closed := domain.CaseStateClosed
 	bestCase := "2026-08-01"
 
@@ -1086,7 +1086,7 @@ func TestSNCaseService_UpdateCase_Close_NoLongerCallsTaskSearch(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	closed := domain.CaseStateClosed
 	if _, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed}); err != nil {
@@ -1103,7 +1103,7 @@ func TestSNCaseService_UpdateCase_Close_NoLongerCallsTaskSearch(t *testing.T) {
 // --- Case tags ---
 
 func TestSNCaseService_AddCaseTag_Validation(t *testing.T) {
-	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	if _, err := svc.AddCaseTag(contextWithUserIDToken("token"), "not-a-uuid", "micro-gw"); err == nil {
 		t.Fatalf("expected error for invalid case id")
@@ -1134,7 +1134,7 @@ func TestSNCaseService_AddCaseTag_Success(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	tag, err := svc.AddCaseTag(contextWithUserIDToken("token"), testCaseUUID, "micro-gw")
 	if err != nil {
@@ -1152,7 +1152,7 @@ func TestSNCaseService_AddCaseTag_Success(t *testing.T) {
 }
 
 func TestSNCaseService_RemoveCaseTag_Validation(t *testing.T) {
-	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	if err := svc.RemoveCaseTag(contextWithUserIDToken("token"), "not-a-uuid", testTagUUID); err == nil {
 		t.Fatalf("expected error for invalid case id")
@@ -1179,7 +1179,7 @@ func TestSNCaseService_RemoveCaseTag_Success(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	if err := svc.RemoveCaseTag(contextWithUserIDToken("token"), testCaseUUID, testTagUUID); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1192,7 +1192,7 @@ func TestSNCaseService_RemoveCaseTag_Success(t *testing.T) {
 // --- Internal-only fix-ETA estimates: best/most-likely/worst case ---
 
 func TestSNCaseService_UpdateCase_FieldCountValidation_InternalFixEtaVariants(t *testing.T) {
-	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "", nil)
 	closed := domain.CaseStateClosed
 	bestCase := "2026-08-02"
 
@@ -1238,7 +1238,7 @@ func TestSNCaseService_UpdateCase_CombinableFieldsCombineInSingleRequest(t *test
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	req := domain.UpdateCaseRequest{
 		ID:               testDeploymentUUID,
 		Subject:          strPtr("Updated subject"),
@@ -1308,7 +1308,7 @@ func TestSNCaseService_UpdateCase_InternalFixEtaVariants_EachIndependentlySettab
 			})
 
 			client := newTestSNClient(t, mux)
-			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 			value := "2026-03-01"
 			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req(value))
@@ -1343,7 +1343,7 @@ func TestSNCaseService_UpdateCase_InternalFixEtaVariants_RejectsMalformedDate(t 
 		},
 	}
 
-	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(nil, nil, nil, noopSLAClockService{}, nil, "", nil)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req)
@@ -1371,7 +1371,7 @@ func TestSNCaseService_GetCaseByID_MapsInternalFixEtaFields(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), testCaseUUID)
 	if err != nil {
@@ -1404,7 +1404,7 @@ func TestSNCaseService_UpdateCase_EchoesInternalFixEtaFieldsBack(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	bestCase := "2026-02-10"
 	resp, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: &bestCase})
@@ -1446,7 +1446,7 @@ func TestSNCaseService_SearchCases_EmptyTypesFilterSendsNoTypeRestriction(t *tes
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	if _, err := svc.SearchCases(contextWithUserIDToken("token"), domain.SearchCasesRequest{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1482,7 +1482,7 @@ func TestSNCaseService_SearchCases_HostingCaseTypesTranslate(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.SearchCasesRequest{
 		Filters: domain.SearchCasesFilters{
@@ -1521,7 +1521,7 @@ func TestSNCaseService_SearchCases_GenericFiltersTranslateToSNPayload(t *testing
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.SearchCasesRequest{
 		Filters: domain.SearchCasesFilters{
@@ -1594,7 +1594,7 @@ func TestSNCaseService_SearchCases_SLABreachedAndAccountEscalationTravelOnTheirO
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.SearchCasesRequest{
 		Filters: domain.SearchCasesFilters{
@@ -1653,7 +1653,7 @@ func TestSNCaseService_SearchCases_CreTeamAndSreTeamFiltersTranslateToSysidsOnTh
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	creUUID := sysidToUUID(testCreTeamSysid)
 	sreUUID := sysidToUUID(testSreTeamSysid)
@@ -1718,7 +1718,7 @@ func TestSNCaseService_SearchCases_ProjectTypeGoesOutAsNamesOnItsOwnKey(t *testi
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.SearchCasesRequest{
 		Filters: domain.SearchCasesFilters{
@@ -1771,7 +1771,7 @@ func TestSNCaseService_SearchCases_StateNotInTranslatesToExcludeStateKeys(t *tes
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.SearchCasesRequest{
 		Filters: domain.SearchCasesFilters{
@@ -1826,7 +1826,7 @@ func TestSNCaseService_SearchCases_StateNotInOmittedWhenUnused(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.SearchCasesRequest{
 		Filters: domain.SearchCasesFilters{
@@ -1853,7 +1853,7 @@ func TestSNCaseService_SearchCases_StateNotInRejectsUnknownValue(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.SearchCasesRequest{
 		Filters: domain.SearchCasesFilters{
@@ -1905,7 +1905,7 @@ func TestSNCaseService_SearchCases_AnyOfKeepsSNOrGroupsWireFormat(t *testing.T) 
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.SearchCasesRequest{
 		Filters: domain.SearchCasesFilters{
@@ -1993,7 +1993,7 @@ func TestSNCaseService_SearchCases_AnyOfBranchTagsFlowToSNOrGroups(t *testing.T)
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.SearchCasesRequest{
 		Filters: domain.SearchCasesFilters{
@@ -2057,7 +2057,7 @@ func TestSNCaseService_SearchCases_AnyOfBranchTagsFlowToSNOrGroups(t *testing.T)
 // reaching the backing service, not silently ignored or forwarded.
 func TestSNCaseService_SearchCases_RejectsBadFilterFieldAndCombo(t *testing.T) {
 	client := newTestSNClient(t, http.NewServeMux())
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
 
 	t.Run("bad field name", func(t *testing.T) {
@@ -2090,7 +2090,7 @@ func TestSNCaseService_SearchCases_RejectsBadFilterFieldAndCombo(t *testing.T) {
 // previously this widened the result set instead of erroring).
 func TestSNCaseService_SearchCases_RejectsUnrecognizedEnumValues(t *testing.T) {
 	client := newTestSNClient(t, http.NewServeMux())
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
 
 	cases := []struct {
@@ -2126,7 +2126,7 @@ func TestSNCaseService_SearchCases_AcceptsAllPreviouslyValidEnumValues(t *testin
 		_ = json.NewEncoder(w).Encode(map[string]any{"cases": []map[string]any{}, "total": 0, "offset": 0, "limit": 20})
 	})
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
 
 	allStates := make([]string, 0, len(validCaseState))
@@ -2186,7 +2186,7 @@ func TestSNCaseService_SearchCases_PopulatesUpdatedOn(t *testing.T) {
 		})
 	})
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
 
 	resp, err := svc.SearchCases(ctx, domain.SearchCasesRequest{})
@@ -2225,7 +2225,7 @@ func TestSNCaseService_SearchCases_SetsIncludeExtendedFields(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	if _, err := svc.SearchCases(contextWithUserIDToken("token"), domain.SearchCasesRequest{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2265,7 +2265,7 @@ func TestSNCaseService_SearchCases_MapsExtendedFieldsWhenPresent(t *testing.T) {
 		})
 	})
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
 
 	resp, err := svc.SearchCases(ctx, domain.SearchCasesRequest{})
@@ -2325,7 +2325,7 @@ func TestSNCaseService_SearchCases_ExtendedFieldsAbsentDoNotPanic(t *testing.T) 
 		})
 	})
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
 
 	resp, err := svc.SearchCases(ctx, domain.SearchCasesRequest{})
@@ -2376,7 +2376,7 @@ func TestSNCaseService_SearchTags_Success(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	tags, err := svc.SearchTags(contextWithUserIDToken("token"), domain.SearchTagsRequest{
 		Filters: domain.SearchTagsFilters{SearchQuery: "micro"},
@@ -2423,7 +2423,7 @@ func TestSNCaseService_SearchTags_ForwardsLimit(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	if _, err := svc.SearchTags(contextWithUserIDToken("token"), domain.SearchTagsRequest{
 		Filters: domain.SearchTagsFilters{SearchQuery: "micro"},
@@ -2445,7 +2445,7 @@ func TestSNCaseService_SearchTags_EmptyQuery(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	tags, err := svc.SearchTags(contextWithUserIDToken("token"), domain.SearchTagsRequest{})
 	if err != nil {
@@ -2471,7 +2471,7 @@ func TestSNCaseService_SearchTags_NeverSendsCaseID(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	if _, err := svc.SearchTags(contextWithUserIDToken("token"), domain.SearchTagsRequest{
 		Filters: domain.SearchTagsFilters{SearchQuery: "micro"},
@@ -2491,7 +2491,7 @@ func TestSNCaseService_SearchTags_QueryTooLong(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	_, err := svc.SearchTags(contextWithUserIDToken("token"), domain.SearchTagsRequest{
 		Filters: domain.SearchTagsFilters{SearchQuery: strings.Repeat("a", 201)},
@@ -2549,7 +2549,7 @@ func TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(newBody(changeRequests)))
 		})
-		svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+		svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 		cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
 		if err != nil {
@@ -2638,7 +2638,7 @@ func TestSNCaseService_GetCaseByID_PopulatesTags(t *testing.T) {
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), testCaseUUID)
 	if err != nil {
@@ -2675,7 +2675,7 @@ func TestSNCaseService_GetCaseByID_TagsFetchFailureDoesNotFailRead(t *testing.T)
 	})
 
 	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), testCaseUUID)
 	if err != nil {

--- a/entity-service/internal/service/sn_case_severity_changed_test.go
+++ b/entity-service/internal/service/sn_case_severity_changed_test.go
@@ -65,7 +65,7 @@ func TestSNCaseService_UpdateCase_PublishesSeverityChanged(t *testing.T) {
 
 	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	newSeverity := domain.CaseSeverityLow
 	req := domain.UpdateCaseRequest{ID: caseID, Severity: &newSeverity}
@@ -149,7 +149,7 @@ func TestSNCaseService_UpdateCase_SkipsPublishSeverityChangedWhenNoWatchers(t *t
 
 	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	newSeverity := domain.CaseSeverityLow
 	req := domain.UpdateCaseRequest{ID: caseID, Severity: &newSeverity}
@@ -198,7 +198,7 @@ func TestSNCaseService_UpdateCase_SkipsPublishSeverityChangedWhenUnchanged(t *te
 
 	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	sameSeverity := domain.CaseSeverityHigh
 	req := domain.UpdateCaseRequest{ID: caseID, Severity: &sameSeverity}
@@ -254,7 +254,7 @@ func TestSNCaseService_UpdateCase_SkipsPublishSeverityChangedWhenPATCHResponseEc
 
 	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
 	publisher := &mockEventPublisher{}
-	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, publisher, noopSLAClockService{}, nil, "", nil)
 
 	newSeverity := domain.CaseSeverityLow
 	req := domain.UpdateCaseRequest{ID: caseID, Severity: &newSeverity}

--- a/entity-service/internal/service/sn_case_variables_test.go
+++ b/entity-service/internal/service/sn_case_variables_test.go
@@ -86,7 +86,7 @@ func TestSNCaseService_GetCaseByID_MapsVariables(t *testing.T) {
 				_, _ = w.Write([]byte(body))
 			})
 
-			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 			cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
 			if err != nil {

--- a/entity-service/internal/service/sn_date_parse_test.go
+++ b/entity-service/internal/service/sn_date_parse_test.go
@@ -91,7 +91,7 @@ func TestSNCaseService_UpdateCase_AlternateDateFormat(t *testing.T) {
 	})
 
 	subject := "Updated subject"
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	resp, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
 		ID:      testDeploymentUUID, // any valid UUID; the request id is not asserted here
 		Subject: &subject,

--- a/entity-service/internal/service/sn_user_reference_test.go
+++ b/entity-service/internal/service/sn_user_reference_test.go
@@ -152,7 +152,7 @@ func TestCaseCommentUserReferenceUpstreamVariants(t *testing.T) {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(tc.body))
 			})
-			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 			resp, err := svc.SearchCaseComments(contextWithUserIDToken("token"), domain.SearchCaseCommentsRequest{
 				CaseID:     sysidToUUID(caseSysid),
@@ -209,7 +209,7 @@ func TestAttachmentUserReference(t *testing.T) {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(tc.body))
 			})
-			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+			svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 			resp, err := svc.SearchCaseAttachments(contextWithUserIDToken("token"), domain.SearchAttachmentsRequest{
 				ReferenceID:   sysidToUUID(caseSysid),
@@ -271,7 +271,7 @@ func TestCaseViewUserReferences(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	})
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(caseSysid))
 	if err != nil {
@@ -362,7 +362,7 @@ func TestCaseActivityUserReference(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	})
-	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	resp, err := svc.SearchCaseActivities(contextWithUserIDToken("token"), domain.SearchCaseActivitiesRequest{
 		CaseID:     sysidToUUID(caseSysid),

--- a/entity-service/internal/service/sn_watch_list_test.go
+++ b/entity-service/internal/service/sn_watch_list_test.go
@@ -106,7 +106,7 @@ func TestSNCaseService_CreateCase_WatchListResolvedToEmails(t *testing.T) {
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	req := domain.CreateCaseRequest{
 		Type:                  "engagement",
@@ -147,7 +147,7 @@ func TestSNCaseService_UpdateCase_WatchListResolvedToEmails(t *testing.T) {
 		}`))
 	})
 
-	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "")
+	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "", nil)
 
 	watchList := []string{testIncidentWatcherUUID1, testIncidentWatcherUUID2}
 	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
@@ -272,7 +272,7 @@ func TestSNCaseService_UpdateCase_WatchListAbsentVsEmpty(t *testing.T) {
 				}`))
 			})
 
-			svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "")
+			svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "", nil)
 			if _, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -371,7 +371,7 @@ func TestSNCaseService_UpdateCase_EmptyWatchListFieldAccounting(t *testing.T) {
 				}`))
 			})
 
-			svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "")
+			svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil, noopSLAClockService{}, nil, "", nil)
 			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req)
 			if tt.wantErr {
 				if _, ok := err.(*apierror.ValidationError); !ok {
@@ -397,7 +397,7 @@ func TestWatchListResolution_UnknownUserID(t *testing.T) {
 	})
 	client := newTestSNClient(t, mux)
 
-	caseSvc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "")
+	caseSvc := NewServiceNowCaseService(client, nil, nil, noopSLAClockService{}, nil, "", nil)
 	incidentSvc := NewServiceNowIncidentService(client, nil)
 	unknown := []string{testIncidentWatcherUUID1, testUnknownWatcherUUID}
 


### PR DESCRIPTION
## Summary
- New env var `CUSTOMER_ROLES` (comma-separated ServiceNow role names, no committed default — same organisation-specific-vocabulary reasoning as the existing `SUPPORT_ENGINEER_ROLE`).
- When a customer-visible comment (not a work note) from a user holding one of those roles arrives while a case is `Awaiting Info`/`Solution Proposed`, `applyCustomerReplyStateTransition` (`sn_case_service.go`, called from `CreateCaseComment`) moves the case back to `Work In Progress`.
- Implemented as a plain in-process call to this service's own `UpdateCase` rather than a second, separate ServiceNow PATCH — this reuses the existing `case.status_changed` publish and the SLA pause/resume side effects (`applyCaseStateSLAEffects`'s `default` branch already resumes Workaround/Resolution on any state other than Awaiting Info/Solution Proposed/Closed) with no duplicated logic.
- Done synchronously/in-process rather than via Azure Event Hub, matching this service's existing SLA pause/resume/completion pattern: nothing in this codebase consumes an event to mutate the case back, Event Hub publishing is optional per-deployment, and this can reuse `UpdateCase` directly only by staying in-process.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean on `entity-service`
- [x] `gosec ./...` clean (0 issues)
- [x] `govulncheck ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Customer-visible replies from users with configured customer roles now move cases from **Awaiting Info** or **Solution Proposed** back to **Work in Progress**.
  - Customer roles can be configured through a comma-separated environment variable.

- **Documentation**
  - Added configuration guidance for customer roles.
  - Documented the customer-reply case state transition and its interaction with SLA tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->