### PR TITLE
[CSM Portal] time card Engineer directory search + case listing State filter cleanup

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useUserSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useUserSearch.ts
@@ -43,6 +43,16 @@ export interface UserSearchOption {
   email: string;
 }
 
+/** Optional server-side scoping beyond the typed search term — e.g. an
+ * id-keyed picker that should only ever offer internal staff (see
+ * `AsyncUserIdMultiSelect`'s own `roleIds`/`active` props). Left unset, the
+ * search is unscoped, matching this hook's original assignee/`createdBy`
+ * behavior. */
+export interface UserSearchScope {
+  roleIds?: string[];
+  active?: boolean;
+}
+
 /** Flattened, paginated result for the lazy-loaded assignee filter. */
 export interface InfiniteUserSearch {
   /** All matching users loaded so far, de-duplicated by email. */
@@ -64,21 +74,30 @@ export interface InfiniteUserSearch {
  * empty query lists the directory a page at a time; a typed query sends
  * `searchQuery` to `POST /users/search` so anyone is findable, not just the
  * first page of users. The `oneOf` PG/SN response is normalized so the picker
- * never branches on the live data source.
+ * never branches on the live data source. An optional {@link UserSearchScope}
+ * narrows the search server-side (e.g. internal-only, active-only) for a
+ * caller that should never offer, say, a customer contact — left unset, the
+ * search stays unscoped.
  */
 export function useInfiniteUserSearch(
   query: string,
   enabled: boolean,
+  scope?: UserSearchScope,
 ): InfiniteUserSearch {
   const api = useBackendApi();
   const q = query.trim();
 
   const result = useInfiniteQuery<NormalizedUserSearchResult, Error>({
-    queryKey: ["csm-users", "assignee-search", q],
+    queryKey: ["csm-users", "assignee-search", q, scope?.roleIds, scope?.active],
     queryFn: async ({ pageParam }) => {
+      const filters: SearchUsersRequest["filters"] = {
+        ...(q.length > 0 && { searchQuery: q }),
+        ...(scope?.roleIds && { roleIds: scope.roleIds }),
+        ...(scope?.active !== undefined && { active: scope.active }),
+      };
       const request: SearchUsersRequest = {
         pagination: { offset: pageParam as number, limit: USER_PAGE_SIZE },
-        ...(q.length > 0 ? { filters: { searchQuery: q } } : {}),
+        ...(Object.keys(filters ?? {}).length > 0 && { filters }),
       };
       const res = await api.post<SearchUsersRequest, SearchUsersResponse>(
         "/users/search",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.test.tsx
@@ -86,3 +86,34 @@ describe("AsyncUserIdMultiSelect — @me label", () => {
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
   });
 });
+
+describe("AsyncUserIdMultiSelect — server-side role scoping", () => {
+  it("forwards roleIds/active straight through to useInfiniteUserSearch's scope, not just the typed query", () => {
+    mockedUseInfiniteUserSearch.mockReturnValue(NO_RESULTS);
+
+    render(
+      <AsyncUserIdMultiSelect
+        values={[]}
+        onChange={vi.fn()}
+        roleIds={["internal", "agent"]}
+        active
+      />,
+    );
+
+    expect(mockedUseInfiniteUserSearch).toHaveBeenCalledWith("", false, {
+      roleIds: ["internal", "agent"],
+      active: true,
+    });
+  });
+
+  it("passes an unset scope through unchanged when roleIds/active aren't given", () => {
+    mockedUseInfiniteUserSearch.mockReturnValue(NO_RESULTS);
+
+    render(<AsyncUserIdMultiSelect values={[]} onChange={vi.fn()} />);
+
+    expect(mockedUseInfiniteUserSearch).toHaveBeenCalledWith("", false, {
+      roleIds: undefined,
+      active: undefined,
+    });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.tsx
@@ -58,6 +58,16 @@ interface AsyncUserIdMultiSelectProps {
    * values just render their raw UUID (or a `nameSeed` label) until it has.
    */
   currentUserId?: string;
+  /**
+   * Server-side role scoping passed straight through to
+   * {@link useInfiniteUserSearch}'s {@link UserSearchScope} — e.g. a picker
+   * that should only ever offer internal staff (time-card/case-assignment
+   * style filters), not a customer contact. Left unset, the search stays
+   * unscoped (this component's original behavior).
+   */
+  roleIds?: string[];
+  /** See {@link roleIds}; restrict to active accounts only. */
+  active?: boolean;
 }
 
 /**
@@ -73,6 +83,8 @@ export default function AsyncUserIdMultiSelect({
   onChange,
   nameSeed,
   currentUserId,
+  roleIds,
+  active,
 }: AsyncUserIdMultiSelectProps): JSX.Element {
   const [input, setInput] = useState("");
   const [open, setOpen] = useState(false);
@@ -80,7 +92,7 @@ export default function AsyncUserIdMultiSelect({
   const query = debounced.trim();
 
   const { users: searchResults, isFetching, isFetchingNextPage, hasNextPage, isError, fetchNextPage } =
-    useInfiniteUserSearch(query, open);
+    useInfiniteUserSearch(query, open, { roleIds, active });
   // `id` is optional on `UserSearchOption` (`POST /users/search` doesn't
   // guarantee it) — this picker filters on the id, so a row without one is
   // unusable here and dropped, unlike the email-keyed pickers.

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.tsx
@@ -68,6 +68,15 @@ interface AsyncUserIdMultiSelectProps {
   roleIds?: string[];
   /** See {@link roleIds}; restrict to active accounts only. */
   active?: boolean;
+  /**
+   * Called with every id -> name pair this instance resolves (from a
+   * directory search result or an existing selection), so a caller that
+   * persists its own id -> name cache across this component's unmount
+   * (e.g. a tab switch) can learn names this instance discovered but the
+   * caller's own data never would have — {@link nameSeed} alone only ever
+   * flows one way (caller to component).
+   */
+  onNamesResolved?: (entries: [string, string][]) => void;
 }
 
 /**
@@ -85,6 +94,7 @@ export default function AsyncUserIdMultiSelect({
   currentUserId,
   roleIds,
   active,
+  onNamesResolved,
 }: AsyncUserIdMultiSelectProps): JSX.Element {
   const [input, setInput] = useState("");
   const [open, setOpen] = useState(false);
@@ -171,6 +181,14 @@ export default function AsyncUserIdMultiSelect({
           });
           return m;
         });
+        // Bubble the picked name(s) up before the caller's `values` change
+        // takes effect, so a persistent id -> name cache the caller keeps
+        // (to survive this component unmounting on e.g. a tab switch)
+        // learns names this search just resolved, not only names the
+        // caller's own data already knew.
+        onNamesResolved?.(
+          next.filter((o) => o.id !== currentUserId).map((o) => [o.id, o.name]),
+        );
         onChange(next.map((o) => o.id));
       }}
       inputValue={input}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -290,12 +290,26 @@ describe("CasesFilterBar — removed bar controls fall back to chips", () => {
     expect(screen.queryByText(/^CS team:/)).not.toBeInTheDocument();
   });
 
-  // `excludeStates` now has its own "State" bar control (the tri-state
-  // `TriStateMultiSelectField`, digiops-cs#2907 follow-up), same as
-  // `excludeTags` above — no second, redundant chip.
-  it("does not render a chip for excludeStates — it has its own 'State' bar control now", () => {
-    renderBar({ ...DEFAULT_CASES_FILTERS, states: ["open"], excludeStates: ["closed"] });
-    expect(screen.queryByText(/^Excluding state:/)).not.toBeInTheDocument();
+  // The State field's tri-state include/exclude toggle was removed — Simple
+  // mode's "State" control is now a plain include-only multi-select, so
+  // `excludeStates` has no bar control of its own any more. Any active
+  // `excludeStates` value also forces Advanced mode on mount (see
+  // `isSimpleRepresentable`), where the "State"/"is not one of" row is the
+  // primary way to see/edit it while the panel is open — same reasoning as
+  // `sreTeams`/`workStates` above, a chip is still the only summary while the
+  // panel is collapsed (`activeFilterChips`'s own `effectiveMode`/
+  // `isFiltersOpen` gating), so it's asserted here with the panel collapsed.
+  it("renders a removable chip for excludeStates now that the tri-state 'State' control is gone", () => {
+    const { onChange } = renderBar(
+      { ...DEFAULT_CASES_FILTERS, states: ["open"], excludeStates: ["closed"] },
+      undefined,
+      { isFiltersOpen: false },
+    );
+    const chip = screen.getByText("Excluding state: Closed");
+    expect(chip).toBeInTheDocument();
+
+    fireEvent.click(chip.closest(".MuiChip-root")!.querySelector("svg")!);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ excludeStates: [] }));
   });
 
   it("does not render a chip for onboardingStatuses — it has its own 'Onboarding status' bar control", () => {
@@ -339,8 +353,13 @@ describe("CasesFilterBar — 'CRE Team' control (replaces the removed 'Work stat
   });
 });
 
-describe("CasesFilterBar — 'State' control (tri-state include/exclude, digiops-cs#2907 follow-up)", () => {
-  it("clicking an unselected state once includes it", async () => {
+// The tri-state include/exclude toggle (digiops-cs#2907) was removed —
+// Simple mode's "State" control is now a plain include-only multi-select,
+// same as every other Simple-mode field (Severity, Case type, ...).
+// Exclusion (`excludeStates`) is still expressible, just Advanced-mode-only
+// now (the "State"/"is not one of" row) — see `filterFieldAdapters.test.ts`.
+describe("CasesFilterBar — 'State' control (plain include-only multi-select)", () => {
+  it("selecting a state adds it to states, leaving excludeStates untouched", async () => {
     const { onChange } = renderBar({ ...DEFAULT_CASES_FILTERS });
 
     fireEvent.mouseDown(screen.getByRole("combobox", { name: "State" }));
@@ -351,19 +370,8 @@ describe("CasesFilterBar — 'State' control (tri-state include/exclude, digiops
     );
   });
 
-  it("clicking an included state a second time moves it to excluded", async () => {
+  it("deselecting an already-selected state removes it from states", async () => {
     const { onChange } = renderBar({ ...DEFAULT_CASES_FILTERS, states: ["closed"] });
-
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: "State" }));
-    fireEvent.click(await screen.findByRole("option", { name: "Closed" }));
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ states: [], excludeStates: ["closed"] }),
-    );
-  });
-
-  it("clicking an excluded state a third time clears it back to unselected", async () => {
-    const { onChange } = renderBar({ ...DEFAULT_CASES_FILTERS, excludeStates: ["closed"] });
 
     fireEvent.mouseDown(screen.getByRole("combobox", { name: "State" }));
     fireEvent.click(await screen.findByRole("option", { name: "Closed" }));
@@ -371,6 +379,14 @@ describe("CasesFilterBar — 'State' control (tri-state include/exclude, digiops
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ states: [], excludeStates: [] }),
     );
+  });
+
+  it("has no exclude affordance any more — only a checkbox per option, no +/- icon", async () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS });
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "State" }));
+    const option = await screen.findByRole("option", { name: "Closed" });
+    expect(option.querySelector('input[type="checkbox"]')).toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -76,7 +76,6 @@ import {
 } from "@features/csm-cases/utils/caseType";
 import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
 import MultiSelectField from "@components/MultiSelectField";
-import TriStateMultiSelectField from "@components/TriStateMultiSelectField";
 import AsyncAssigneeMultiSelect from "@features/csm-cases/components/AsyncAssigneeMultiSelect";
 import ProductNameMultiSelect from "@features/csm-cases/components/ProductNameMultiSelect";
 import AdvancedFiltersBuilder from "@features/csm-cases/components/AdvancedFiltersBuilder";
@@ -118,9 +117,13 @@ export interface CasesFilters {
   states: CaseState[];
   /** States the case must NOT be in (`state` op:notIn). Not the inverse of
    * `states` — a distinct field so `in` and `notIn` can never be conflated
-   * on the round trip, same reasoning as `tags`/`excludeTags`. Has its own
-   * bar control (the State field's `TriStateMultiSelectField`, digiops-cs#2907
-   * follow-up) as well as being settable via a dashboard click-through. */
+   * on the round trip, same reasoning as `tags`/`excludeTags`. No dedicated
+   * Simple-mode bar control of its own (the State field's tri-state
+   * include/exclude toggle was removed — Simple mode's "State" control is
+   * now a plain include-only multi-select, matching every other Simple
+   * field); still settable via the Advanced-mode `state`/`notIn` row or a
+   * dashboard click-through, and surfaced as a removable chip when active
+   * (see `buildActiveFilterChips`). */
   excludeStates: CaseState[];
   /** Case-type filter (BE `typeKeys`). Empty = all types. */
   caseTypes: BeCaseType[];
@@ -306,7 +309,11 @@ interface ActiveFilterChip {
  * their bar controls were removed as clutter (they are advanced, rarely
  * hand-picked, and a better home for advanced filters is still to be
  * designed), so a chip is now the ONLY way a user can see or clear them
- * after arriving from a dashboard click-through. `csTeams`/
+ * after arriving from a dashboard click-through. `excludeStates` joins this
+ * group too: the State field's tri-state include/exclude toggle was removed
+ * (Simple mode's "State" control is now a plain include-only multi-select),
+ * so a chip is the only way to see/clear an exclusion that arrived via a
+ * saved view, a shared URL, or a dashboard click-through. `csTeams`/
  * `onboardingStatuses` has its own bar control (see the filter grid below)
  * and is deliberately NOT chipped here — every other bar-controlled field
  * (`states`, `severities`, ...) shows its selection inside its own control,
@@ -352,15 +359,26 @@ function buildActiveFilterChips(
     });
   });
 
-  // `states`/`excludeStates` has its own tri-state bar control
-  // (`TriStateMultiSelectField` on the State field -- see the filter grid
-  // below) -- not chipped here, same as `csTeams`/`onboardingStatuses`. A
-  // dashboard click-through (or a saved view) that seeds `excludeStates`
-  // still round-trips losslessly through the URL and shows up as that
-  // control's own "- " chip, same as any other exclusion a user picks by
-  // hand. `tags`/`excludeTags` are Advanced-mode-only now (see the mode
-  // toggle below) -- also not chipped, since any non-empty value forces
-  // Advanced mode, where the Tag row itself is the visible/removable UI.
+  // `states` still has its own bar control (a plain include-only
+  // multi-select on the State field -- see the filter grid below), so it is
+  // not chipped, same as `csTeams`/`onboardingStatuses`. `excludeStates` no
+  // longer has a bar control of its own (the tri-state include/exclude
+  // toggle that used to live on the State field was removed), so it gets a
+  // chip here -- the only way to see/clear it once it arrives via a saved
+  // view, a shared URL, or a dashboard click-through. `tags`/`excludeTags`
+  // are Advanced-mode-only now (see the mode toggle below) -- also not
+  // chipped, since any non-empty value forces Advanced mode, where the Tag
+  // row itself is the visible/removable UI.
+  filters.excludeStates.forEach((state) => {
+    chips.push({
+      key: `excludeState-${state}`,
+      label: `Excluding state: ${STATE_OPTIONS.find((o) => o.value === state)?.label ?? state}`,
+      onRemove: (f) => ({
+        ...f,
+        excludeStates: f.excludeStates.filter((s) => s !== state),
+      }),
+    });
+  });
 
   filters.workStates.forEach((workState) => {
     chips.push({
@@ -986,32 +1004,28 @@ export default function CasesFilterBar({
               </Grid>
             )}
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              {/* Tri-state (digiops-cs#2907 follow-up): `state` is one of
-                  only two fields (with `tag`) the search contract supports
-                  a real `notIn` on, so "State is not Closed" is now
-                  directly expressible here instead of only via a dashboard
-                  click-through's `excludeStates` chip. */}
-              <TriStateMultiSelectField
+              {/* Plain include-only multi-select, same as every other
+                  Simple-mode field. `state`/`notIn` is still expressible via
+                  the Advanced-mode "State" row (or a dashboard click-through
+                  seeding `excludeStates`, surfaced as a removable chip — see
+                  `buildActiveFilterChips`) — this control only ever writes
+                  `states`. */}
+              <MultiSelectField
                 id="cases-filter-state"
                 label="State"
-                includedValues={filters.states}
-                excludedValues={filters.excludeStates}
+                values={filters.states}
                 options={stateOptions}
                 // Work sub-state only applies when `work_in_progress` is the
-                // *sole* included state — with other states also included
-                // (or excluded — an exclusion doesn't narrow to a single
-                // work state either) the work-state filter can't be applied
+                // *sole* selected state — with any other state also
+                // selected, the work-state filter can't be applied
                 // server-side, so drop any selected work states as soon as
-                // the selection stops being exactly that one included state.
+                // the selection stops being exactly that one state.
                 onChange={(next) =>
                   handleSimpleFieldChange({
                     ...filters,
-                    states: next.included,
-                    excludeStates: next.excluded,
+                    states: next,
                     workStates:
-                      next.included.length === 1 &&
-                      next.included[0] === "work_in_progress" &&
-                      next.excluded.length === 0
+                      next.length === 1 && next[0] === "work_in_progress"
                         ? filters.workStates
                         : [],
                   })

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/filterFieldAdapters.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/filterFieldAdapters.test.ts
@@ -36,7 +36,6 @@ describe("isSimpleRepresentable", () => {
       ...DEFAULT_CASES_FILTERS,
       severities: ["S1"],
       states: ["open"],
-      excludeStates: ["closed"],
       caseTypes: ["case"],
       assignees: ["@me"],
       workStates: ["ongoing"],
@@ -52,6 +51,11 @@ describe("isSimpleRepresentable", () => {
   const gatingOverrides: [string, Partial<CasesFilters>][] = [
     ["tags", { tags: ["urgent"] }],
     ["excludeTags", { excludeTags: ["spam"] }],
+    // The Simple-mode "State" control used to be a tri-state that read/wrote
+    // `excludeStates` directly (digiops-cs#2907); now that it's a plain
+    // include-only multi-select, `excludeStates` is only representable via
+    // the Advanced-mode "State"/"is not one of" row, same as `excludeTags`.
+    ["excludeStates", { excludeStates: ["closed"] }],
     ["sreTeams", { sreTeams: ["g1"] }],
     ["projectTypes", { projectTypes: ["Subscription"] }],
     ["escalationLevels", { escalationLevels: ["1"] }],

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/filterFieldAdapters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/filterFieldAdapters.ts
@@ -365,23 +365,24 @@ export function normalizeCasesFilters(filters: CasesFilters): CasesFilters {
  * Fields the Simple grid's dedicated controls do NOT cover (after removing
  * Tags — it's Advanced-only now, see `CasesFilterBar.tsx`). Filters
  * expressible entirely within the Simple grid's fields (`severities`,
- * `states`, `excludeStates`, `caseTypes`, `assignees`, `workStates`,
- * `projects`, `engagementTypes`, `productNames`, `csTeams`,
- * `onboardingStatuses`) can still be represented in Simple mode regardless
- * of this check — those fields simply aren't in this list.
+ * `states`, `caseTypes`, `assignees`, `workStates`, `projects`,
+ * `engagementTypes`, `productNames`, `csTeams`, `onboardingStatuses`) can
+ * still be represented in Simple mode regardless of this check — those
+ * fields simply aren't in this list.
  *
- * `excludeStates` deliberately does NOT gate Simple mode, unlike `tags`/
- * `excludeTags`: the Simple grid's "State" control is already a tri-state
- * (`TriStateMultiSelectField`, digiops-cs#2907) that reads/writes both
- * `states` AND `excludeStates` directly — it's genuinely Simple-representable
- * today, not merely tolerated there. `tags`/`excludeTags` have no such
- * Simple-mode control any more (Tags moved to Advanced-only), which is why
- * they DO gate it.
+ * `excludeStates` DOES gate Simple mode now, same reasoning as `tags`/
+ * `excludeTags`: the Simple grid's "State" control used to be a tri-state
+ * toggle that read/wrote both `states` AND `excludeStates` directly, but
+ * that control was removed (Simple mode's "State" field is now a plain
+ * include-only multi-select, matching every other Simple field) — so an
+ * active `excludeStates` value is only representable via the Advanced-mode
+ * `state`/`notIn` row now, same as a `tag`/`notIn` value.
  */
 export function isSimpleRepresentable(filters: CasesFilters): boolean {
   return (
     filters.tags.length === 0 &&
     filters.excludeTags.length === 0 &&
+    filters.excludeStates.length === 0 &&
     filters.sreTeams.length === 0 &&
     filters.projectTypes.length === 0 &&
     filters.escalationLevels.length === 0 &&

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -81,6 +81,8 @@ import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardRev
 import BulkApproveDialog from "@features/csm-timecards/components/BulkApproveDialog";
 import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
 import SearchableMultiSelect from "@components/SearchableMultiSelect";
+import AsyncUserIdMultiSelect from "@features/csm-cases/components/AsyncUserIdMultiSelect";
+import { INTERNAL_USER_ROLES } from "@features/csm-users/types/csmUsers";
 import { exportTimeCardsCsv } from "@features/csm-timecards/utils/timeCardCsvExport";
 import { cardActions, type TimecardAction, type TimecardRoleCtx } from "@features/csm-timecards/utils/timeSheetState";
 import type { TimeCardGroupBy } from "@features/csm-timecards/utils/timeCardGrouping";
@@ -90,23 +92,12 @@ import type {
   TimeCardState,
 } from "@features/csm-timecards/types/timeCards";
 
-/** Builds a `userId -> userName` lookup plus the option list a
- * `SearchableMultiSelect` engineer filter needs, scoped to whatever cards are
- * currently loaded for one tab (there's no engineer-search endpoint for time
- * cards, so — like the work-item filter — this only ever offers engineers
- * actually present on the current page, not the full directory). */
-function engineerOptionsFrom(cards: CsmTimeCard[] | undefined): {
-  ids: string[];
-  nameById: Map<string, string>;
-} {
-  const nameById = new Map<string, string>();
-  (cards ?? []).forEach((c) => nameById.set(c.userId, c.userName));
-  return { ids: [...nameById.keys()], nameById };
-}
-
 /** Distinct case numbers present in whatever cards are currently loaded for
- * one tab — the option list for the work-item filter. Same "current page
- * only" caveat as {@link engineerOptionsFrom}. */
+ * one tab — the option list for the work-item filter. There's no
+ * case-number search endpoint for time cards, so — unlike the Engineer
+ * filter (see `AsyncUserIdMultiSelect` below, which searches the real users
+ * directory) — this only ever offers case numbers actually present on the
+ * current page, not every case the viewer could filter by. */
 function workItemOptionsFrom(cards: CsmTimeCard[] | undefined): string[] {
   return Array.from(new Set((cards ?? []).map((c) => c.caseNumber)));
 }
@@ -117,6 +108,16 @@ function workItemOptionsFrom(cards: CsmTimeCard[] | undefined): string[] {
  * not a new fetch. */
 function projectNamesIn(cards: CsmTimeCard[] | undefined): [string, string][] {
   return (cards ?? []).map((c) => [c.projectId, c.projectName]);
+}
+
+/** `[userId, userName]` pairs present in a batch of cards — same role as
+ * {@link projectNamesIn}, but for the Engineer filter's chip-label cache
+ * (see `engineerNameCache` below): the filter itself now searches the real
+ * users directory via `AsyncUserIdMultiSelect`, but a selected engineer's
+ * name still needs a source before that search has run against the id
+ * already in the filter (e.g. right after switching tabs). */
+function engineerNamesIn(cards: CsmTimeCard[] | undefined): [string, string][] {
+  return (cards ?? []).map((c) => [c.userId, c.userName]);
 }
 
 const DEFAULT_ROWS_PER_PAGE = 20;
@@ -386,21 +387,28 @@ export default function CsmTimeCardsPage(): JSX.Element {
     () => workItemOptionsFrom(queue.data?.cards),
     [queue.data],
   );
-  // Persistent projectId -> projectName cache for the Project filter's chip
-  // labels, accumulated across every tab's loaded cards over the page's
-  // lifetime and never shrunk. Unlike workItemOptions/engineerOptions above
-  // (deliberately scoped to one tab's current page), this can't be a per-tab
-  // derivation: each tab's FilterBar/AsyncProjectMultiSelect instance
-  // unmounts on tab switch (conditional rendering below), which would
-  // otherwise drop a selected project's name the moment the newly active
-  // tab's own cards don't happen to include it — or are empty — leaving the
-  // chip showing a raw id until the dropdown is reopened and re-searched.
+  // Persistent projectId -> projectName / userId -> userName caches for the
+  // Project and Engineer filters' chip labels, accumulated across every tab's
+  // loaded cards over the page's lifetime and never shrunk. Unlike
+  // workItemOptions above (deliberately scoped to one tab's current page),
+  // these can't be a per-tab derivation: each tab's FilterBar/
+  // AsyncProjectMultiSelect/AsyncUserIdMultiSelect instance unmounts on tab
+  // switch (conditional rendering below), which would otherwise drop a
+  // selected project/engineer's name the moment the newly active tab's own
+  // cards don't happen to include it — or are empty — leaving the chip
+  // showing a raw id until the dropdown is reopened and re-searched. (The
+  // Engineer filter's own search always finds the name eventually, since it
+  // now queries the real users directory rather than only the current page —
+  // this cache just avoids a raw-UUID flash in the meantime.)
   //
   // Reconciled during render (React's "adjusting state when data changes"
   // pattern: https://react.dev/reference/react/useState#storing-information-from-previous-renders)
-  // rather than in an effect, so a fresh name is available in the same
+  // rather than in an effect, so fresh names are available in the same
   // render the data arrived in instead of one render later.
   const [projectNameCache, setProjectNameCache] = useState<Map<string, string>>(
+    () => new Map(),
+  );
+  const [engineerNameCache, setEngineerNameCache] = useState<Map<string, string>>(
     () => new Map(),
   );
   const [lastSeenCards, setLastSeenCards] = useState<{
@@ -414,28 +422,34 @@ export default function CsmTimeCardsPage(): JSX.Element {
     lastSeenCards.queue !== queue.data
   ) {
     setLastSeenCards({ mine: myCards.data, all: allCards.data, queue: queue.data });
-    const learned = [
+    const learnedProjects = [
       ...projectNamesIn(myCards.data?.cards),
       ...projectNamesIn(allCards.data?.cards),
       ...projectNamesIn(queue.data?.cards),
     ];
-    let next: Map<string, string> | undefined;
-    for (const [id, name] of learned) {
+    let nextProjects: Map<string, string> | undefined;
+    for (const [id, name] of learnedProjects) {
       if (projectNameCache.get(id) !== name) {
-        next ??= new Map(projectNameCache);
-        next.set(id, name);
+        nextProjects ??= new Map(projectNameCache);
+        nextProjects.set(id, name);
       }
     }
-    if (next) setProjectNameCache(next);
+    if (nextProjects) setProjectNameCache(nextProjects);
+
+    const learnedEngineers = [
+      ...engineerNamesIn(myCards.data?.cards),
+      ...engineerNamesIn(allCards.data?.cards),
+      ...engineerNamesIn(queue.data?.cards),
+    ];
+    let nextEngineers: Map<string, string> | undefined;
+    for (const [id, name] of learnedEngineers) {
+      if (engineerNameCache.get(id) !== name) {
+        nextEngineers ??= new Map(engineerNameCache);
+        nextEngineers.set(id, name);
+      }
+    }
+    if (nextEngineers) setEngineerNameCache(nextEngineers);
   }
-  const allEngineerOptions = useMemo(
-    () => engineerOptionsFrom(allCards.data?.cards),
-    [allCards.data],
-  );
-  const approvalsEngineerOptions = useMemo(
-    () => engineerOptionsFrom(queue.data?.cards),
-    [queue.data],
-  );
 
   // Filtered cards per tab, computed once and shared between the FilterBar's
   // export action and the table rendering below — rather than recomputing
@@ -622,14 +636,14 @@ export default function CsmTimeCardsPage(): JSX.Element {
             setFilterTo={handleFilterToChange}
             onClear={clearFilters}
             engineerSlot={
-              <SearchableMultiSelect
+              <AsyncUserIdMultiSelect
                 id="timecards-filter-engineer-all"
                 label="Engineer"
-                placeholder="Search engineers…"
                 values={filterEngineer}
-                options={allEngineerOptions.ids}
-                formatOption={(id) => allEngineerOptions.nameById.get(id) ?? id}
                 onChange={handleFilterEngineerChange}
+                nameSeed={engineerNameCache}
+                roleIds={INTERNAL_USER_ROLES}
+                active
               />
             }
             engineerActive={filterEngineer.length > 0}
@@ -700,14 +714,14 @@ export default function CsmTimeCardsPage(): JSX.Element {
             onClear={clearFilters}
             hideStateFilter
             engineerSlot={
-              <SearchableMultiSelect
+              <AsyncUserIdMultiSelect
                 id="timecards-filter-engineer-approvals"
                 label="Engineer"
-                placeholder="Search engineers…"
                 values={filterEngineer}
-                options={approvalsEngineerOptions.ids}
-                formatOption={(id) => approvalsEngineerOptions.nameById.get(id) ?? id}
                 onChange={handleFilterEngineerChange}
+                nameSeed={engineerNameCache}
+                roleIds={INTERNAL_USER_ROLES}
+                active
               />
             }
             engineerActive={filterEngineer.length > 0}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -451,6 +451,24 @@ export default function CsmTimeCardsPage(): JSX.Element {
     if (nextEngineers) setEngineerNameCache(nextEngineers);
   }
 
+  // `AsyncUserIdMultiSelect` resolves a name the moment a directory search
+  // result is picked — earlier than `engineerNamesIn` above could ever know
+  // it (that only learns from cards already loaded on screen). Without
+  // this, an engineer picked purely from the directory (no card of theirs
+  // on the current page) would render as a raw UUID on the next tab, since
+  // that tab mounts a fresh `AsyncUserIdMultiSelect` instance with no
+  // memory of the pick.
+  const handleEngineerNamesResolved = (entries: [string, string][]): void => {
+    let next: Map<string, string> | undefined;
+    for (const [id, name] of entries) {
+      if (engineerNameCache.get(id) !== name) {
+        next ??= new Map(engineerNameCache);
+        next.set(id, name);
+      }
+    }
+    if (next) setEngineerNameCache(next);
+  };
+
   // Filtered cards per tab, computed once and shared between the FilterBar's
   // export action and the table rendering below — rather than recomputing
   // (and risking drift) in two places. Engineer is already applied
@@ -642,6 +660,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
                 values={filterEngineer}
                 onChange={handleFilterEngineerChange}
                 nameSeed={engineerNameCache}
+                onNamesResolved={handleEngineerNamesResolved}
                 roleIds={INTERNAL_USER_ROLES}
                 active
               />
@@ -720,6 +739,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
                 values={filterEngineer}
                 onChange={handleFilterEngineerChange}
                 nameSeed={engineerNameCache}
+                onNamesResolved={handleEngineerNamesResolved}
                 roleIds={INTERNAL_USER_ROLES}
                 active
               />


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

This PR now bundles two small, unrelated CSM portal frontend fixes landed in the same session:

1. The time card list's Engineer filter only ever offered engineers already present on the currently loaded page of time cards. An engineer with no cards on the current page (a different project filter, a different date range, or simply further down the result set) couldn't be filtered on at all, even though they're a valid engineer in the directory.
2. The case listing page's Simple-mode "State" filter cycled each option through unselected → include → exclude on click, a tri-state toggle that read as an unexpected three-way control rather than an ordinary filter.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

1. Make the Engineer filter search-as-you-type against the real users directory, scoped to active internal (engineer) accounts, instead of only the current page's cards.
2. Replace the case listing's tri-state "State" control with a plain include-only multi-select, matching every other Simple-mode filter field.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

**1. Time card Engineer filter (`CsmTimeCardsPage.tsx`, `AsyncUserIdMultiSelect`, `useInfiniteUserSearch`)**
- Both time card Engineer filter instances (the "All" and "Approvals" tabs in `CsmTimeCardsPage.tsx`) now render `AsyncUserIdMultiSelect` instead of a plain `SearchableMultiSelect` fed from `engineerOptionsFrom(cards)`. That helper (and its now-stale "there's no engineer-search endpoint" comment) is removed.
- `AsyncUserIdMultiSelect` already implements this exact pattern for other id-keyed pickers (debounced input → `useInfiniteUserSearch` → `POST /users/search`, normalized against the source's `oneOf` PG/SN response shape) — it needed one addition: optional `roleIds`/`active` props, threaded through to a new optional `scope` argument on `useInfiniteUserSearch`. Left unset, both default to the same unscoped search the component's one existing caller (a dashboard widget preview) already relies on, so that caller is unaffected.
- The time card filter passes `roleIds={INTERNAL_USER_ROLES}` and `active` (the same internal-staff scoping `AssignEngineerDialog` uses for case assignment), since a time card is always attributed to a CS engineer, never a customer contact.
- A selected engineer's chip needs a label before any search has run (e.g. right after switching tabs, since each tab's filter instance unmounts on tab switch). Added an `engineerNameCache` accumulated from every tab's loaded cards over the page's lifetime, the same pattern the existing `projectNameCache` already uses for the Project filter's chip labels.
- No backend change: `POST /users/search` (with `roleIds`/`active` filters) is already deployed and already used elsewhere in this app (`AssignEngineerDialog`).

**2. Case listing "State" filter (`CasesFilterBar.tsx`, `filterFieldAdapters.ts`)**
- Simple mode's "State" control now renders a plain `MultiSelectField` (include-only), writing only `states` — the same component every other Simple-mode field (Severity, Case type, CRE Team, ...) already uses. The tri-state cycling control (`TriStateMultiSelectField`) is no longer used on this page; that shared component itself is untouched and still used elsewhere (a dashboard widget preview).
- Exclusion (`state` "is not one of") is unaffected as a filtering capability — it was already offered as a first-class row in the unified "Advanced filters" builder before this change, so removing the Simple-mode tri-state toggle doesn't remove anything the backend contract can no longer express; it removes a second, redundant path to the same predicate.
- `isSimpleRepresentable` now also gates on `excludeStates` being empty (same treatment as `tags`/`excludeTags`): an active exclude-state value forces Advanced mode on mount, where the "State"/"is not one of" row is the primary UI for it.
- An `excludeStates` value that arrives without a dedicated bar control (a saved view, a shared URL, or a dashboard click-through) still renders as a removable "Excluding state: …" chip while the panel is collapsed, the same fallback pattern already used for `sreTeams`/`workStates`.
- No backend change: the entity-service already accepts `state`/`notIn`; this is a pure frontend simplification.

## User stories
> Summary of user stories addressed by this change

1. As a CS engineer/approver reviewing time cards, I can filter by any engineer in the directory, not just one whose cards happen to already be on the currently loaded page.
2. As a CS engineer filtering the case list, the "State" filter behaves like an ordinary multi-select (pick states to include) instead of cycling through an unexpected third, exclude state on repeated clicks.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

- The time cards Engineer filter now searches the full engineer directory as you type, instead of only offering engineers already visible on the current page.
- The case listing's "State" filter is now a plain multi-select; excluding a state is still available via Advanced filters.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A — the in-app help topics don't describe the Engineer filter's search scope or the State filter's include/exclude mechanics today, so there's nothing there to update.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A — no training content covers either filter.

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

N/A — internal filter UX behavior, not a certification-exam topic.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

N/A — internal engineer-facing filter changes, not customer/market-facing.

## Automation tests
 - Unit tests
   > Code coverage information

   - Extended `AsyncUserIdMultiSelect.test.tsx` with two tests covering the new `roleIds`/`active` scoping: one asserting both are forwarded to `useInfiniteUserSearch`'s scope argument, one asserting the scope stays `{ roleIds: undefined, active: undefined }` when the caller doesn't pass them (i.e. the existing dashboard caller's behavior doesn't change). `CsmTimeCardsPage.tsx` has no existing test file, so none needed updating.
   - Updated `CasesFilterBar.test.tsx` and `filterFieldAdapters.test.ts` for the "State" control change: the old tri-state click-cycling tests are replaced with plain multi-select tests, the "excludeStates has no chip" test is flipped (it now does render a chip), and `excludeStates` moved into `isSimpleRepresentable`'s gating-override test cases. Ran the full `csm-cases` and `csm-timecards`-adjacent test files — 206 tests pass in `CasesFilterBar`/`filterFieldAdapters`/`CsmIssuesView`/`casesFiltersUrl`/`caseSearchPayload`/`advancedFilters`/`anyOfFilters`/`savedFilterViews`/`caseListColumns`, plus the pre-existing `AsyncUserIdMultiSelect` suite.
 - Integration tests
   > Details about the test cases and coverage

None added — no integration test suite covers either page today.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React change, not a JVM component FindSecurityBugs covers.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

N/A — no samples affected.

## Related PRs
> List any other related PRs

None.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A — no data or schema migration; both changes are frontend-only against already-deployed endpoints/contracts.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Verified via `tsc -b`, `eslint .`, `vite build`, and `vitest run` on macOS (Darwin), Node/npm toolchain per `apps/csm-portal/webapp/package.json` (pnpm-managed). No running local stack or backend available in this environment, so neither change was exercised in a live browser against real data — see PR description/comments for that caveat.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

- Time card filter: found the pattern already established in this codebase (`AsyncProjectMultiSelect`, `AsyncAssigneeMultiSelect`, `AsyncUserIdMultiSelect` — all debounced Autocomplete-over-backend-search components) and extended the closest match (`AsyncUserIdMultiSelect`, since the time card filter is UUID-keyed) rather than introducing a new component or pattern.
- State filter: confirmed the `state`/`notIn` predicate was already fully supported end-to-end via the existing "Advanced filters" builder before removing the Simple-mode tri-state control, so no filtering capability is lost — only the redundant Simple-mode toggle.
