### PR TITLE
[Entity-Service] Add a native watch list for Postgres-backed cases

### DIFF
--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -56,6 +56,19 @@ type CaseRepository interface {
 	// closed_at is set to NOW() when transitioning to closed.
 	// Returns a NotFoundError if no matching row exists.
 	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error)
+	// ListCaseWatchers returns the case's watch list, in the order watchers were
+	// added. A watcher need not be a platform user, so an entry's user reference
+	// may carry a null id -- see migration 000017 and domain.WatchListUser.
+	// Returns an empty (non-nil) slice for a case with no watchers, and for a
+	// case that does not exist: the read is a projection, not an existence check.
+	ListCaseWatchers(ctx context.Context, caseID string) ([]domain.WatchListUser, error)
+	// ReplaceCaseWatchers replaces the case's watch list wholesale with the users
+	// named by userIDs, transactionally, and returns the resulting list. An empty
+	// userIDs clears the list. Returns a NotFoundError if the case does not
+	// exist, and a ValidationError if any id names no user or a user with no
+	// email address -- the request is rejected whole rather than partially
+	// applied, so a caller is never silently left with fewer watchers than asked.
+	ReplaceCaseWatchers(ctx context.Context, caseID string, userIDs []string) ([]domain.WatchListUser, error)
 	// CreateCaseAttachment inserts a new attachment metadata row for the case
 	// identified by req.ReferenceID. req.StorageKey must be non-nil: this data
 	// source stores file bytes externally in SFTPGo, never inline in Postgres.
@@ -222,6 +235,14 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 	if rcID != nil {
 		cv.RelatedCase = &domain.CaseNumberRef{ID: *rcID, Number: *rcNum}
 	}
+	// The watch list lives in its own table, so it is a second query rather than
+	// another join: joining it would multiply the case row by the number of
+	// watchers and force every other scanned column to be de-duplicated.
+	watchers, err := listCaseWatchers(ctx, r.db, id)
+	if err != nil {
+		return domain.CaseView{}, err
+	}
+	cv.WatchList = watchers
 	return cv, nil
 }
 

--- a/entity-service/internal/repository/case_watcher_repo.go
+++ b/entity-service/internal/repository/case_watcher_repo.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// watchersQuery reads one case's watch list. The join is LEFT because a watcher
+// need not be a platform user: entries carried over from ServiceNow's collapsed
+// glide_lists may name a group or a bare address, and those rows keep a NULL
+// user_id (see migration 000017).
+//
+// Ordered by added_at so the list reads in the order people were added, with
+// email as the tie-break to keep the order total -- two watchers added in the
+// same transaction share an added_at, and an unstable order would make the
+// response differ between identical reads.
+const watchersQuery = `
+	SELECT w.user_id, w.email,
+	       COALESCE(u.user_name, ''),
+	       COALESCE(TRIM(u.first_name || ' ' || u.last_name), '')
+	FROM case_watchers w
+	LEFT JOIN users u ON u.id = w.user_id
+	WHERE w.case_id = $1
+	ORDER BY w.added_at, w.email`
+
+// listCaseWatchers runs watchersQuery against any query-capable handle, so it
+// serves both the standalone read and the read-back inside ReplaceCaseWatchers'
+// transaction (which must see that transaction's own writes).
+func listCaseWatchers(ctx context.Context, q interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+}, caseID string) ([]domain.WatchListUser, error) {
+	rows, err := q.Query(ctx, watchersQuery, caseID)
+	if err != nil {
+		return nil, fmt.Errorf("query case watchers: %w", err)
+	}
+	defer rows.Close()
+
+	watchers := make([]domain.WatchListUser, 0)
+	for rows.Next() {
+		var userID *string
+		var email, userName, name string
+		if err := rows.Scan(&userID, &email, &userName, &name); err != nil {
+			return nil, fmt.Errorf("scan case watcher: %w", err)
+		}
+		w := domain.WatchListUser{UserName: userName, Name: name, Email: email}
+		// Unlike the ServiceNow path -- which nulls the reference id because a
+		// collapsed glide_list entry might not be a user at all -- a non-NULL
+		// user_id here is a foreign key into users, so the id is known to be a
+		// user's and is emitted. A NULL user_id still yields a null id.
+		if userID != nil {
+			w.ID = *userID
+			w.User = domain.NewUserReference(*userID, email, name)
+		} else {
+			w.User = domain.NewUserReference("", email, name)
+		}
+		watchers = append(watchers, w)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate case watchers: %w", err)
+	}
+	return watchers, nil
+}
+
+// ListCaseWatchers implements CaseRepository.
+func (r *caseRepo) ListCaseWatchers(ctx context.Context, caseID string) ([]domain.WatchListUser, error) {
+	return listCaseWatchers(ctx, r.db, caseID)
+}
+
+// ReplaceCaseWatchers implements CaseRepository.
+//
+// Replacement is wholesale and transactional: the old list is deleted and the
+// resolved users inserted in one transaction, so a concurrent read sees either
+// the whole previous list or the whole new one, never a half-cleared list. An
+// empty userIDs clears the watch list -- that is a legitimate request, not a
+// no-op, which is why the case's existence is checked explicitly rather than
+// inferred from rows having been written.
+func (r *caseRepo) ReplaceCaseWatchers(ctx context.Context, caseID string, userIDs []string) ([]domain.WatchListUser, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("replace case watchers: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var exists bool
+	if err := tx.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM cases WHERE id = $1)`, caseID).Scan(&exists); err != nil {
+		return nil, fmt.Errorf("check case exists: %w", err)
+	}
+	if !exists {
+		return nil, &apierror.NotFoundError{Msg: "case not found"}
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM case_watchers WHERE case_id = $1`, caseID); err != nil {
+		return nil, fmt.Errorf("clear case watchers: %w", err)
+	}
+
+	if len(userIDs) > 0 {
+		// Reject the whole request if any id is unresolvable, before writing
+		// anything: a watch list silently missing a member is worse than a
+		// rejected update, because nobody notices the person who stopped being
+		// notified. An email-less user is unresolvable for the same reason the
+		// ServiceNow path rejects it -- email is what the notification path
+		// consumes, so such an entry could never be delivered to.
+		unresolved, err := unresolvedWatcherIDs(ctx, tx, userIDs)
+		if err != nil {
+			return nil, err
+		}
+		if len(unresolved) > 0 {
+			return nil, &apierror.ValidationError{
+				Msg: "watchList contains users that do not exist or have no email address: " + strings.Join(unresolved, ", "),
+			}
+		}
+
+		// LOWER(u.email) matches the normalisation the (case_id, email) primary
+		// key assumes. ON CONFLICT makes the same user listed twice in one
+		// request a no-op rather than an error -- a duplicate expresses the same
+		// intent as a single mention.
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO case_watchers (case_id, user_id, email)
+			SELECT $1, u.id, LOWER(u.email)
+			FROM users u
+			WHERE u.id = ANY($2::text[])
+			ON CONFLICT (case_id, email) DO NOTHING`, caseID, userIDs); err != nil {
+			if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) && pgErr.Code == "23503" {
+				return nil, &apierror.ValidationError{Msg: "one or more referenced IDs do not exist: " + pgErr.Detail}
+			}
+			return nil, fmt.Errorf("insert case watchers: %w", err)
+		}
+	}
+
+	watchers, err := listCaseWatchers(ctx, tx, caseID)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("replace case watchers: commit: %w", err)
+	}
+	return watchers, nil
+}
+
+// unresolvedWatcherIDs returns the subset of ids that name no user, or a user
+// with no email address. It preserves the caller's order so the error message
+// reads in the order the ids were sent.
+func unresolvedWatcherIDs(ctx context.Context, q interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+}, ids []string) ([]string, error) {
+	rows, err := q.Query(ctx, `
+		SELECT candidate.id
+		FROM unnest($1::text[]) WITH ORDINALITY AS candidate(id, ord)
+		LEFT JOIN users u ON u.id = candidate.id
+		WHERE u.id IS NULL OR COALESCE(TRIM(u.email), '') = ''
+		ORDER BY candidate.ord`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("resolve watch list users: %w", err)
+	}
+	defer rows.Close()
+
+	var unresolved []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan unresolved watch list user: %w", err)
+		}
+		unresolved = append(unresolved, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate unresolved watch list users: %w", err)
+	}
+	return unresolved, nil
+}

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -368,13 +368,24 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
 		return domain.UpdateCaseResponse{}, err
 	}
-	if req.WatchList != nil || req.AssigneeEmail != nil ||
+	if req.AssigneeEmail != nil ||
 		req.RelatedCaseID != nil || req.ParentID != nil || req.AutocloseHoldUntil != nil ||
 		req.Subject != nil || req.Description != nil || req.DeploymentID != nil || req.DeployedProductID != nil ||
 		req.BestCaseFixEta != nil || req.MostLikelyFixEta != nil || req.WorstCaseFixEta != nil ||
 		req.Type != nil || req.EngagementType != nil || req.CatalogID != nil ||
 		req.CatalogItemID != nil || len(req.Variables) > 0 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList, assigneeEmail, relatedCaseId, parentId, autocloseHoldUntil, subject, description, deploymentId, deployedProductId, bestCaseFixEta, mostLikelyFixEta, worstCaseFixEta, type, engagementType, catalogId, catalogItemId, and variables are only supported for the ServiceNow data source"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "assigneeEmail, relatedCaseId, parentId, autocloseHoldUntil, subject, description, deploymentId, deployedProductId, bestCaseFixEta, mostLikelyFixEta, worstCaseFixEta, type, engagementType, catalogId, catalogItemId, and variables are only supported for the ServiceNow data source"}
+	}
+	// Native watch list: watchList is a standalone update on the Postgres data
+	// source, mutually exclusive with every other field exactly as on the
+	// ServiceNow path. It replaces the list wholesale -- a non-nil pointer to an
+	// empty slice clears it, which is why the branch keys on the pointer being
+	// non-nil rather than on the slice being non-empty.
+	if req.WatchList != nil {
+		if req.State != nil || req.Severity != nil || req.WorkState != nil {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList cannot be combined with state, severity, or workState"}
+		}
+		return s.updateCaseWatchList(ctx, req.ID, *req.WatchList)
 	}
 	fieldCount := 0
 	if req.State != nil {
@@ -402,6 +413,44 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "workState contains invalid value: " + string(*req.WorkState)}
 	}
 	c, err := s.repo.UpdateCase(ctx, req)
+	if err != nil {
+		return domain.UpdateCaseResponse{}, err
+	}
+	return domain.UpdateCaseResponse{
+		Message: "Case updated successfully",
+		Case: domain.UpdatedCase{
+			ID:        c.ID,
+			UpdatedOn: c.UpdatedOn,
+			State:     c.State,
+			Severity:  c.Severity,
+			WorkState: c.WorkState,
+		},
+	}, nil
+}
+
+// updateCaseWatchList handles the watchList branch of UpdateCase: it validates
+// the requested watcher ids and replaces the case's watch list with them.
+//
+// Each id must be a platform user UUID. Existence and the presence of an email
+// address are enforced by the repository in the same transaction as the write,
+// so a partially-applied watch list is not reachable: the request either lands
+// whole or is rejected whole. That matters more here than for most fields --
+// a watcher silently dropped from the list is a person who stops being
+// notified, and nobody observes the absence.
+func (s *caseService) updateCaseWatchList(ctx context.Context, caseID string, userIDs []string) (domain.UpdateCaseResponse, error) {
+	if len(userIDs) > 0 {
+		if err := validateUUIDs("watchList", userIDs); err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+	}
+	if _, err := s.repo.ReplaceCaseWatchers(ctx, caseID, userIDs); err != nil {
+		return domain.UpdateCaseResponse{}, err
+	}
+	// The watch list is not a column on cases, so the case row itself is
+	// unchanged and is re-read rather than returned by the write. A case that
+	// vanished between the two is reported as not found, matching every other
+	// update path.
+	c, err := s.repo.GetCaseByID(ctx, caseID)
 	if err != nil {
 		return domain.UpdateCaseResponse{}, err
 	}

--- a/entity-service/internal/service/case_service_test.go
+++ b/entity-service/internal/service/case_service_test.go
@@ -38,13 +38,31 @@ type stubCaseRepo struct {
 	updateAttachmentName  func(ctx context.Context, id, name, updatedBy string) (time.Time, error)
 	confirmCaseAttachment func(ctx context.Context, id string) (domain.Attachment, error)
 	searchCaseComments    func(ctx context.Context, req domain.SearchCaseCommentsRequest) ([]domain.CaseComment, int, error)
+	getCaseByID           func(ctx context.Context, id string) (domain.CaseView, error)
+	listCaseWatchers      func(ctx context.Context, caseID string) ([]domain.WatchListUser, error)
+	replaceCaseWatchers   func(ctx context.Context, caseID string, userIDs []string) ([]domain.WatchListUser, error)
 }
 
 func (s *stubCaseRepo) CreateCase(context.Context, domain.CreateCaseRequest) (domain.Case, error) {
 	panic("not implemented")
 }
-func (s *stubCaseRepo) GetCaseByID(context.Context, string) (domain.CaseView, error) {
+func (s *stubCaseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView, error) {
+	if s.getCaseByID != nil {
+		return s.getCaseByID(ctx, id)
+	}
 	panic("not implemented")
+}
+func (s *stubCaseRepo) ListCaseWatchers(ctx context.Context, caseID string) ([]domain.WatchListUser, error) {
+	if s.listCaseWatchers != nil {
+		return s.listCaseWatchers(ctx, caseID)
+	}
+	panic("not implemented")
+}
+func (s *stubCaseRepo) ReplaceCaseWatchers(ctx context.Context, caseID string, userIDs []string) ([]domain.WatchListUser, error) {
+	if s.replaceCaseWatchers != nil {
+		return s.replaceCaseWatchers(ctx, caseID, userIDs)
+	}
+	panic("ReplaceCaseWatchers called unexpectedly: validation should have short-circuited before reaching the repository")
 }
 func (s *stubCaseRepo) SearchCases(ctx context.Context, req domain.SearchCasesRequest) ([]domain.SearchCaseView, int, error) {
 	if s.searchCases != nil {
@@ -477,5 +495,146 @@ func TestCaseService_UpdateCase_RejectsTypeTransferFields(t *testing.T) {
 				t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
 			}
 		})
+	}
+}
+
+// testWatcherUUID is a platform user UUID used as a watch-list member. It is
+// local to these tests: the watch list is the only case field that takes a list
+// of user ids, so no shared fixture covers it.
+const testWatcherUUID = "66666666-6666-6666-6666-666666666666"
+
+// TestCaseService_UpdateCase_SetWatchList covers the native watch-list write
+// path: a lone watchList replaces or clears the list, its ids are validated as
+// UUIDs, and it is mutually exclusive with state/severity/workState. Repo
+// access is stubbed -- stubCaseRepo.ReplaceCaseWatchers panics unless a test
+// installs it, so a passing rejection case proves the short-circuit rather than
+// a repository that happened to accept the call.
+func TestCaseService_UpdateCase_SetWatchList(t *testing.T) {
+	ctx := context.Background()
+	watchers := func(ids ...string) *[]string { s := append([]string{}, ids...); return &s }
+	okCase := func(_ context.Context, id string) (domain.CaseView, error) {
+		return domain.CaseView{ID: id, State: domain.CaseStateOpen}, nil
+	}
+
+	t.Run("replaces the list with the given users", func(t *testing.T) {
+		var gotCase string
+		var gotIDs []string
+		repo := &stubCaseRepo{
+			replaceCaseWatchers: func(_ context.Context, caseID string, userIDs []string) ([]domain.WatchListUser, error) {
+				gotCase, gotIDs = caseID, userIDs
+				return []domain.WatchListUser{{ID: userIDs[0], Email: "w@example.com"}}, nil
+			},
+			getCaseByID: okCase,
+		}
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		resp, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{
+			ID: testCaseID, WatchList: watchers(testWatcherUUID),
+		})
+		if err != nil {
+			t.Fatalf("expected success, got: %v", err)
+		}
+		if gotCase != testCaseID {
+			t.Errorf("case id: got %q, want %q", gotCase, testCaseID)
+		}
+		if len(gotIDs) != 1 || gotIDs[0] != testWatcherUUID {
+			t.Errorf("watcher ids: got %v, want [%s]", gotIDs, testWatcherUUID)
+		}
+		if resp.Case.ID != testCaseID {
+			t.Errorf("response case id: got %q, want %q", resp.Case.ID, testCaseID)
+		}
+	})
+
+	t.Run("an explicitly empty list clears the watch list", func(t *testing.T) {
+		called := false
+		repo := &stubCaseRepo{
+			replaceCaseWatchers: func(_ context.Context, _ string, userIDs []string) ([]domain.WatchListUser, error) {
+				called = true
+				if len(userIDs) != 0 {
+					t.Errorf("expected no watcher ids, got %v", userIDs)
+				}
+				return nil, nil
+			},
+			getCaseByID: okCase,
+		}
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		if _, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{ID: testCaseID, WatchList: watchers()}); err != nil {
+			t.Fatalf("expected success, got: %v", err)
+		}
+		if !called {
+			t.Fatal("expected an empty watchList to reach the repository as a clear, not be treated as absent")
+		}
+	})
+
+	t.Run("watchList cannot be combined with a state change", func(t *testing.T) {
+		closed := domain.CaseStateClosed
+		svc := NewCaseService(&stubCaseRepo{}, stubUserRepo{})
+
+		_, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{
+			ID: testCaseID, WatchList: watchers(testWatcherUUID), State: &closed,
+		})
+		var ve *apierror.ValidationError
+		if !asValidationError(err, &ve) {
+			t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("a non-uuid watcher id is rejected", func(t *testing.T) {
+		svc := NewCaseService(&stubCaseRepo{}, stubUserRepo{})
+
+		_, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{
+			ID: testCaseID, WatchList: watchers("not-a-uuid"),
+		})
+		var ve *apierror.ValidationError
+		if !asValidationError(err, &ve) {
+			t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("an unresolvable watcher surfaces the repo validation error", func(t *testing.T) {
+		repo := &stubCaseRepo{
+			replaceCaseWatchers: func(context.Context, string, []string) ([]domain.WatchListUser, error) {
+				return nil, &apierror.ValidationError{Msg: "watchList contains users that do not exist or have no email address: " + testWatcherUUID}
+			},
+		}
+		svc := NewCaseService(repo, stubUserRepo{})
+
+		_, err := svc.UpdateCase(ctx, domain.UpdateCaseRequest{
+			ID: testCaseID, WatchList: watchers(testWatcherUUID),
+		})
+		var ve *apierror.ValidationError
+		if !asValidationError(err, &ve) {
+			t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+		}
+	})
+}
+
+// TestCaseService_UpdateCase_WatchListNoLongerServiceNowOnly proves watchList is
+// no longer refused on the Postgres data source. It is the regression guard for
+// the field's removal from the ServiceNow-only rejection list: if that entry
+// creeps back, the request fails validation before reaching the repository and
+// this test fails.
+func TestCaseService_UpdateCase_WatchListNoLongerServiceNowOnly(t *testing.T) {
+	reached := false
+	repo := &stubCaseRepo{
+		replaceCaseWatchers: func(context.Context, string, []string) ([]domain.WatchListUser, error) {
+			reached = true
+			return nil, nil
+		},
+		getCaseByID: func(_ context.Context, id string) (domain.CaseView, error) {
+			return domain.CaseView{ID: id}, nil
+		},
+	}
+	svc := NewCaseService(repo, stubUserRepo{})
+
+	ids := []string{testWatcherUUID}
+	if _, err := svc.UpdateCase(context.Background(), domain.UpdateCaseRequest{
+		ID: testCaseID, WatchList: &ids,
+	}); err != nil {
+		t.Fatalf("expected watchList to be supported on this data source, got: %v", err)
+	}
+	if !reached {
+		t.Fatal("expected the update to reach ReplaceCaseWatchers")
 	}
 }

--- a/entity-service/migrations/000017_create_case_watchers.down.sql
+++ b/entity-service/migrations/000017_create_case_watchers.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS case_watchers;

--- a/entity-service/migrations/000017_create_case_watchers.up.sql
+++ b/entity-service/migrations/000017_create_case_watchers.up.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+-- case_watchers is the native watch list: the people notified about a case
+-- beyond its creator and assignee.
+--
+-- ServiceNow modelled this as four separate glide_lists that Ballerina
+-- collapsed into one on read, and those upstream lists could name groups as
+-- well as users -- which is why domain.WatchListUser carries a nullable User
+-- reference and never promises the entry's id is a user's. This table keeps
+-- that looseness deliberately: user_id is the canonical reference when the
+-- watcher is a known platform user, and NULL when the entry came from a group
+-- or an address with no user record behind it. email is therefore the field
+-- that is always present, and the one the notification path actually consumes.
+CREATE TABLE IF NOT EXISTS case_watchers (
+  case_id  UUID        NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  user_id  TEXT        REFERENCES users(id) ON DELETE SET NULL,
+  email    TEXT        NOT NULL,
+  added_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Keyed on email, not user_id: email is the one column always populated, and
+  -- it is what makes "watch this case" idempotent for an address that has no
+  -- user record. Callers normalise to lower case before writing (see
+  -- CaseRepository.ReplaceCaseWatchers) so the key does not admit case-variant
+  -- duplicates of one address.
+  PRIMARY KEY (case_id, email)
+);
+
+-- ON DELETE CASCADE covers removing a case's watchers with the case; this index
+-- serves the other direction -- finding or clearing one user's watched cases --
+-- which no other index on the table covers. Partial because a NULL user_id
+-- entry can never be found by user.
+CREATE INDEX IF NOT EXISTS idx_case_watchers_user_id
+  ON case_watchers (user_id)
+  WHERE user_id IS NOT NULL;
+
+COMMIT;

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1446,9 +1446,9 @@ paths:
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `severity`,
         `workState`, `watchList`, `assigneeEmail`, `acknowledge`, `bestCaseFixEta`,
-        `mostLikelyFixEta`, or `worstCaseFixEta`. `watchList`, `assigneeEmail`, `bestCaseFixEta`,
+        `mostLikelyFixEta`, or `worstCaseFixEta`. `assigneeEmail`, `bestCaseFixEta`,
         `mostLikelyFixEta`, and `worstCaseFixEta` are supported only when the ServiceNow data
-        source is active.
+        source is active; `watchList` is supported by both data sources.
       operationId: patchCase
       parameters:
         - name: id
@@ -6909,8 +6909,8 @@ components:
         four fields may be sent together in one request (e.g. all three fix-ETA estimates plus
         `workaroundProvided` in the same call) — they must not be combined with any of the
         exclusive fields above, though.
-        `watchList`, `assigneeEmail`, and the whole combinable group are supported only for the
-        ServiceNow data source.
+        `assigneeEmail` and the whole combinable group are supported only for the
+        ServiceNow data source; `watchList` is supported by both.
         `resolutionCode`, `cause`, and `closeNotes` are optional and may only be provided alongside
         `state` when the state is `closed` or `solution_proposed`.
         `type` transfers the case to another type and is supported only for the ServiceNow
@@ -6999,8 +6999,10 @@ components:
             format: uuid
           description: |
             The full set of user identifiers to set as the case watch list, replacing
-            whatever is there (ServiceNow only). An empty array clears the watch list,
-            and counts as providing the field.
+            whatever is there. An empty array clears the watch list, and counts as
+            providing the field. Supported by both data sources; must be sent on its own.
+            Every id must name an existing user that has an email address — the request is
+            rejected whole if any does not, rather than applying the resolvable subset.
         assigneeEmail:
           type: string
           format: email


### PR DESCRIPTION
## Purpose

The watch list existed **only on the ServiceNow path**. On the Postgres data source `watchList` was rejected outright, and no table stored watchers. ServiceNow is being decommissioned, so the watch list has to become native.

This is the storage + API layer. It is deliberately self-contained and does not depend on native event publishing (which does not exist yet — see *Follow-ups*).

## Changes

**Migration `000017_create_case_watchers`**

```sql
case_watchers (case_id UUID FK cases ON DELETE CASCADE,
               user_id TEXT NULL FK users,
               email   TEXT NOT NULL,
               added_at TIMESTAMPTZ,
               PRIMARY KEY (case_id, email))
```

ServiceNow modelled the watch list as **four separate glide_lists** collapsed into one by Ballerina, and those upstream lists could name groups as well as users — which is why `domain.WatchListUser` already carries a nullable user reference. The table preserves that looseness on purpose: `user_id` is a real FK when the watcher is a known platform user, `NULL` otherwise. `email` is therefore the always-present column, and the one the notification path actually consumes.

Keyed on `(case_id, email)`, normalised to lower case, so watching a case is idempotent even for an address with no user record. Partial index on `user_id` serves the other direction (one user's watched cases) — `ON DELETE CASCADE` already covers removal with the case.

**Service (`case_service.go`)**
- `watchList` removed from the ServiceNow-only rejection list and given its own branch, mutually exclusive with every other field.
- A non-nil pointer to an **empty slice clears** the list rather than reading as absent.

**Repository (`case_watcher_repo.go`)**
- `ListCaseWatchers` — LEFT JOIN to users, so non-user entries survive the read.
- `ReplaceCaseWatchers` — transactional wholesale replace. Delete + insert in one transaction, so a concurrent read sees one complete list or the other, never a half-cleared one.

**Native read** — `GetCaseByID` populates the watch list with a second query rather than a join, which would multiply the case row by its watcher count.

## Two decisions worth reviewing

1. **Unresolvable ids reject the whole request** rather than applying the resolvable subset. A watcher silently dropped from the list is a person who stops being notified, and nobody observes the absence — a rejected update is the better failure.
2. **The user reference id is emitted here, unlike on the ServiceNow path.** SN nulls it because a collapsed glide_list entry might not be a user at all; a non-NULL `user_id` here is a foreign key, so the id is known to be a user's. The reason for the null no longer applies.

## Testing

- `TestCaseService_UpdateCase_SetWatchList` — replace, clear-via-empty-list, mutual exclusion with state, non-UUID rejection, unresolvable-watcher error.
- `TestCaseService_UpdateCase_WatchListNoLongerServiceNowOnly` — regression guard for the field's removal from the ServiceNow-only list.

`go build`, `go vet` and `go test ./internal/...` are clean, with one exception: `TestSNCaseService_CreateCase_PublishesCaseCreated` fails, and it **fails identically on `dev-app-csm-portal`** — verified in a clean worktree of the base branch. Unrelated to this change.

## Follow-ups (not in this PR)

- **The native case service publishes no domain events at all.** All 8 publish call sites live in `sn_case_service.go` / `sn_incident_service.go`. Until `case_service.go` publishes `case.created` / `status_changed` / `assigned` / `comment_added`, native watchers are stored and editable but nothing notifies them — and `csm-flow-service` has no native stream to consume.
- The ServiceNow `Watch List` flow (auto-add a commenter to the list) can only be ported once the above lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)