### PR TITLE
[Entity-Service] Native (Postgres) time-cards entity

### DIFF
--- a/entity-service/internal/repository/time_card_repo.go
+++ b/entity-service/internal/repository/time_card_repo.go
@@ -1,0 +1,463 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// TimeCardRepository is the native (Postgres) persistence for time cards.
+// SearchCaseTimeCards (the by-case rollup) is intentionally absent: it is a
+// ServiceNow-only capability, so the service layer rejects it before reaching
+// the repository.
+type TimeCardRepository interface {
+	// CreateTimeCard inserts a time card (in the submitted state) and its
+	// eligible-approver rows atomically, returning the enriched view.
+	CreateTimeCard(ctx context.Context, req domain.CreateTimeCardRequest, submitter string) (domain.TimeCardView, error)
+	// GetTimeCardByID returns the enriched view, or a NotFoundError.
+	GetTimeCardByID(ctx context.Context, id string) (domain.TimeCardView, error)
+	// SearchTimeCards returns a filtered, paginated page of views plus the total
+	// count of matching rows before pagination.
+	SearchTimeCards(ctx context.Context, req domain.SearchTimeCardsRequest) ([]domain.TimeCardView, int, error)
+	// UpdateTimeCardFields edits the mutable fields of a time card (and replaces
+	// its approver set when ApproverIDs is non-nil). Returns a NotFoundError if
+	// the row does not exist.
+	UpdateTimeCardFields(ctx context.Context, req domain.UpdateTimeCardRequest) (domain.TimeCardView, error)
+	// TransitionTimeCard moves a card to approved or rejected, stamping approved_by
+	// (on approve) or rejection_reason (on reject). Returns a NotFoundError if the
+	// row does not exist.
+	TransitionTimeCard(ctx context.Context, id string, state domain.TimeCardState, approvedBy string, rejectionReason *string) (domain.TimeCardView, error)
+	// DeleteTimeCard permanently removes the card (approver rows cascade).
+	DeleteTimeCard(ctx context.Context, id string) error
+}
+
+type timeCardRepo struct {
+	db *pgxpool.Pool
+}
+
+// NewTimeCardRepository constructs a TimeCardRepository backed by the pool.
+func NewTimeCardRepository(db *pgxpool.Pool) TimeCardRepository {
+	return &timeCardRepo{db: db}
+}
+
+// querier is the subset of pgxpool.Pool / pgx.Tx used here, so loadView can run
+// on either the pool or an open transaction.
+type querier interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// timeCardSelectBase selects every column loadTimeCardRows needs, in order.
+// total_time is the sum of the five effort buckets, cast to float8 to match
+// domain.TimeCardView.TotalTime.
+const timeCardSelectBase = `
+	SELECT tc.id, tc.work_date,
+	       (tc.time_analyzing + tc.time_setting_up + tc.time_reproducing_debugging +
+	        tc.time_providing_solution + tc.time_patching)::float8 AS total_time,
+	       tc.is_billable,
+	       tc.time_analyzing, tc.time_setting_up, tc.time_reproducing_debugging,
+	       tc.time_providing_solution, tc.time_patching,
+	       tc.issue_complexity, tc.work_log_comment, tc.rejection_reason, tc.state,
+	       su.id, TRIM(su.first_name || ' ' || su.last_name) AS submitter_name,
+	       ab.id, TRIM(ab.first_name || ' ' || ab.last_name) AS approver_name,
+	       p.id, p.name,
+	       c.id, c.subject, c.number
+	FROM time_cards tc
+	JOIN users su ON su.id = tc.submitter
+	LEFT JOIN users ab ON ab.id = tc.approved_by
+	JOIN projects p ON p.id = tc.project_id
+	JOIN cases c ON c.id = tc.case_id`
+
+// scanTimeCardRow scans one timeCardSelectBase row into a view (approvers are
+// loaded separately by attachApprovers).
+func scanTimeCardRow(row pgx.Row) (domain.TimeCardView, error) {
+	var (
+		v                               domain.TimeCardView
+		workDate                        time.Time
+		issueComplexity, workLogComment *string
+		rejectionReason, state          *string
+		submitterID, submitterName      string
+		approvedByID, approvedByName    *string
+		projectID, projectName          string
+		caseID, caseSubject, caseNumber string
+	)
+	if err := row.Scan(
+		&v.ID, &workDate, &v.TotalTime, &v.HasBillable,
+		&v.TimeAnalyzing, &v.TimeSettingUp, &v.TimeReproducingDebugging,
+		&v.TimeProvidingSolution, &v.TimePatching,
+		&issueComplexity, &workLogComment, &rejectionReason, &state,
+		&submitterID, &submitterName,
+		&approvedByID, &approvedByName,
+		&projectID, &projectName,
+		&caseID, &caseSubject, &caseNumber,
+	); err != nil {
+		return domain.TimeCardView{}, err
+	}
+	dateStr := workDate.Format("2006-01-02")
+	v.WorkDate = dateStr
+	v.CreatedOn = dateStr
+	v.IssueComplexity = issueComplexity
+	v.WorkLogComment = workLogComment
+	v.RejectionReason = rejectionReason
+	v.State = state
+	v.User = &domain.TimeCardRef{ID: submitterID, Name: submitterName}
+	v.Project = &domain.TimeCardRef{ID: projectID, Name: projectName}
+	v.Case = &domain.TimeCardCaseRef{ID: caseID, Name: caseSubject, Number: caseNumber}
+	if approvedByID != nil {
+		name := ""
+		if approvedByName != nil {
+			name = *approvedByName
+		}
+		v.ApprovedBy = &domain.TimeCardRef{ID: *approvedByID, Name: name}
+	}
+	return v, nil
+}
+
+// attachApprovers loads the eligible approvers for every card in views and
+// attaches them. Runs on q so it can share an open transaction.
+func attachApprovers(ctx context.Context, q querier, views []domain.TimeCardView) error {
+	if len(views) == 0 {
+		return nil
+	}
+	ids := make([]string, len(views))
+	for i := range views {
+		ids[i] = views[i].ID
+	}
+	rows, err := q.Query(ctx, `
+		SELECT tca.time_card_id, u.id, TRIM(u.first_name || ' ' || u.last_name)
+		FROM time_card_approvers tca
+		JOIN users u ON u.id = tca.approver_id
+		WHERE tca.time_card_id = ANY($1)`, ids)
+	if err != nil {
+		return fmt.Errorf("load time card approvers: %w", err)
+	}
+	defer rows.Close()
+	byCard := map[string][]domain.TimeCardRef{}
+	for rows.Next() {
+		var cardID, uID, uName string
+		if err := rows.Scan(&cardID, &uID, &uName); err != nil {
+			return fmt.Errorf("scan time card approver: %w", err)
+		}
+		byCard[cardID] = append(byCard[cardID], domain.TimeCardRef{ID: uID, Name: uName})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate time card approvers: %w", err)
+	}
+	for i := range views {
+		if a := byCard[views[i].ID]; len(a) > 0 {
+			views[i].Approvers = a
+		}
+	}
+	return nil
+}
+
+// loadTimeCardByID loads one enriched view (with approvers) on q.
+func (r *timeCardRepo) loadTimeCardByID(ctx context.Context, q querier, id string) (domain.TimeCardView, error) {
+	v, err := scanTimeCardRow(q.QueryRow(ctx, timeCardSelectBase+"\n\tWHERE tc.id = $1", id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.TimeCardView{}, &apierror.NotFoundError{Msg: "time card not found"}
+	}
+	if err != nil {
+		return domain.TimeCardView{}, fmt.Errorf("load time card: %w", err)
+	}
+	views := []domain.TimeCardView{v}
+	if err := attachApprovers(ctx, q, views); err != nil {
+		return domain.TimeCardView{}, err
+	}
+	return views[0], nil
+}
+
+// GetTimeCardByID implements TimeCardRepository.
+func (r *timeCardRepo) GetTimeCardByID(ctx context.Context, id string) (domain.TimeCardView, error) {
+	return r.loadTimeCardByID(ctx, r.db, id)
+}
+
+// CreateTimeCard implements TimeCardRepository.
+func (r *timeCardRepo) CreateTimeCard(ctx context.Context, req domain.CreateTimeCardRequest, submitter string) (domain.TimeCardView, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return domain.TimeCardView{}, fmt.Errorf("create time card: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var id string
+	err = tx.QueryRow(ctx, `
+		INSERT INTO time_cards (
+			case_id, project_id, submitter, work_date, state, is_billable,
+			issue_complexity, work_log_comment,
+			time_analyzing, time_setting_up, time_reproducing_debugging,
+			time_providing_solution, time_patching)
+		VALUES ($1, $2, $3, $4::date, 'submitted', $5, $6, $7, $8, $9, $10, $11, $12)
+		RETURNING id`,
+		req.CaseID, req.ProjectID, submitter, req.Date, req.IsBillable,
+		req.IssueComplexity, req.WorkLogComment,
+		req.TimeAnalyzing, req.TimeSettingUp, req.TimeReproducingDebugging,
+		req.TimeProvidingSolution, req.TimePatching,
+	).Scan(&id)
+	if err != nil {
+		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return domain.TimeCardView{}, &apierror.ValidationError{Msg: "one or more referenced IDs do not exist: " + pgErr.Detail}
+		}
+		return domain.TimeCardView{}, fmt.Errorf("insert time card: %w", err)
+	}
+	if err := insertApprovers(ctx, tx, id, req.ApproverIDs); err != nil {
+		return domain.TimeCardView{}, err
+	}
+	v, err := r.loadTimeCardByID(ctx, tx, id)
+	if err != nil {
+		return domain.TimeCardView{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return domain.TimeCardView{}, fmt.Errorf("create time card: commit: %w", err)
+	}
+	return v, nil
+}
+
+// insertApprovers inserts the eligible-approver rows for a card. Duplicates in
+// the input are ignored (ON CONFLICT DO NOTHING).
+func insertApprovers(ctx context.Context, q querier, cardID string, approverIDs []string) error {
+	for _, aid := range approverIDs {
+		if _, err := q.Exec(ctx, `
+			INSERT INTO time_card_approvers (time_card_id, approver_id)
+			VALUES ($1, $2) ON CONFLICT DO NOTHING`, cardID, aid); err != nil {
+			if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) && pgErr.Code == "23503" {
+				return &apierror.ValidationError{Msg: "approver does not exist: " + aid}
+			}
+			return fmt.Errorf("insert time card approver: %w", err)
+		}
+	}
+	return nil
+}
+
+// UpdateTimeCardFields implements TimeCardRepository.
+func (r *timeCardRepo) UpdateTimeCardFields(ctx context.Context, req domain.UpdateTimeCardRequest) (domain.TimeCardView, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return domain.TimeCardView{}, fmt.Errorf("update time card: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	set := []string{"updated_at = NOW()"}
+	args := []any{req.ID}
+	n := 1
+	add := func(expr string, val any) { n++; set = append(set, fmt.Sprintf(expr, n)); args = append(args, val) }
+	if req.Date != nil {
+		add("work_date = $%d::date", *req.Date)
+	}
+	if req.IsBillable != nil {
+		add("is_billable = $%d", *req.IsBillable)
+	}
+	if req.IssueComplexity != nil {
+		add("issue_complexity = $%d", *req.IssueComplexity)
+	}
+	if req.WorkLogComment != nil {
+		add("work_log_comment = $%d", *req.WorkLogComment)
+	}
+	if req.LeadComment != nil {
+		add("lead_comment = $%d", *req.LeadComment)
+	}
+	if req.TimeAnalyzing != nil {
+		add("time_analyzing = $%d", *req.TimeAnalyzing)
+	}
+	if req.TimeSettingUp != nil {
+		add("time_setting_up = $%d", *req.TimeSettingUp)
+	}
+	if req.TimeReproducingDebugging != nil {
+		add("time_reproducing_debugging = $%d", *req.TimeReproducingDebugging)
+	}
+	if req.TimeProvidingSolution != nil {
+		add("time_providing_solution = $%d", *req.TimeProvidingSolution)
+	}
+	if req.TimePatching != nil {
+		add("time_patching = $%d", *req.TimePatching)
+	}
+
+	tag, err := tx.Exec(ctx, "UPDATE time_cards SET "+strings.Join(set, ", ")+" WHERE id = $1", args...)
+	if err != nil {
+		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) && pgErr.Code == "23514" {
+			return domain.TimeCardView{}, &apierror.ValidationError{Msg: "time buckets must not be negative"}
+		}
+		return domain.TimeCardView{}, fmt.Errorf("update time card: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.TimeCardView{}, &apierror.NotFoundError{Msg: "time card not found"}
+	}
+	if req.ApproverIDs != nil {
+		if _, err := tx.Exec(ctx, `DELETE FROM time_card_approvers WHERE time_card_id = $1`, req.ID); err != nil {
+			return domain.TimeCardView{}, fmt.Errorf("clear time card approvers: %w", err)
+		}
+		if err := insertApprovers(ctx, tx, req.ID, req.ApproverIDs); err != nil {
+			return domain.TimeCardView{}, err
+		}
+	}
+	v, err := r.loadTimeCardByID(ctx, tx, req.ID)
+	if err != nil {
+		return domain.TimeCardView{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return domain.TimeCardView{}, fmt.Errorf("update time card: commit: %w", err)
+	}
+	return v, nil
+}
+
+// TransitionTimeCard implements TimeCardRepository.
+func (r *timeCardRepo) TransitionTimeCard(ctx context.Context, id string, state domain.TimeCardState, approvedBy string, rejectionReason *string) (domain.TimeCardView, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return domain.TimeCardView{}, fmt.Errorf("transition time card: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var approvedByArg any
+	var rejectionArg any
+	if state == domain.TimeCardStateApproved {
+		approvedByArg = approvedBy
+	}
+	if state == domain.TimeCardStateRejected {
+		rejectionArg = rejectionReason
+	}
+	tag, err := tx.Exec(ctx, `
+		UPDATE time_cards
+		SET state = $2::time_card_state_enum,
+		    approved_by = $3,
+		    rejection_reason = $4,
+		    updated_at = NOW()
+		WHERE id = $1`, id, string(state), approvedByArg, rejectionArg)
+	if err != nil {
+		return domain.TimeCardView{}, fmt.Errorf("transition time card: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.TimeCardView{}, &apierror.NotFoundError{Msg: "time card not found"}
+	}
+	v, err := r.loadTimeCardByID(ctx, tx, id)
+	if err != nil {
+		return domain.TimeCardView{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return domain.TimeCardView{}, fmt.Errorf("transition time card: commit: %w", err)
+	}
+	return v, nil
+}
+
+// DeleteTimeCard implements TimeCardRepository.
+func (r *timeCardRepo) DeleteTimeCard(ctx context.Context, id string) error {
+	tag, err := r.db.Exec(ctx, `DELETE FROM time_cards WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete time card: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return &apierror.NotFoundError{Msg: "time card not found"}
+	}
+	return nil
+}
+
+// SearchTimeCards implements TimeCardRepository.
+func (r *timeCardRepo) SearchTimeCards(ctx context.Context, req domain.SearchTimeCardsRequest) ([]domain.TimeCardView, int, error) {
+	where := []string{"1 = 1"}
+	args := []any{}
+	n := 0
+	add := func(expr string, val any) { n++; where = append(where, fmt.Sprintf(expr, n)); args = append(args, val) }
+
+	if f := req.Filters; f != nil {
+		if len(f.ProjectIDs) > 0 {
+			add("tc.project_id = ANY($%d)", f.ProjectIDs)
+		}
+		if f.CaseID != nil {
+			add("tc.case_id = $%d", *f.CaseID)
+		}
+		if f.UserID != nil {
+			add("tc.submitter = $%d", *f.UserID)
+		}
+		if len(f.UserIDs) > 0 {
+			add("tc.submitter = ANY($%d)", f.UserIDs)
+		}
+		if f.ApprovedByID != nil {
+			add("tc.approved_by = $%d", *f.ApprovedByID)
+		}
+		if f.ApproverID != nil {
+			// eligible approver of the card, never the card's own submitter
+			n++
+			where = append(where, fmt.Sprintf("tc.id IN (SELECT time_card_id FROM time_card_approvers WHERE approver_id = $%d) AND tc.submitter <> $%d", n, n))
+			args = append(args, *f.ApproverID)
+		}
+		if f.StartDate != nil {
+			add("tc.work_date >= $%d::date", *f.StartDate)
+		}
+		if f.EndDate != nil {
+			add("tc.work_date <= $%d::date", *f.EndDate)
+		}
+		if len(f.States) > 0 {
+			states := make([]string, len(f.States))
+			for i, s := range f.States {
+				states[i] = string(s)
+			}
+			add("tc.state = ANY($%d::time_card_state_enum[])", states)
+		}
+	}
+	whereSQL := strings.Join(where, " AND ")
+
+	var total int
+	if err := r.db.QueryRow(ctx, `SELECT COUNT(*) FROM time_cards tc WHERE `+whereSQL, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count time cards: %w", err)
+	}
+
+	orderCol := "tc.updated_at"
+	if req.SortBy.Field == domain.TimeCardSortFieldWorkDate {
+		orderCol = "tc.work_date"
+	}
+	orderDir := "DESC"
+	if req.SortBy.Order == domain.TimeCardSortOrderAsc {
+		orderDir = "ASC"
+	}
+	limitArg := n + 1
+	offsetArg := n + 2
+	query := timeCardSelectBase + "\n\tWHERE " + whereSQL +
+		fmt.Sprintf("\n\tORDER BY %s %s\n\tLIMIT $%d OFFSET $%d", orderCol, orderDir, limitArg, offsetArg)
+	args = append(args, req.Pagination.Limit, req.Pagination.Offset)
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("search time cards: %w", err)
+	}
+	defer rows.Close()
+	views := []domain.TimeCardView{}
+	for rows.Next() {
+		v, err := scanTimeCardRow(rows)
+		if err != nil {
+			return nil, 0, fmt.Errorf("scan time card: %w", err)
+		}
+		views = append(views, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate time cards: %w", err)
+	}
+	if err := attachApprovers(ctx, r.db, views); err != nil {
+		return nil, 0, err
+	}
+	return views, total, nil
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -219,9 +219,12 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) (http.Handler, service.Even
 		changeRequestHandler = handler.NewChangeRequestHandler(service.NewServiceNowChangeRequestService(serviceNowIntegrationServiceClient))
 	}
 
+	timeCardRepo := repository.NewTimeCardRepository(db)
 	var timeCardHandler *handler.TimeCardHandler
 	if cfg.DataSource == config.DataSourceServiceNow {
 		timeCardHandler = handler.NewTimeCardHandler(service.NewServiceNowTimeCardService(serviceNowIntegrationServiceClient))
+	} else {
+		timeCardHandler = handler.NewTimeCardHandler(service.NewTimeCardService(timeCardRepo, userRepo))
 	}
 
 	var catalogHandler *handler.CatalogHandler

--- a/entity-service/internal/service/time_card_service.go
+++ b/entity-service/internal/service/time_card_service.go
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/repository"
+)
+
+// timeCardService is the native (Postgres) TimeCardService. Unlike the
+// ServiceNow implementation, ServiceNow enforces no authorization for us here,
+// so the state machine and the "who may do what" rules are enforced in Go:
+//   - a card is created in the submitted state by its submitter;
+//   - only the submitter may edit or delete their own card, and only while it
+//     is still submitted;
+//   - only an eligible approver (never the submitter) may approve or reject a
+//     submitted card.
+//
+// These rules mirror the documented ServiceNow behavior; where the exact rule
+// wasn't recoverable from the SN definition it's marked DECISION and is safe to
+// tune.
+type timeCardService struct {
+	repo     repository.TimeCardRepository
+	userRepo repository.UserRepository
+}
+
+// NewTimeCardService constructs the native TimeCardService.
+func NewTimeCardService(repo repository.TimeCardRepository, userRepo repository.UserRepository) TimeCardService {
+	return &timeCardService{repo: repo, userRepo: userRepo}
+}
+
+var timeCardDateRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+var validTimeCardSortField = map[domain.TimeCardSortField]bool{
+	domain.TimeCardSortFieldUpdatedOn: true,
+	domain.TimeCardSortFieldWorkDate:  true,
+}
+
+var validTimeCardState = map[domain.TimeCardState]bool{
+	domain.TimeCardStatePending:   true,
+	domain.TimeCardStateSubmitted: true,
+	domain.TimeCardStateApproved:  true,
+	domain.TimeCardStateRejected:  true,
+	domain.TimeCardStateProcessed: true,
+	domain.TimeCardStateRecalled:  true,
+}
+
+// resolveTimeCardActor resolves the authenticated caller to a domain.User.
+func (s *timeCardService) resolveActor(ctx context.Context) (domain.User, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.User{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+	email, err := emailFromJWT(token)
+	if err != nil {
+		return domain.User{}, &apierror.ValidationError{Msg: "x-user-id-token: " + err.Error()}
+	}
+	return s.userRepo.GetUserByEmail(ctx, email)
+}
+
+// SearchTimeCards implements TimeCardService.
+func (s *timeCardService) SearchTimeCards(ctx context.Context, req domain.SearchTimeCardsRequest) (domain.SearchTimeCardsResponse, error) {
+	if req.SortBy.Field != "" && !validTimeCardSortField[req.SortBy.Field] {
+		return domain.SearchTimeCardsResponse{}, &apierror.ValidationError{Msg: "sortBy.field contains invalid value: " + string(req.SortBy.Field)}
+	}
+	if req.SortBy.Order != "" && req.SortBy.Order != domain.TimeCardSortOrderAsc && req.SortBy.Order != domain.TimeCardSortOrderDesc {
+		return domain.SearchTimeCardsResponse{}, &apierror.ValidationError{Msg: "sortBy.order contains invalid value: " + string(req.SortBy.Order)}
+	}
+	if req.Filters != nil {
+		for _, st := range req.Filters.States {
+			if !validTimeCardState[st] {
+				return domain.SearchTimeCardsResponse{}, &apierror.ValidationError{Msg: "states contains invalid value: " + string(st)}
+			}
+		}
+	}
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchTimeCardsResponse{}, err
+	}
+	cards, total, err := s.repo.SearchTimeCards(ctx, req)
+	if err != nil {
+		return domain.SearchTimeCardsResponse{}, err
+	}
+	return domain.SearchTimeCardsResponse{
+		TimeCards: cards,
+		Total:     total,
+		Limit:     req.Pagination.Limit,
+		Offset:    req.Pagination.Offset,
+	}, nil
+}
+
+// SearchCaseTimeCards implements TimeCardService. The by-case rollup is a
+// ServiceNow-only capability; the native path does not provide it.
+func (s *timeCardService) SearchCaseTimeCards(_ context.Context, _ domain.SearchTimeCardsRequest) (domain.SearchCaseTimeCardsResponse, error) {
+	return domain.SearchCaseTimeCardsResponse{}, &apierror.ServiceUnavailableError{Msg: "case time-card rollup is only supported for the ServiceNow data source"}
+}
+
+func nonNegativeTimeBucket(field string, v int) error {
+	if v < 0 {
+		return &apierror.ValidationError{Msg: field + " must not be negative"}
+	}
+	return nil
+}
+
+// CreateTimeCard implements TimeCardService.
+func (s *timeCardService) CreateTimeCard(ctx context.Context, req domain.CreateTimeCardRequest) (domain.TimeCardMutationResponse, error) {
+	if req.CaseID == "" {
+		return domain.TimeCardMutationResponse{}, &apierror.ValidationError{Msg: "caseId is required"}
+	}
+	if req.ProjectID == "" {
+		return domain.TimeCardMutationResponse{}, &apierror.ValidationError{Msg: "projectId is required"}
+	}
+	if req.Date == "" || !timeCardDateRe.MatchString(req.Date) {
+		return domain.TimeCardMutationResponse{}, &apierror.ValidationError{Msg: "date is required in YYYY-MM-DD format"}
+	}
+	if len(req.ApproverIDs) == 0 {
+		return domain.TimeCardMutationResponse{}, &apierror.ValidationError{Msg: "approverIds must not be empty"}
+	}
+	for field, v := range map[string]int{
+		"timeAnalyzing": req.TimeAnalyzing, "timeSettingUp": req.TimeSettingUp,
+		"timeReproducingDebugging": req.TimeReproducingDebugging,
+		"timeProvidingSolution":    req.TimeProvidingSolution, "timePatching": req.TimePatching,
+	} {
+		if err := nonNegativeTimeBucket(field, v); err != nil {
+			return domain.TimeCardMutationResponse{}, err
+		}
+	}
+	actor, err := s.resolveActor(ctx)
+	if err != nil {
+		return domain.TimeCardMutationResponse{}, err
+	}
+	// DECISION (verify vs SN): a submitter may not list themselves as an approver.
+	for _, aid := range req.ApproverIDs {
+		if aid == actor.ID {
+			return domain.TimeCardMutationResponse{}, &apierror.ValidationError{Msg: "the submitter cannot be their own approver"}
+		}
+	}
+	card, err := s.repo.CreateTimeCard(ctx, req, actor.ID)
+	if err != nil {
+		return domain.TimeCardMutationResponse{}, err
+	}
+	return domain.TimeCardMutationResponse{Message: "Time card created successfully", TimeCard: &card}, nil
+}
+
+// UpdateTimeCard implements TimeCardService. It is either a field edit (by the
+// submitter, while submitted) or a state transition to approved/rejected (by an
+// eligible approver) -- never both in one request.
+func (s *timeCardService) UpdateTimeCard(ctx context.Context, req domain.UpdateTimeCardRequest) (domain.TimeCardMutationResponse, error) {
+	if err := validateUUIDs("id", []string{req.ID}); err != nil {
+		return domain.TimeCardMutationResponse{}, err
+	}
+	isEdit := req.Date != nil || req.IsBillable != nil || req.IssueComplexity != nil ||
+		req.WorkLogComment != nil || req.ApproverIDs != nil ||
+		req.TimeAnalyzing != nil || req.TimeSettingUp != nil || req.TimeReproducingDebugging != nil ||
+		req.TimeProvidingSolution != nil || req.TimePatching != nil
+	if req.State == nil && !isEdit && req.LeadComment == nil {
+		return domain.TimeCardMutationResponse{}, &apierror.ValidationError{Msg: "no fields to update"}
+	}
+	if req.State != nil && isEdit {
+		return domain.TimeCardMutationResponse{}, &apierror.ValidationError{Msg: "a state transition cannot be combined with field edits"}
+	}
+
+	actor, err := s.resolveActor(ctx)
+	if err != nil {
+		return domain.TimeCardMutationResponse{}, err
+	}
+	current, err := s.repo.GetTimeCardByID(ctx, req.ID)
+	if err != nil {
+		return domain.TimeCardMutationResponse{}, err
+	}
+
+	if req.State != nil {
+		return s.transition(ctx, req, actor, current)
+	}
+
+	// Field edit: submitter only, submitted only.
+	if current.User == nil || current.User.ID != actor.ID {
+		return domain.TimeCardMutationResponse{}, &apierror.ForbiddenError{Msg: "only the submitter can edit their time card"}
+	}
+	if current.State == nil || *current.State != string(domain.TimeCardStateSubmitted) {
+		return domain.TimeCardMutationResponse{}, &apierror.ValidationError{Msg: "only submitted time cards can be edited"}
+	}
+	for field, v := range map[string]*int{
+		"timeAnalyzing": req.TimeAnalyzing, "timeSettingUp": req.TimeSettingUp,
+		"timeReproducingDebugging": req.TimeReproducingDebugging,
+		"timeProvidingSolution":    req.TimeProvidingSolution, "timePatching": req.TimePatching,
+	} {
+		if v != nil {
+			if err := nonNegativeTimeBucket(field, *v); err != nil {
+				return domain.TimeCardMutationResponse{}, err
+			}
+		}
+	}
+	card, err := s.repo.UpdateTimeCardFields(ctx, req)
+	if err != nil {
+		return domain.TimeCardMutationResponse{}, err
+	}
+	return domain.TimeCardMutationResponse{Message: "Time card updated successfully", TimeCard: &card}, nil
+}
+
+// transition handles the approve/reject path of UpdateTimeCard.
+func (s *timeCardService) transition(ctx context.Context, req domain.UpdateTimeCardRequest, actor domain.User, current domain.TimeCardView) (domain.TimeCardMutationResponse, error) {
+	if *req.State != domain.TimeCardStateApproved && *req.State != domain.TimeCardStateRejected {
+		return domain.TimeCardMutationResponse{}, &apierror.ValidationError{Msg: "state must be approved or rejected"}
+	}
+	if current.State == nil || *current.State != string(domain.TimeCardStateSubmitted) {
+		return domain.TimeCardMutationResponse{}, &apierror.ValidationError{Msg: "only submitted time cards can be approved or rejected"}
+	}
+	// approver must be an eligible approver of this card, and never its submitter
+	if current.User != nil && current.User.ID == actor.ID {
+		return domain.TimeCardMutationResponse{}, &apierror.ForbiddenError{Msg: "a submitter cannot approve or reject their own time card"}
+	}
+	eligible := false
+	for _, a := range current.Approvers {
+		if a.ID == actor.ID {
+			eligible = true
+			break
+		}
+	}
+	if !eligible {
+		return domain.TimeCardMutationResponse{}, &apierror.ForbiddenError{Msg: "only an eligible approver can approve or reject this time card"}
+	}
+	// DECISION (verify vs SN): on reject, leadComment carries the rejection reason.
+	card, err := s.repo.TransitionTimeCard(ctx, req.ID, *req.State, actor.ID, req.LeadComment)
+	if err != nil {
+		return domain.TimeCardMutationResponse{}, err
+	}
+	return domain.TimeCardMutationResponse{Message: "Time card " + string(*req.State), TimeCard: &card}, nil
+}
+
+// DeleteTimeCard implements TimeCardService. Submitter only, while submitted.
+func (s *timeCardService) DeleteTimeCard(ctx context.Context, req domain.DeleteTimeCardRequest) (domain.DeleteTimeCardResponse, error) {
+	if err := validateUUIDs("id", []string{req.ID}); err != nil {
+		return domain.DeleteTimeCardResponse{}, err
+	}
+	actor, err := s.resolveActor(ctx)
+	if err != nil {
+		return domain.DeleteTimeCardResponse{}, err
+	}
+	current, err := s.repo.GetTimeCardByID(ctx, req.ID)
+	if err != nil {
+		return domain.DeleteTimeCardResponse{}, err
+	}
+	if current.User == nil || current.User.ID != actor.ID {
+		return domain.DeleteTimeCardResponse{}, &apierror.ForbiddenError{Msg: "only the submitter can delete their time card"}
+	}
+	if current.State == nil || *current.State != string(domain.TimeCardStateSubmitted) {
+		return domain.DeleteTimeCardResponse{}, &apierror.ValidationError{Msg: "only submitted time cards can be deleted"}
+	}
+	if err := s.repo.DeleteTimeCard(ctx, req.ID); err != nil {
+		return domain.DeleteTimeCardResponse{}, err
+	}
+	return domain.DeleteTimeCardResponse{Message: "Time card deleted successfully"}, nil
+}

--- a/entity-service/internal/service/time_card_service_test.go
+++ b/entity-service/internal/service/time_card_service_test.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// stubTimeCardRepo is a configurable repository.TimeCardRepository for the
+// service tests: each method delegates to a func field, or panics if unset.
+type stubTimeCardRepo struct {
+	create     func(ctx context.Context, req domain.CreateTimeCardRequest, submitter string) (domain.TimeCardView, error)
+	getByID    func(ctx context.Context, id string) (domain.TimeCardView, error)
+	search     func(ctx context.Context, req domain.SearchTimeCardsRequest) ([]domain.TimeCardView, int, error)
+	updateFlds func(ctx context.Context, req domain.UpdateTimeCardRequest) (domain.TimeCardView, error)
+	transition func(ctx context.Context, id string, state domain.TimeCardState, approvedBy string, rejectionReason *string) (domain.TimeCardView, error)
+	del        func(ctx context.Context, id string) error
+}
+
+func (s *stubTimeCardRepo) CreateTimeCard(ctx context.Context, req domain.CreateTimeCardRequest, submitter string) (domain.TimeCardView, error) {
+	if s.create != nil {
+		return s.create(ctx, req, submitter)
+	}
+	panic("CreateTimeCard called unexpectedly")
+}
+func (s *stubTimeCardRepo) GetTimeCardByID(ctx context.Context, id string) (domain.TimeCardView, error) {
+	if s.getByID != nil {
+		return s.getByID(ctx, id)
+	}
+	panic("GetTimeCardByID called unexpectedly")
+}
+func (s *stubTimeCardRepo) SearchTimeCards(ctx context.Context, req domain.SearchTimeCardsRequest) ([]domain.TimeCardView, int, error) {
+	if s.search != nil {
+		return s.search(ctx, req)
+	}
+	panic("SearchTimeCards called unexpectedly")
+}
+func (s *stubTimeCardRepo) UpdateTimeCardFields(ctx context.Context, req domain.UpdateTimeCardRequest) (domain.TimeCardView, error) {
+	if s.updateFlds != nil {
+		return s.updateFlds(ctx, req)
+	}
+	panic("UpdateTimeCardFields called unexpectedly")
+}
+func (s *stubTimeCardRepo) TransitionTimeCard(ctx context.Context, id string, state domain.TimeCardState, approvedBy string, rejectionReason *string) (domain.TimeCardView, error) {
+	if s.transition != nil {
+		return s.transition(ctx, id, state, approvedBy, rejectionReason)
+	}
+	panic("TransitionTimeCard called unexpectedly")
+}
+func (s *stubTimeCardRepo) DeleteTimeCard(ctx context.Context, id string) error {
+	if s.del != nil {
+		return s.del(ctx, id)
+	}
+	panic("DeleteTimeCard called unexpectedly")
+}
+
+const (
+	tcSubmitterID = "11111111-1111-1111-1111-111111111111"
+	tcApproverID  = "22222222-2222-2222-2222-222222222222"
+	tcCardID      = "33333333-3333-3333-3333-333333333333"
+)
+
+func tcActorCtx(t *testing.T) context.Context {
+	return contextWithUserIDToken(fakeJWTWithEmail(t, "actor@wso2.com"))
+}
+func tcUserRepo(id string) stubUserRepo {
+	return stubUserRepo{getUserByEmail: func(context.Context, string) (domain.User, error) {
+		return domain.User{ID: id, Email: "actor@wso2.com"}, nil
+	}}
+}
+func strp(s string) *string { return &s }
+func intp(i int) *int       { return &i }
+
+func submittedCard(submitter string, approvers ...string) domain.TimeCardView {
+	st := string(domain.TimeCardStateSubmitted)
+	v := domain.TimeCardView{ID: tcCardID, State: &st, User: &domain.TimeCardRef{ID: submitter}}
+	for _, a := range approvers {
+		v.Approvers = append(v.Approvers, domain.TimeCardRef{ID: a})
+	}
+	return v
+}
+
+func asVErr(t *testing.T, err error) {
+	t.Helper()
+	var ve *apierror.ValidationError
+	if !asValidationError(err, &ve) {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+func asForbidden(t *testing.T, err error) {
+	t.Helper()
+	if _, ok := err.(*apierror.ForbiddenError); !ok {
+		t.Fatalf("expected *apierror.ForbiddenError, got %T: %v", err, err)
+	}
+}
+
+func TestTimeCardService_SearchCaseTimeCards_UnsupportedNatively(t *testing.T) {
+	svc := NewTimeCardService(&stubTimeCardRepo{}, stubUserRepo{})
+	_, err := svc.SearchCaseTimeCards(context.Background(), domain.SearchTimeCardsRequest{})
+	if _, ok := err.(*apierror.ServiceUnavailableError); !ok {
+		t.Fatalf("expected *apierror.ServiceUnavailableError, got %T: %v", err, err)
+	}
+}
+
+func TestTimeCardService_CreateTimeCard_Validation(t *testing.T) {
+	svc := NewTimeCardService(&stubTimeCardRepo{}, tcUserRepo(tcSubmitterID))
+	ctx := tcActorCtx(t)
+	base := func() domain.CreateTimeCardRequest {
+		return domain.CreateTimeCardRequest{CaseID: tcCardID, ProjectID: "proj-1", Date: "2026-09-07", ApproverIDs: []string{tcApproverID}}
+	}
+	t.Run("missing caseId", func(t *testing.T) {
+		r := base()
+		r.CaseID = ""
+		_, err := svc.CreateTimeCard(ctx, r)
+		asVErr(t, err)
+	})
+	t.Run("bad date", func(t *testing.T) {
+		r := base()
+		r.Date = "07/09/2026"
+		_, err := svc.CreateTimeCard(ctx, r)
+		asVErr(t, err)
+	})
+	t.Run("no approvers", func(t *testing.T) {
+		r := base()
+		r.ApproverIDs = nil
+		_, err := svc.CreateTimeCard(ctx, r)
+		asVErr(t, err)
+	})
+	t.Run("negative time", func(t *testing.T) {
+		r := base()
+		r.TimeAnalyzing = -5
+		_, err := svc.CreateTimeCard(ctx, r)
+		asVErr(t, err)
+	})
+	t.Run("submitter as own approver", func(t *testing.T) {
+		r := base()
+		r.ApproverIDs = []string{tcSubmitterID}
+		_, err := svc.CreateTimeCard(ctx, r)
+		asVErr(t, err)
+	})
+	t.Run("happy path creates in submitted state", func(t *testing.T) {
+		called := false
+		repo := &stubTimeCardRepo{create: func(_ context.Context, req domain.CreateTimeCardRequest, submitter string) (domain.TimeCardView, error) {
+			called = true
+			if submitter != tcSubmitterID {
+				t.Fatalf("submitter = %q, want %q", submitter, tcSubmitterID)
+			}
+			return domain.TimeCardView{ID: tcCardID}, nil
+		}}
+		svc := NewTimeCardService(repo, tcUserRepo(tcSubmitterID))
+		resp, err := svc.CreateTimeCard(ctx, base())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called || resp.TimeCard == nil {
+			t.Fatal("expected repo.CreateTimeCard to run and a card to be returned")
+		}
+	})
+}
+
+func TestTimeCardService_UpdateTimeCard_StateMachineAndAuthz(t *testing.T) {
+	closed := domain.TimeCardStateApproved
+	t.Run("state cannot combine with field edits", func(t *testing.T) {
+		svc := NewTimeCardService(&stubTimeCardRepo{}, tcUserRepo(tcApproverID))
+		_, err := svc.UpdateTimeCard(tcActorCtx(t), domain.UpdateTimeCardRequest{ID: tcCardID, State: &closed, IsBillable: func() *bool { b := true; return &b }()})
+		asVErr(t, err)
+	})
+	t.Run("field edit by non-submitter is forbidden", func(t *testing.T) {
+		repo := &stubTimeCardRepo{getByID: func(context.Context, string) (domain.TimeCardView, error) {
+			return submittedCard("someone-else", tcApproverID), nil
+		}}
+		svc := NewTimeCardService(repo, tcUserRepo(tcApproverID))
+		_, err := svc.UpdateTimeCard(tcActorCtx(t), domain.UpdateTimeCardRequest{ID: tcCardID, TimeAnalyzing: intp(10)})
+		asForbidden(t, err)
+	})
+	t.Run("submitter cannot approve own card", func(t *testing.T) {
+		repo := &stubTimeCardRepo{getByID: func(context.Context, string) (domain.TimeCardView, error) {
+			return submittedCard(tcSubmitterID, tcApproverID), nil
+		}}
+		svc := NewTimeCardService(repo, tcUserRepo(tcSubmitterID))
+		_, err := svc.UpdateTimeCard(tcActorCtx(t), domain.UpdateTimeCardRequest{ID: tcCardID, State: &closed})
+		asForbidden(t, err)
+	})
+	t.Run("non-approver cannot approve", func(t *testing.T) {
+		repo := &stubTimeCardRepo{getByID: func(context.Context, string) (domain.TimeCardView, error) {
+			return submittedCard(tcSubmitterID, "other-approver"), nil
+		}}
+		svc := NewTimeCardService(repo, tcUserRepo(tcApproverID))
+		_, err := svc.UpdateTimeCard(tcActorCtx(t), domain.UpdateTimeCardRequest{ID: tcCardID, State: &closed})
+		asForbidden(t, err)
+	})
+	t.Run("eligible approver approves", func(t *testing.T) {
+		repo := &stubTimeCardRepo{
+			getByID: func(context.Context, string) (domain.TimeCardView, error) {
+				return submittedCard(tcSubmitterID, tcApproverID), nil
+			},
+			transition: func(_ context.Context, id string, state domain.TimeCardState, approvedBy string, _ *string) (domain.TimeCardView, error) {
+				if state != domain.TimeCardStateApproved || approvedBy != tcApproverID {
+					t.Fatalf("unexpected transition: state=%v approvedBy=%v", state, approvedBy)
+				}
+				return domain.TimeCardView{ID: id}, nil
+			},
+		}
+		svc := NewTimeCardService(repo, tcUserRepo(tcApproverID))
+		if _, err := svc.UpdateTimeCard(tcActorCtx(t), domain.UpdateTimeCardRequest{ID: tcCardID, State: &closed}); err != nil {
+			t.Fatalf("expected approve to succeed, got %v", err)
+		}
+	})
+	t.Run("state must be approved or rejected", func(t *testing.T) {
+		processed := domain.TimeCardStateProcessed
+		repo := &stubTimeCardRepo{getByID: func(context.Context, string) (domain.TimeCardView, error) {
+			return submittedCard(tcSubmitterID, tcApproverID), nil
+		}}
+		svc := NewTimeCardService(repo, tcUserRepo(tcApproverID))
+		_, err := svc.UpdateTimeCard(tcActorCtx(t), domain.UpdateTimeCardRequest{ID: tcCardID, State: &processed})
+		asVErr(t, err)
+	})
+}
+
+func TestTimeCardService_DeleteTimeCard_Authz(t *testing.T) {
+	t.Run("non-submitter forbidden", func(t *testing.T) {
+		repo := &stubTimeCardRepo{getByID: func(context.Context, string) (domain.TimeCardView, error) {
+			return submittedCard("someone-else"), nil
+		}}
+		svc := NewTimeCardService(repo, tcUserRepo(tcSubmitterID))
+		_, err := svc.DeleteTimeCard(tcActorCtx(t), domain.DeleteTimeCardRequest{ID: tcCardID})
+		asForbidden(t, err)
+	})
+	t.Run("submitter deletes submitted card", func(t *testing.T) {
+		delCalled := false
+		repo := &stubTimeCardRepo{
+			getByID: func(context.Context, string) (domain.TimeCardView, error) { return submittedCard(tcSubmitterID), nil },
+			del:     func(context.Context, string) error { delCalled = true; return nil },
+		}
+		svc := NewTimeCardService(repo, tcUserRepo(tcSubmitterID))
+		if _, err := svc.DeleteTimeCard(tcActorCtx(t), domain.DeleteTimeCardRequest{ID: tcCardID}); err != nil {
+			t.Fatalf("expected delete to succeed, got %v", err)
+		}
+		if !delCalled {
+			t.Fatal("expected repo.DeleteTimeCard to run")
+		}
+	})
+}
+
+// keep strp referenced (used by future edit-path tests)
+var _ = strp

--- a/entity-service/migrations/000016_create_time_cards.down.sql
+++ b/entity-service/migrations/000016_create_time_cards.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS time_card_approvers;
+DROP TABLE IF EXISTS time_cards;
+DROP TYPE IF EXISTS time_card_state_enum;

--- a/entity-service/migrations/000016_create_time_cards.up.sql
+++ b/entity-service/migrations/000016_create_time_cards.up.sql
@@ -1,0 +1,63 @@
+BEGIN;
+
+-- Native time-card entity. Until now time cards were served only through the
+-- ServiceNow passthrough (sn_time_card_service.go); this is their Postgres home.
+-- A time card logs effort against a case, in five effort buckets, moving through
+-- submitted -> approved/rejected. is_billable is the per-card flag the "TimeCard
+-- billable/non-billable" case-type rules key off.
+--
+-- NOTE ON FK TYPES: users.id and projects.id are TEXT (see 000001, 000003), so
+-- the user/project references here are TEXT. cases.id is UUID, so case_id is UUID.
+-- (The cases table declares created_by/project_id as UUID against those TEXT PKs,
+-- which is a pre-existing inconsistency; this table references each PK with its
+-- actual type so the constraints apply.)
+CREATE TYPE time_card_state_enum AS ENUM (
+  'pending', 'submitted', 'approved', 'rejected', 'processed', 'recalled'
+);
+
+CREATE TABLE time_cards (
+  id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id                    UUID NOT NULL REFERENCES cases(id),
+  project_id                 TEXT NOT NULL REFERENCES projects(id),
+  submitter                  TEXT NOT NULL REFERENCES users(id),
+  work_date                  DATE NOT NULL,
+  state                      time_card_state_enum NOT NULL DEFAULT 'submitted',
+  is_billable                BOOLEAN NOT NULL DEFAULT FALSE,
+  issue_complexity           TEXT NULL,
+  work_log_comment           TEXT NULL,
+  lead_comment               TEXT NULL,
+  rejection_reason           TEXT NULL,
+  -- effort buckets, in minutes; non-negative
+  time_analyzing             INTEGER NOT NULL DEFAULT 0 CHECK (time_analyzing >= 0),
+  time_setting_up            INTEGER NOT NULL DEFAULT 0 CHECK (time_setting_up >= 0),
+  time_reproducing_debugging INTEGER NOT NULL DEFAULT 0 CHECK (time_reproducing_debugging >= 0),
+  time_providing_solution    INTEGER NOT NULL DEFAULT 0 CHECK (time_providing_solution >= 0),
+  time_patching              INTEGER NOT NULL DEFAULT 0 CHECK (time_patching >= 0),
+  approved_by                TEXT NULL REFERENCES users(id),
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- rejection_reason only makes sense on a rejected card
+  CONSTRAINT chk_time_card_rejection
+    CHECK (rejection_reason IS NULL OR state = 'rejected'),
+  -- approved_by only set once approved
+  CONSTRAINT chk_time_card_approved_by
+    CHECK (approved_by IS NULL OR state = 'approved')
+);
+
+-- Eligible approvers (SN's approver_list): many candidate approvers per card,
+-- distinct from approved_by (the one who actually approved).
+CREATE TABLE time_card_approvers (
+  time_card_id UUID NOT NULL REFERENCES time_cards(id) ON DELETE CASCADE,
+  approver_id  TEXT NOT NULL REFERENCES users(id),
+  PRIMARY KEY (time_card_id, approver_id)
+);
+
+CREATE INDEX idx_time_cards_case_id        ON time_cards(case_id);
+CREATE INDEX idx_time_cards_project_id     ON time_cards(project_id);
+CREATE INDEX idx_time_cards_submitter      ON time_cards(submitter);
+CREATE INDEX idx_time_cards_state          ON time_cards(state);
+CREATE INDEX idx_time_cards_work_date      ON time_cards(work_date);
+CREATE INDEX idx_time_cards_approved_by    ON time_cards(approved_by) WHERE approved_by IS NOT NULL;
+CREATE INDEX idx_time_card_approvers_appr  ON time_card_approvers(approver_id);
+
+COMMIT;

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3461,7 +3461,7 @@ paths:
 
   /time-cards/search:
     post:
-      summary: Search time cards (ServiceNow data source only).
+      summary: Search time cards.
       operationId: searchTimeCards
       requestBody:
         required: true
@@ -3497,7 +3497,7 @@ paths:
 
   /time-cards:
     post:
-      summary: Create a time card in the submitted state (ServiceNow data source only).
+      summary: Create a time card in the submitted state.
       operationId: createTimeCard
       requestBody:
         required: true
@@ -3533,7 +3533,7 @@ paths:
 
   /time-cards/{id}:
     patch:
-      summary: Update an editable (submitted) time card (ServiceNow data source only).
+      summary: Update an editable (submitted) time card.
       operationId: updateTimeCard
       parameters:
         - name: id
@@ -3580,7 +3580,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
     delete:
-      summary: Delete a time card (ServiceNow data source only).
+      summary: Delete a time card.
       description: >
         Only validates that id is a well-formed UUID; ServiceNow enforces
         that the caller is the card's own submitter and that it's still in


### PR DESCRIPTION
## Summary

Adds a native time-cards implementation so time cards no longer require the ServiceNow passthrough:

- **migration 000016**: `time_cards` + `time_card_approvers`, state enum, indexes, checks
- **`TimeCardRepository`** (pgx): create/get/search/update/transition/delete
- **native `TimeCardService`**: validation, submitted-on-create, approve/reject state machine, submitter/approver authorization; `SearchCaseTimeCards` stays ServiceNow-only
- **routes**: use the native service under the Postgres data source
- **openapi**: drop `(ServiceNow data source only)` from the four endpoints this makes native
- table-driven service tests

Prerequisite for the billable/non-billable case-type rule (see Follow-ups).

## No new API — a second backend for the existing one

The routes, handler and OpenAPI contract already existed; they were served by `sn_time_card_service.go`, which forwarded every call to ServiceNow. This adds a second implementation behind the same `TimeCardService` interface, selected once at startup by `cfg.DataSource`:

```
POST /time-cards → TimeCardHandler → TimeCardService (interface)
                                       ├── ServiceNowTimeCardService → HTTP → ServiceNow
                                       └── timeCardService (NEW)     → SQL  → Postgres
```

Callers send identical requests either way. Neither the repository nor the service imports anything ServiceNow-related — no outbound HTTP, no integration-service client. `x-user-id-token` is the platform's own caller-identity header (decoded locally, user resolved from the Postgres `users` table), not a ServiceNow dependency.

## Spec changes

Four endpoint summaries claimed `(ServiceNow data source only)` and were made false by this change — corrected:

| Endpoint | Now |
|---|---|
| `POST /time-cards` | native |
| `POST /time-cards/search` | native |
| `PATCH /time-cards/{id}` | native |
| `DELETE /time-cards/{id}` | native |
| `POST /cases/time-cards/search` | **still ServiceNow-only** — summary unchanged, and it already documents the `503` |

## Schema note

`users.id` and `projects.id` are `TEXT` (migrations 000001 / 000003), so the user and project references here are `TEXT`; `case_id` is `UUID` because `cases.id` is.

This matches the convention in `000009_create_case_comments` and `000012_create_case_attachments`, which also reference `users(id)` as `TEXT`. It deliberately does **not** match `000006` / `000008`, which declare `UUID` columns against those `TEXT` primary keys — a pre-existing inconsistency, out of scope here.

## Testing

`go build`, `go vet` and `go test ./internal/service/ -run TestTimeCard` are clean — 4 test functions, 14 subtests covering create validation, the approve/reject state machine, submitter/approver authorization, and delete authorization.

Full `go test ./internal/...` is clean with one exception: `TestSNCaseService_CreateCase_PublishesCaseCreated` fails, and it **fails identically on `dev-app-csm-portal`** — verified in a clean worktree of the base branch. Unrelated to this change.

The migration was **not** applied against a live database — no Postgres or Docker in this environment. Verified statically only (FK type compatibility against the referenced primary keys; `down` drops in reverse dependency order). Worth a real up/down run before merge.

## Follow-ups

1. **Billable/non-billable case-type cascade.** Needs native `u_case_type` first, then a cascade in `case_service.UpdateCase`: billable ← Query; non-billable ← Incident, Security Report Analysis, Service Request, Engagement.
2. ~~Confirm a `DELETE /time-cards/{id}` route exists.~~ **Confirmed — already exists** at `internal/server/routes.go:476`, now resolving to the native service.
3. **The `DECISION`-marked authorization rules need checking against the ServiceNow definition** — particularly who may edit a card after submission and who may approve.
4. **Check whether anything actually calls `POST /cases/time-cards/search`** (portal, microapp). It returns 503 on Postgres, so a live caller would break at cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)