### PR TITLE
[Entity-Service] Port Prevent Closure Of Parent to the Postgres data source

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1876,9 +1876,10 @@ type SearchCasesResponse struct {
 // each other and of every other field in this request. RelatedCaseID, AutocloseHoldUntil,
 // Subject, Description, DeploymentID, DeployedProductID, BestCaseFixEta, MostLikelyFixEta, and
 // WorstCaseFixEta may be combined with each other in any subset within a single request.
-// WatchList, AssigneeEmail, ParentID, RelatedCaseID, AutocloseHoldUntil, Subject, Description,
+// WatchList, AssigneeEmail, RelatedCaseID, AutocloseHoldUntil, Subject, Description,
 // DeploymentID, DeployedProductID, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta
-// are only supported for the ServiceNow data source.
+// are only supported for the ServiceNow data source. ParentID is supported by both the
+// ServiceNow and Postgres data sources.
 // An explicitly empty WatchList clears the case's watch list and counts as a provided field.
 // ResolutionCode, Cause, and CloseNotes are optional resolution fields only allowed when
 // State is closed or solution_proposed.
@@ -1918,10 +1919,12 @@ type UpdateCaseRequest struct {
 	Cause          *CaseCause          `json:"cause"`
 	CloseNotes     *string             `json:"closeNotes"`
 	// ParentID links this case (typically a service request) to another task-derived
-	// record (case, incident, change request, or problem) as its parent. Platform UUID,
-	// converted to the backing data source's internal id before dispatch. This is the
-	// native hierarchical "major case / child case" relationship — subject to the
-	// close-gating rule that rejects closing a case with open children.
+	// record as its parent — the native hierarchical "major case / child case"
+	// relationship the Prevent Closure Of Parent close-gate acts on. A case UUID sets
+	// the link; an empty string clears it. Supported by both data sources: on ServiceNow
+	// the UUID is converted to the backing internal id before dispatch and may point at
+	// a case, incident, change request, or problem; on Postgres it is written to
+	// cases.parent_case_id directly (case-to-case).
 	ParentID *string `json:"parentId"`
 	// RelatedCaseID links this case to another case via a looser, non-hierarchical
 	// cross-link, not subject to any close-gating rule. Platform UUID, converted to the

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -56,6 +56,20 @@ type CaseRepository interface {
 	// closed_at is set to NOW() when transitioning to closed.
 	// Returns a NotFoundError if no matching row exists.
 	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error)
+	// CountNonClosedChildCases returns how many child cases (rows whose
+	// parent_case_id equals parentID) are not in the closed state. It backs the
+	// "Prevent Closure Of Parent" guard in CaseService.UpdateCase: a case may
+	// not be closed while it still has open children. Counts children in any
+	// non-closed state, mirroring the ServiceNow rule (state != closed), not
+	// only "open".
+	CountNonClosedChildCases(ctx context.Context, parentID string) (int, error)
+	// UpdateCaseParent sets or clears the parent link of the case identified by
+	// caseID. A non-nil parentID links this case to that parent (the native
+	// "major case / child case" relationship the Prevent Closure Of Parent guard
+	// acts on); a nil parentID clears the link. Returns a NotFoundError if the
+	// case does not exist, and a ValidationError if a non-nil parentID references
+	// a case that does not exist.
+	UpdateCaseParent(ctx context.Context, caseID string, parentID *string) (domain.Case, error)
 	// CreateCaseAttachment inserts a new attachment metadata row for the case
 	// identified by req.ReferenceID. req.StorageKey must be non-nil: this data
 	// source stores file bytes externally in SFTPGo, never inline in Postgres.
@@ -361,6 +375,63 @@ func (r *caseRepo) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest)
 	}
 	if err != nil {
 		return domain.Case{}, fmt.Errorf("update case: %w", err)
+	}
+	if workStateRaw != nil {
+		ws := domain.CaseWorkState(*workStateRaw)
+		c.WorkState = &ws
+	}
+	return c, nil
+}
+
+// CountNonClosedChildCases implements CaseRepository.
+func (r *caseRepo) CountNonClosedChildCases(ctx context.Context, parentID string) (int, error) {
+	// Counts this parent's children that are not closed. Served by the partial
+	// index idx_cases_open_children (parent_case_id WHERE state <> 'closed'),
+	// which holds exactly these rows -- see
+	// migrations/000015_add_cases_parent_case_id_index.up.sql.
+	const query = `SELECT COUNT(*) FROM cases WHERE parent_case_id = $1 AND state <> 'closed'::case_state_enum`
+	var count int
+	if err := r.db.QueryRow(ctx, query, parentID).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count non-closed child cases: %w", err)
+	}
+	return count, nil
+}
+
+// UpdateCaseParent implements CaseRepository.
+func (r *caseRepo) UpdateCaseParent(ctx context.Context, caseID string, parentID *string) (domain.Case, error) {
+	// parentID is nil to clear the link or a case UUID to set it; $2::uuid
+	// encodes both (NULL::uuid stays NULL). The cases.parent_case_id foreign key
+	// enforces that a non-nil parent actually exists -- a dangling id surfaces as
+	// a foreign_key_violation, mapped to a ValidationError below rather than a 500.
+	const query = `
+		UPDATE cases
+		SET parent_case_id = $2::uuid,
+		    updated_at     = NOW()
+		WHERE id = $1
+		RETURNING id, number, internal_id, created_by, project_id, deployment_id, deployed_product_id,
+		          subject, description, severity, issue_type, state, work_state, created_at, updated_at, closed_at`
+
+	var c domain.Case
+	var workStateRaw *string
+	err := r.db.QueryRow(ctx, query, caseID, parentID).Scan(
+		&c.ID, &c.Number, &c.InternalID, &c.CreatedBy,
+		&c.ProjectID, &c.DeploymentID, &c.DeployedProductID,
+		&c.Subject, &c.Description, &c.Severity, &c.IssueType, &c.State, &workStateRaw,
+		&c.CreatedOn, &c.UpdatedOn, &c.ClosedOn,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.Case{}, &apierror.NotFoundError{Msg: "case not found"}
+	}
+	if err != nil {
+		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case "23503": // foreign_key_violation -- parent_case_id references a case that does not exist
+				return domain.Case{}, &apierror.ValidationError{Msg: "parent case does not exist"}
+			case "P0001": // raise_exception from an integrity trigger
+				return domain.Case{}, &apierror.ValidationError{Msg: pgErr.Message}
+			}
+		}
+		return domain.Case{}, fmt.Errorf("update case parent: %w", err)
 	}
 	if workStateRaw != nil {
 		ws := domain.CaseWorkState(*workStateRaw)

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -20,6 +20,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -369,12 +370,23 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 		return domain.UpdateCaseResponse{}, err
 	}
 	if req.WatchList != nil || req.AssigneeEmail != nil ||
-		req.RelatedCaseID != nil || req.ParentID != nil || req.AutocloseHoldUntil != nil ||
+		req.RelatedCaseID != nil || req.AutocloseHoldUntil != nil ||
 		req.Subject != nil || req.Description != nil || req.DeploymentID != nil || req.DeployedProductID != nil ||
 		req.BestCaseFixEta != nil || req.MostLikelyFixEta != nil || req.WorstCaseFixEta != nil ||
 		req.Type != nil || req.EngagementType != nil || req.CatalogID != nil ||
 		req.CatalogItemID != nil || len(req.Variables) > 0 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList, assigneeEmail, relatedCaseId, parentId, autocloseHoldUntil, subject, description, deploymentId, deployedProductId, bestCaseFixEta, mostLikelyFixEta, worstCaseFixEta, type, engagementType, catalogId, catalogItemId, and variables are only supported for the ServiceNow data source"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList, assigneeEmail, relatedCaseId, autocloseHoldUntil, subject, description, deploymentId, deployedProductId, bestCaseFixEta, mostLikelyFixEta, worstCaseFixEta, type, engagementType, catalogId, catalogItemId, and variables are only supported for the ServiceNow data source"}
+	}
+	// Native parent-linking: parentId is a standalone update on the Postgres data
+	// source -- it links this case to a parent, or clears the link when empty --
+	// and is mutually exclusive with every other field, as on the ServiceNow path.
+	// This is the write counterpart to the Prevent Closure Of Parent guard below:
+	// it is how a parent link comes to exist natively in the first place.
+	if req.ParentID != nil {
+		if req.State != nil || req.Severity != nil || req.WorkState != nil {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "parentId cannot be combined with state, severity, or workState"}
+		}
+		return s.updateCaseParent(ctx, req.ID, *req.ParentID)
 	}
 	fieldCount := 0
 	if req.State != nil {
@@ -401,6 +413,32 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 	if req.WorkState != nil && !validCaseWorkState[*req.WorkState] {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "workState contains invalid value: " + string(*req.WorkState)}
 	}
+	// Prevent Closure Of Parent (ported from the ServiceNow `before` business
+	// rule of the same name, which called current.setAbortAction(true)): a case
+	// may not be closed while any of its child cases is still open. Only the
+	// transition to closed is gated -- every other state change, and severity or
+	// work-state edits, are unaffected. Enforced here in the service layer,
+	// matching the other case invariants, rather than in the UPDATE statement.
+	//
+	// The count and the close are not one transaction, so a child could be linked
+	// to this parent (via the parentId branch above) between them. That is not a
+	// correctness hole: as in ServiceNow, linking an open child under an
+	// already-closed parent is itself allowed, so "closed parent + open child" is a
+	// legitimately reachable state, not a strict invariant this guard promises to
+	// hold. The guard blocks the one path ServiceNow blocked -- closing a parent
+	// that currently has open children -- and nothing more. If the product later
+	// decides that state must never exist, gate the parentId branch too and make
+	// both atomic (an advisory lock keyed on the parent id, as in
+	// scheduled_task_run_repo.Attempt).
+	if req.State != nil && *req.State == domain.CaseStateClosed {
+		openChildren, err := s.repo.CountNonClosedChildCases(ctx, req.ID)
+		if err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		if openChildren > 0 {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "cannot close this case while it has open child cases"}
+		}
+	}
 	c, err := s.repo.UpdateCase(ctx, req)
 	if err != nil {
 		return domain.UpdateCaseResponse{}, err
@@ -415,6 +453,80 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 			WorkState: c.WorkState,
 		},
 	}, nil
+}
+
+// updateCaseParent handles the parentId branch of UpdateCase: it validates the
+// requested parent link and applies it. An empty parentId clears the link; a
+// non-empty one must be a UUID other than the case's own id -- a case cannot be
+// its own parent. The parent's existence is enforced by the foreign key in the
+// repository, which maps a dangling reference to a ValidationError.
+//
+// Faithful to the ServiceNow "Prevent Closure Of Parent" rule, only closing a
+// parent is gated (see UpdateCase); linking an open child under an already-closed
+// parent is not rejected here, matching the source system. Closing that asymmetry
+// would be a deliberate product decision, not a bug fix.
+func (s *caseService) updateCaseParent(ctx context.Context, caseID, parentID string) (domain.UpdateCaseResponse, error) {
+	var parent *string
+	if parentID != "" {
+		if err := validateUUIDs("parentId", []string{parentID}); err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		if parentID == caseID {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "a case cannot be its own parent"}
+		}
+		parent = &parentID
+	}
+	c, err := s.repo.UpdateCaseParent(ctx, caseID, parent)
+	if err != nil {
+		return domain.UpdateCaseResponse{}, err
+	}
+	// Add Work notes on Parent addition (ported from the ServiceNow business rule
+	// of the same name): when a parent is linked, record it on the case timeline
+	// as a work note. Fires only on link, not on clear -- matching the rule ("on
+	// addition"). ServiceNow ran this inside the write transaction; here the link
+	// is the committed result and the note is a best-effort follow-on write, so a
+	// failure to note it (a caller who isn't the internal user the work_note
+	// trigger requires, or who carries no identity token) is logged, never
+	// surfaced, and never undoes the link.
+	if parent != nil {
+		s.addParentLinkedWorkNote(ctx, caseID, parentID)
+	}
+	return domain.UpdateCaseResponse{
+		Message: "Case updated successfully",
+		Case: domain.UpdatedCase{
+			ID:        c.ID,
+			UpdatedOn: c.UpdatedOn,
+			State:     c.State,
+			Severity:  c.Severity,
+			WorkState: c.WorkState,
+		},
+	}, nil
+}
+
+// addParentLinkedWorkNote posts the "parent linked" work note for updateCaseParent.
+// It is deliberately side-effect-only (no error return): the parent link has already
+// committed, and per the rule's port the note must not be able to roll it back. It
+// resolves the acting user (the work_note DB trigger requires an internal author),
+// resolves the parent's human-readable number for a readable note, and logs — rather
+// than fails — if either step or the insert doesn't succeed.
+func (s *caseService) addParentLinkedWorkNote(ctx context.Context, caseID, parentID string) {
+	actor, err := s.resolveActor(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "parent-linked work note skipped: cannot resolve actor", "caseId", caseID, "parentId", parentID, "error", err)
+		return
+	}
+	parentRef := parentID
+	if pv, err := s.repo.GetCaseByID(ctx, parentID); err == nil && pv.Number != "" {
+		parentRef = pv.Number
+	}
+	if _, err := s.repo.CreateCaseComment(ctx, domain.CreateCaseCommentRequest{
+		CaseID:    caseID,
+		CreatedBy: actor.ID,
+		Type:      domain.CommentTypeWorkNote,
+		Content:   "Linked to parent case " + parentRef + ".",
+	}); err != nil {
+		slog.WarnContext(ctx, "parent-linked work note failed", "caseId", caseID, "parentId", parentID, "error", err)
+	}
 }
 
 // SearchCases implements CaseService.

--- a/entity-service/internal/service/case_service_test.go
+++ b/entity-service/internal/service/case_service_test.go
@@ -18,6 +18,8 @@ package service
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,12 +40,20 @@ type stubCaseRepo struct {
 	updateAttachmentName  func(ctx context.Context, id, name, updatedBy string) (time.Time, error)
 	confirmCaseAttachment func(ctx context.Context, id string) (domain.Attachment, error)
 	searchCaseComments    func(ctx context.Context, req domain.SearchCaseCommentsRequest) ([]domain.CaseComment, int, error)
+	updateCase            func(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error)
+	countNonClosedChild   func(ctx context.Context, parentID string) (int, error)
+	updateCaseParent      func(ctx context.Context, caseID string, parentID *string) (domain.Case, error)
+	getCaseByID           func(ctx context.Context, id string) (domain.CaseView, error)
+	createCaseComment     func(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error)
 }
 
 func (s *stubCaseRepo) CreateCase(context.Context, domain.CreateCaseRequest) (domain.Case, error) {
 	panic("not implemented")
 }
-func (s *stubCaseRepo) GetCaseByID(context.Context, string) (domain.CaseView, error) {
+func (s *stubCaseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView, error) {
+	if s.getCaseByID != nil {
+		return s.getCaseByID(ctx, id)
+	}
 	panic("not implemented")
 }
 func (s *stubCaseRepo) SearchCases(ctx context.Context, req domain.SearchCasesRequest) ([]domain.SearchCaseView, int, error) {
@@ -52,7 +62,10 @@ func (s *stubCaseRepo) SearchCases(ctx context.Context, req domain.SearchCasesRe
 	}
 	panic("SearchCases called unexpectedly: the unsupported-field check should have short-circuited before reaching the repository")
 }
-func (s *stubCaseRepo) CreateCaseComment(context.Context, domain.CreateCaseCommentRequest) (domain.CaseComment, error) {
+func (s *stubCaseRepo) CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error) {
+	if s.createCaseComment != nil {
+		return s.createCaseComment(ctx, req)
+	}
 	panic("not implemented")
 }
 func (s *stubCaseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) ([]domain.CaseComment, int, error) {
@@ -61,8 +74,23 @@ func (s *stubCaseRepo) SearchCaseComments(ctx context.Context, req domain.Search
 	}
 	panic("not implemented")
 }
-func (s *stubCaseRepo) UpdateCase(context.Context, domain.UpdateCaseRequest) (domain.Case, error) {
+func (s *stubCaseRepo) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
+	if s.updateCase != nil {
+		return s.updateCase(ctx, req)
+	}
 	panic("not implemented")
+}
+func (s *stubCaseRepo) CountNonClosedChildCases(ctx context.Context, parentID string) (int, error) {
+	if s.countNonClosedChild != nil {
+		return s.countNonClosedChild(ctx, parentID)
+	}
+	panic("CountNonClosedChildCases called unexpectedly")
+}
+func (s *stubCaseRepo) UpdateCaseParent(ctx context.Context, caseID string, parentID *string) (domain.Case, error) {
+	if s.updateCaseParent != nil {
+		return s.updateCaseParent(ctx, caseID, parentID)
+	}
+	panic("UpdateCaseParent called unexpectedly")
 }
 func (s *stubCaseRepo) CreateCaseAttachment(ctx context.Context, req domain.CreateAttachmentRequest) (domain.Attachment, error) {
 	if s.createCaseAttachment != nil {
@@ -479,3 +507,333 @@ func TestCaseService_UpdateCase_RejectsTypeTransferFields(t *testing.T) {
 		})
 	}
 }
+
+// errCountChildren is a sentinel used to prove UpdateCase surfaces a
+// CountNonClosedChildCases failure unchanged rather than swallowing it or
+// misreporting it as a validation error.
+var errCountChildren = errors.New("count children failed")
+
+// TestCaseService_UpdateCase_PreventClosureOfParent covers the ported
+// ServiceNow "Prevent Closure Of Parent" business rule on the native path:
+// a case may not be closed while it still has non-closed child cases, but the
+// close proceeds once none remain, and a lookup failure is surfaced, not
+// swallowed.
+func TestCaseService_UpdateCase_PreventClosureOfParent(t *testing.T) {
+	closed := domain.CaseStateClosed
+	ctx := context.Background()
+
+	t.Run("open children block the close", func(t *testing.T) {
+		gotParent := ""
+		repo := &stubCaseRepo{
+			countNonClosedChild: func(_ context.Context, parentID string) (int, error) {
+				gotParent = parentID
+				return 2, nil
+			},
+			// updateCase intentionally left nil: it must never be reached when the
+			// guard rejects, so a call would panic and fail the test.
+		}
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		_, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{ID: testCaseID, State: &closed})
+
+		var ve *apierror.ValidationError
+		if !asValidationError(err, &ve) {
+			t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+		}
+		if ve.Msg != "cannot close this case while it has open child cases" {
+			t.Fatalf("unexpected message: %q", ve.Msg)
+		}
+		if gotParent != testCaseID {
+			t.Fatalf("expected child count to be queried for %q, got %q", testCaseID, gotParent)
+		}
+	})
+
+	t.Run("no open children allows the close", func(t *testing.T) {
+		updateCalled := false
+		repo := &stubCaseRepo{
+			countNonClosedChild: func(_ context.Context, _ string) (int, error) { return 0, nil },
+			updateCase: func(_ context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
+				updateCalled = true
+				return domain.Case{ID: req.ID, State: domain.CaseStateClosed}, nil
+			},
+		}
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		resp, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{ID: testCaseID, State: &closed})
+		if err != nil {
+			t.Fatalf("expected close to succeed, got error: %v", err)
+		}
+		if !updateCalled {
+			t.Fatal("expected repo.UpdateCase to be called once the guard passes")
+		}
+		if resp.Case.State != domain.CaseStateClosed {
+			t.Fatalf("expected closed state in response, got %q", resp.Case.State)
+		}
+	})
+
+	t.Run("a child-count failure is surfaced, not masked", func(t *testing.T) {
+		repo := &stubCaseRepo{
+			countNonClosedChild: func(_ context.Context, _ string) (int, error) { return 0, errCountChildren },
+		}
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		_, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{ID: testCaseID, State: &closed})
+		if !errors.Is(err, errCountChildren) {
+			t.Fatalf("expected the child-count error to be surfaced, got %T: %v", err, err)
+		}
+		var ve *apierror.ValidationError
+		if asValidationError(err, &ve) {
+			t.Fatal("a lookup failure must not be reported as a validation error")
+		}
+	})
+}
+
+// TestCaseService_UpdateCase_GuardOnlyRunsOnClose proves the parent-closure
+// guard is scoped to the transition to closed: any other state change, a
+// severity change, or a work-state change must not trigger a child-count
+// query. countNonClosedChild is left nil, so it panics if the guard runs when
+// it should not.
+func TestCaseService_UpdateCase_GuardOnlyRunsOnClose(t *testing.T) {
+	ctx := context.Background()
+	wip := domain.CaseStateWorkInProgress
+	reopened := domain.CaseStateReopened
+	high := domain.CaseSeverityHigh
+	paused := domain.CaseWorkStatePaused
+
+	cases := []struct {
+		name string
+		req  domain.UpdateCaseRequest
+	}{
+		{name: "state to work_in_progress", req: domain.UpdateCaseRequest{ID: testCaseID, State: &wip}},
+		{name: "state to reopened", req: domain.UpdateCaseRequest{ID: testCaseID, State: &reopened}},
+		{name: "severity change", req: domain.UpdateCaseRequest{ID: testCaseID, Severity: &high}},
+		{name: "work-state change", req: domain.UpdateCaseRequest{ID: testCaseID, WorkState: &paused}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			updateCalled := false
+			repo := &stubCaseRepo{
+				// countNonClosedChild left nil: it panics if the guard wrongly runs.
+				updateCase: func(_ context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
+					updateCalled = true
+					return domain.Case{ID: req.ID}, nil
+				},
+			}
+			svc := NewCaseService(repo, stubUserRepo{})
+
+			if _, err := svc.UpdateCase(ctx, tc.req); err != nil {
+				t.Fatalf("expected update to succeed without the guard running, got: %v", err)
+			}
+			if !updateCalled {
+				t.Fatal("expected repo.UpdateCase to be reached")
+			}
+		})
+	}
+}
+
+// TestCaseService_UpdateCase_SetParent covers the native parent-linking write
+// path: a lone parentId links or clears the parent, is validated, and is
+// mutually exclusive with state/severity/workState. Repo access is stubbed.
+func TestCaseService_UpdateCase_SetParent(t *testing.T) {
+	ctx := context.Background()
+	parentStr := func(v string) *string { return &v }
+
+	t.Run("valid parent id links the case", func(t *testing.T) {
+		var gotCase string
+		var gotParent *string
+		repo := &stubCaseRepo{
+			updateCaseParent: func(_ context.Context, caseID string, parentID *string) (domain.Case, error) {
+				gotCase, gotParent = caseID, parentID
+				return domain.Case{ID: caseID, State: domain.CaseStateOpen}, nil
+			},
+		}
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		resp, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{ID: testCaseUUID, ParentID: parentStr(testParentCaseUUID)})
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if gotCase != testCaseUUID {
+			t.Fatalf("case id = %q, want %q", gotCase, testCaseUUID)
+		}
+		if gotParent == nil || *gotParent != testParentCaseUUID {
+			t.Fatalf("parent id = %v, want %q", gotParent, testParentCaseUUID)
+		}
+		if resp.Case.ID != testCaseUUID {
+			t.Fatalf("response case id = %q, want %q", resp.Case.ID, testCaseUUID)
+		}
+	})
+
+	t.Run("empty parent id clears the link (nil to repo)", func(t *testing.T) {
+		sawCall := false
+		repo := &stubCaseRepo{
+			updateCaseParent: func(_ context.Context, caseID string, parentID *string) (domain.Case, error) {
+				sawCall = true
+				if parentID != nil {
+					t.Fatalf("expected nil parentID for a clear, got %q", *parentID)
+				}
+				return domain.Case{ID: caseID}, nil
+			},
+		}
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		if _, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{ID: testCaseUUID, ParentID: parentStr("")}); err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if !sawCall {
+			t.Fatal("expected repo.UpdateCaseParent to be called")
+		}
+	})
+
+	t.Run("parentId cannot be combined with a state change", func(t *testing.T) {
+		closed := domain.CaseStateClosed
+		// updateCaseParent left nil: it must not be reached.
+		repo := &stubCaseRepo{}
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		_, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{ID: testCaseUUID, ParentID: parentStr(testParentCaseUUID), State: &closed})
+		var ve *apierror.ValidationError
+		if !asValidationError(err, &ve) {
+			t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+		}
+		if ve.Msg != "parentId cannot be combined with state, severity, or workState" {
+			t.Fatalf("unexpected message: %q", ve.Msg)
+		}
+	})
+
+	t.Run("a non-uuid parent id is rejected", func(t *testing.T) {
+		repo := &stubCaseRepo{} // must not reach the repo
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		_, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{ID: testCaseUUID, ParentID: parentStr("not-a-uuid")})
+		var ve *apierror.ValidationError
+		if !asValidationError(err, &ve) {
+			t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("a case cannot be its own parent", func(t *testing.T) {
+		repo := &stubCaseRepo{} // must not reach the repo
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		_, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{ID: testCaseUUID, ParentID: parentStr(testCaseUUID)})
+		var ve *apierror.ValidationError
+		if !asValidationError(err, &ve) {
+			t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+		}
+		if ve.Msg != "a case cannot be its own parent" {
+			t.Fatalf("unexpected message: %q", ve.Msg)
+		}
+	})
+
+	t.Run("a dangling parent reference surfaces the repo validation error", func(t *testing.T) {
+		repo := &stubCaseRepo{
+			updateCaseParent: func(_ context.Context, _ string, _ *string) (domain.Case, error) {
+				return domain.Case{}, &apierror.ValidationError{Msg: "parent case does not exist"}
+			},
+		}
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		_, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{ID: testCaseUUID, ParentID: parentStr(testParentCaseUUID)})
+		var ve *apierror.ValidationError
+		if !asValidationError(err, &ve) {
+			t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+		}
+		if ve.Msg != "parent case does not exist" {
+			t.Fatalf("unexpected message: %q", ve.Msg)
+		}
+	})
+}
+
+// TestCaseService_UpdateCase_ParentLinkWorkNote covers the ported "Add Work notes
+// on Parent addition" rule: linking a parent posts a work note attributed to the
+// acting user; the link still succeeds if the note can't be written; and clearing a
+// parent (or linking without an identity) posts nothing.
+func TestCaseService_UpdateCase_ParentLinkWorkNote(t *testing.T) {
+	parentStr := func(v string) *string { return &v }
+	actor := domain.User{ID: "aaaaaaaa-0000-0000-0000-000000000001", Email: "agent@wso2.com"}
+	authedCtx := contextWithUserIDToken(fakeJWTWithEmail(t, "agent@wso2.com"))
+
+	t.Run("posts a work note on link, attributed to the actor", func(t *testing.T) {
+		var got domain.CreateCaseCommentRequest
+		repo := &stubCaseRepo{
+			updateCaseParent: func(_ context.Context, caseID string, _ *string) (domain.Case, error) {
+				return domain.Case{ID: caseID, State: domain.CaseStateOpen}, nil
+			},
+			getCaseByID: func(_ context.Context, id string) (domain.CaseView, error) {
+				return domain.CaseView{ID: id, Number: "WSO2-500"}, nil
+			},
+			createCaseComment: func(_ context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error) {
+				got = req
+				return domain.CaseComment{ID: "comment-1"}, nil
+			},
+		}
+		svc := NewCaseService(repo, stubUserRepo{getUserByEmail: func(context.Context, string) (domain.User, error) { return actor, nil }})
+
+		if _, err := svc.UpdateCase(authedCtx, domain.UpdateCaseRequest{ID: testCaseUUID, ParentID: parentStr(testParentCaseUUID)}); err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if got.Type != domain.CommentTypeWorkNote {
+			t.Fatalf("note type = %q, want work_note", got.Type)
+		}
+		if got.CreatedBy != actor.ID {
+			t.Fatalf("note author = %q, want actor %q", got.CreatedBy, actor.ID)
+		}
+		if got.CaseID != testCaseUUID {
+			t.Fatalf("note caseId = %q, want %q", got.CaseID, testCaseUUID)
+		}
+		if got.Content == "" || !contains(got.Content, "WSO2-500") {
+			t.Fatalf("note content should reference the parent number, got %q", got.Content)
+		}
+	})
+
+	t.Run("link still succeeds when the note write fails", func(t *testing.T) {
+		repo := &stubCaseRepo{
+			updateCaseParent: func(_ context.Context, caseID string, _ *string) (domain.Case, error) {
+				return domain.Case{ID: caseID}, nil
+			},
+			getCaseByID: func(_ context.Context, id string) (domain.CaseView, error) {
+				return domain.CaseView{ID: id, Number: "WSO2-500"}, nil
+			},
+			createCaseComment: func(context.Context, domain.CreateCaseCommentRequest) (domain.CaseComment, error) {
+				return domain.CaseComment{}, errCountChildren // any error
+			},
+		}
+		svc := NewCaseService(repo, stubUserRepo{getUserByEmail: func(context.Context, string) (domain.User, error) { return actor, nil }})
+
+		if _, err := svc.UpdateCase(authedCtx, domain.UpdateCaseRequest{ID: testCaseUUID, ParentID: parentStr(testParentCaseUUID)}); err != nil {
+			t.Fatalf("a failed work note must not fail the link; got %v", err)
+		}
+	})
+
+	t.Run("clearing a parent posts no note", func(t *testing.T) {
+		// createCaseComment/getCaseByID left nil: they panic if the note path runs.
+		repo := &stubCaseRepo{
+			updateCaseParent: func(_ context.Context, caseID string, parentID *string) (domain.Case, error) {
+				if parentID != nil {
+					t.Fatalf("expected nil parent for clear")
+				}
+				return domain.Case{ID: caseID}, nil
+			},
+		}
+		svc := NewCaseService(repo, stubUserRepo{})
+		if _, err := svc.UpdateCase(authedCtx, domain.UpdateCaseRequest{ID: testCaseUUID, ParentID: parentStr("")}); err != nil {
+			t.Fatalf("expected clear to succeed, got %v", err)
+		}
+	})
+
+	t.Run("no identity token: link succeeds, note skipped", func(t *testing.T) {
+		// getCaseByID/createCaseComment nil; resolveActor fails first so they're never called.
+		repo := &stubCaseRepo{
+			updateCaseParent: func(_ context.Context, caseID string, _ *string) (domain.Case, error) {
+				return domain.Case{ID: caseID}, nil
+			},
+		}
+		svc := NewCaseService(repo, stubUserRepo{})
+		if _, err := svc.UpdateCase(context.Background(), domain.UpdateCaseRequest{ID: testCaseUUID, ParentID: parentStr(testParentCaseUUID)}); err != nil {
+			t.Fatalf("expected success without a token, got %v", err)
+		}
+	})
+}
+
+func contains(haystack, needle string) bool { return strings.Contains(haystack, needle) }

--- a/entity-service/migrations/000015_add_cases_parent_case_id_index.down.sql
+++ b/entity-service/migrations/000015_add_cases_parent_case_id_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_cases_open_children;

--- a/entity-service/migrations/000015_add_cases_parent_case_id_index.up.sql
+++ b/entity-service/migrations/000015_add_cases_parent_case_id_index.up.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+-- Ports ServiceNow's "Prevent Closure Of Parent" business rule (a `before`
+-- update rule with setAbortAction) into the native Postgres path. That guard
+-- rejects closing a case while any of its child cases is still open; enforcing
+-- it means, on every close, counting the case's non-closed children via
+--   SELECT COUNT(*) FROM cases WHERE parent_case_id = $1 AND state <> 'closed'
+-- (see CaseRepository.CountNonClosedChildCases). parent_case_id has no index
+-- today -- the existing indexes on cases cover the parent direction of the
+-- self-join (pc.id = c.parent_case_id) but not the child direction (looking up
+-- rows BY parent_case_id) -- so without this the guard is a sequential scan on
+-- every close.
+--
+-- A partial index keyed exactly to the guard's predicate: only non-closed
+-- children of a parent can ever block a close, so closed rows and rows with no
+-- parent are excluded. This keeps the index small (it holds only the open
+-- children that matter) and makes the count an index-only lookup.
+CREATE INDEX IF NOT EXISTS idx_cases_open_children
+  ON cases (parent_case_id)
+  WHERE parent_case_id IS NOT NULL AND state <> 'closed';
+
+COMMIT;

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -6901,16 +6901,19 @@ components:
     UpdateCaseRequest:
       type: object
       description: |
-        Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`,
-        `acknowledge`, `type`, or the combinable group (`bestCaseFixEta`, `mostLikelyFixEta`,
-        `worstCaseFixEta`, `workaroundProvided`) must be provided. The single exception is
-        `severity`, which may accompany `type` and is required when `type` is `case`.
+        Exactly one of `state`, `severity`, `workState`, `parentId`, `watchList`,
+        `assigneeEmail`, `acknowledge`, `type`, or the combinable group (`bestCaseFixEta`,
+        `mostLikelyFixEta`, `worstCaseFixEta`, `workaroundProvided`) must be provided. The
+        single exception is `severity`, which may accompany `type` and is required when
+        `type` is `case`.
         The combinable group has no cross-field side effects, so any non-empty subset of its
         four fields may be sent together in one request (e.g. all three fix-ETA estimates plus
         `workaroundProvided` in the same call) — they must not be combined with any of the
         exclusive fields above, though.
         `watchList`, `assigneeEmail`, and the whole combinable group are supported only for the
-        ServiceNow data source.
+        ServiceNow data source; `parentId` is supported by both data sources.
+        Setting `state` to `closed` is rejected when the case still has non-closed child
+        cases (the "Prevent Closure Of Parent" rule).
         `resolutionCode`, `cause`, and `closeNotes` are optional and may only be provided alongside
         `state` when the state is `closed` or `solution_proposed`.
         `type` transfers the case to another type and is supported only for the ServiceNow
@@ -6925,6 +6928,7 @@ components:
         - required: [state]
         - required: [severity]
         - required: [workState]
+        - required: [parentId]
         - required: [watchList]
         - required: [assigneeEmail]
         - required: [acknowledge]
@@ -6992,6 +6996,15 @@ components:
           type: string
           enum: [ongoing, paused]
           description: The new work sub-state of the case. Only applicable when the case state is work_in_progress.
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            Link this case to a parent case (the native "major case / child case"
+            relationship). A case UUID sets the link; an empty string clears it. A case
+            cannot be its own parent, and the referenced parent must exist. Supported by
+            both the ServiceNow and Postgres data sources; must be sent on its own.
         watchList:
           type: array
           items:


### PR DESCRIPTION
## Purpose

Ports two ServiceNow business rules into the native Postgres path, so case parent/child behaviour no longer depends on the ServiceNow data source.

- **Prevent Closure Of Parent** — the ServiceNow `before` update rule that called `current.setAbortAction(true)`. Closing a case is now rejected while it still has non-closed child cases.
- **Add Work notes on Parent addition** — linking a parent records a work note on the case timeline.

To make either rule reachable natively, `parentId` also becomes a supported standalone update on the Postgres data source (it was previously ServiceNow-only).

## Changes

**API (`openapi.yaml`)**
- `parentId` added to `UpdateCaseRequest` as a `oneOf` member: a case UUID sets the link, an empty string clears it.
- Documents that it is supported by both data sources, and that closing a case with open children is rejected.

**Service (`case_service.go`)**
- `parentId` removed from the ServiceNow-only rejection list and given its own branch, mutually exclusive with every other field (as on the ServiceNow path).
- Close-gate: on a transition to `closed`, counts non-closed children and rejects the close if any exist. Only the transition to `closed` is gated — other state changes, severity and work-state edits are untouched.
- `addParentLinkedWorkNote` posts the work note on link only (not on clear). It is best-effort: the link has already committed, so a failure to note it is logged, never surfaced, and never undoes the link.

**Repository (`case_repo.go`)**
- `CountNonClosedChildCases` — backs the close-gate.
- `UpdateCaseParent` — sets/clears `cases.parent_case_id`. A dangling parent surfaces as a `ValidationError` (foreign-key violation mapped) rather than a 500.

**Migration (`000015_add_cases_parent_case_id_index`)**
- Partial index on `cases(parent_case_id)` restricted to non-closed children with a non-null parent — keyed exactly to the close-gate's count predicate, so the guard is an index-only lookup instead of a sequential scan on every close. `parent_case_id` had no index; the existing indexes cover the parent direction of the self-join, not lookups *by* `parent_case_id`.

## Deliberate scoping

Only **closing a parent** is gated, matching the source rule. Linking an open child under an already-closed parent is still allowed, so "closed parent + open child" stays a legitimately reachable state — the count and the close are therefore intentionally not one transaction. Making that a strict invariant would be a product decision, not a bug fix; the code comment records what to change if it is ever taken.

## Testing

- `TestCaseService_UpdateCase_PreventClosureOfParent` — open children block the close, no open children allow it, and a child-count failure is surfaced rather than masked.
- `TestCaseService_UpdateCase_GuardOnlyRunsOnClose` — the child-count stub is left nil so it panics if the guard runs on a non-close update.
- `TestCaseService_UpdateCase_SetParent` — link, clear, non-UUID rejection, self-parent rejection, mutual exclusion, dangling reference.
- `TestCaseService_UpdateCase_ParentLinkWorkNote` — note posted on link and attributed to the actor; link still succeeds when the note write fails; no note on clear; no note without an identity token.

`go build`, `go vet` and `go test ./internal/...` are clean, with one exception: `TestSNCaseService_CreateCase_PublishesCaseCreated` fails, and it **fails identically on `dev-app-csm-portal`** — verified in a clean worktree of the base branch. It is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cases can now be linked to or unlinked from a parent case through the update API.
  * Parent-case relationships are supported for both ServiceNow and PostgreSQL data sources.
  * Cases with open child cases can no longer be closed, helping preserve case hierarchy integrity.
  * Linking a case to a parent may add a work note documenting the relationship.

* **Documentation**
  * Updated API documentation to describe parent-case updates and closure restrictions.

* **Tests**
  * Added coverage for parent linking, clearing relationships, validation, work notes, and closure prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->