### PR TITLE
[CSM Portal] Drop auto-closure hold work-note dedup check

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -1149,34 +1149,6 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// The auto-closure hold work note (below) must only fire for an actual change in
-	// the hold date, not for a retry or a no-op PATCH that resends the existing value —
-	// otherwise every duplicate request pollutes the case's activity feed with an
-	// identical note. Read the prior value before the PATCH; after it, the case
-	// already reflects the new value and there'd be nothing to diff against.
-	var priorHoldDate string
-	if patchErr == nil && patch.AutocloseHoldUntil != nil {
-		if current, err := h.entity.GetCase(r.Context(), caseID); err != nil {
-			slog.WarnContext(r.Context(), "entity GetCase failed reading prior autoclose hold date; proceeding without dedup", "userID", user.UserID, "caseID", caseID, "err", err)
-		} else {
-			// autoclosureStateTime is only "the hold date" while the case is actually
-			// ON_HOLD — for every other autoclosureStep it's when that other stage next
-			// advances, a value unrelated to any hold. Without gating on the step, the
-			// very first hold on a case (whose autoclosureStateTime already holds some
-			// unrelated staged-advance date matching the FE's pre-filled picker default)
-			// gets misread as "unchanged" and its note silently skipped.
-			var currentCase struct {
-				AutoclosureStep      *string `json:"autoclosureStep"`
-				AutoclosureStateTime *string `json:"autoclosureStateTime"`
-			}
-			if err := json.Unmarshal(current, &currentCase); err == nil &&
-				currentCase.AutoclosureStep != nil && *currentCase.AutoclosureStep == "ON_HOLD" &&
-				currentCase.AutoclosureStateTime != nil {
-				priorHoldDate = formatHoldDate(*currentCase.AutoclosureStateTime)
-			}
-		}
-	}
-
 	result, err := h.entity.PatchCase(r.Context(), caseID, body)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity PatchCase failed", "userID", user.UserID, "caseID", caseID, "err", err)
@@ -1187,14 +1159,20 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	// Setting/extending the auto-closure hold has no visible trail of its own on the
 	// case (unlike the legacy ticketing UI's equivalent action, which records a work
 	// note). Record one here so CS engineers can see when a hold was set/extended and
-	// until when. Best-effort and fire-and-forget: the hold PATCH above already
-	// succeeded, so this secondary write must not delay the response or fail/roll back
-	// the request if it errors. context.WithoutCancel keeps the request-scoped values
-	// the entity client needs (x-user-id-token, correlation id) while detaching from
-	// the request's own cancellation, which fires as soon as the handler returns —
-	// a bare context.Background() would drop those values and the note would reach
-	// the entity service unattributed.
-	if patchErr == nil && patch.AutocloseHoldUntil != nil && formatHoldDate(*patch.AutocloseHoldUntil) != priorHoldDate {
+	// until when — every PATCH that carries autocloseHoldUntil gets one, with no
+	// no-op/dedup check: the field this would need to key off
+	// (autoclosureStep/autoclosureStateTime) isn't reliably populated on a case read,
+	// and the legacy ticketing UI's own equivalent action has the exact same
+	// behavior (it re-posts an identical note on every resend too), so this matches
+	// established behavior rather than deviating from it. Best-effort and
+	// fire-and-forget: the hold PATCH above already succeeded, so this secondary
+	// write must not delay the response or fail/roll back the request if it errors.
+	// context.WithoutCancel keeps the request-scoped values the entity client needs
+	// (x-user-id-token, correlation id) while detaching from the request's own
+	// cancellation, which fires as soon as the handler returns — a bare
+	// context.Background() would drop those values and the note would reach the
+	// entity service unattributed.
+	if patchErr == nil && patch.AutocloseHoldUntil != nil {
 		holdUntil := *patch.AutocloseHoldUntil
 		detached := context.WithoutCancel(r.Context())
 		go func() {

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1464,46 +1464,14 @@ func TestPatchCase(t *testing.T) {
 		}
 	})
 
-	t.Run("autocloseHoldUntil PATCH does not record a duplicate work note when the hold date is unchanged", func(t *testing.T) {
-		var commentCalled atomic.Bool
-		client := &mockEntityCaseClient{
-			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
-				return []byte(`{"id":"` + testCaseID + `","autoclosureStep":"ON_HOLD","autoclosureStateTime":"2026-08-01T00:00:00Z"}`), nil
-			},
-			patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
-				return []byte(`{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","autoclosureStep":"ON_HOLD","autoclosureStateTime":"2026-08-01T00:00:00Z"}}`), nil
-			},
-			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
-				commentCalled.Store(true)
-				return []byte(`{"id":"wn-1"}`), nil
-			},
-		}
-		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"autocloseHoldUntil":"2026-08-01T00:00:00Z"}`)))
-		r.SetPathValue("id", testCaseID)
-		w := httptest.NewRecorder()
-		h.PatchCase(w, r)
-
-		assertStatus(t, w, http.StatusOK)
-		// Give a would-be goroutine a moment to run; there should be none to wait for.
-		time.Sleep(100 * time.Millisecond)
-		if commentCalled.Load() {
-			t.Error("expected no work note for a PATCH that resends the existing hold date")
-		}
-	})
-
-	t.Run("autocloseHoldUntil PATCH records a work note on the first hold, even if autoclosureStateTime already held an unrelated staged-advance date", func(t *testing.T) {
-		// A case not currently on hold can still carry a non-nil autoclosureStateTime
-		// (e.g. when its autoclosureStep is FIRST_COMMENT) that happens to match the
-		// FE's pre-filled hold-date picker default. The dedup check must gate on
-		// autoclosureStep == ON_HOLD, not merely on the date matching, or this — the
-		// default "open dialog, accept the pre-filled date, click Hold" path — would
-		// wrongly be treated as a no-op and its note dropped.
+	t.Run("autocloseHoldUntil PATCH records a work note even when resent with the same hold date", func(t *testing.T) {
+		// Deliberately no dedup: ServiceNow's own case-read doesn't reliably surface
+		// autoclosureStep/autoclosureStateTime, so a dedup keyed on it can't be trusted,
+		// and the legacy ticketing UI's equivalent action has this exact same behavior
+		// (a resend posts another identical note too) — this matches established
+		// behavior rather than a regression.
 		commentCalled := make(chan struct{})
 		client := &mockEntityCaseClient{
-			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
-				return []byte(`{"id":"` + testCaseID + `","autoclosureStep":"FIRST_COMMENT","autoclosureStateTime":"2026-08-01T00:00:00Z"}`), nil
-			},
 			patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
 				return []byte(`{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","autoclosureStep":"ON_HOLD","autoclosureStateTime":"2026-08-01T00:00:00Z"}}`), nil
 			},
@@ -1522,7 +1490,7 @@ func TestPatchCase(t *testing.T) {
 		select {
 		case <-commentCalled:
 		case <-time.After(2 * time.Second):
-			t.Fatal("expected CreateCaseComment to be called for the first hold, despite a matching prior autoclosureStateTime")
+			t.Fatal("expected CreateCaseComment to be called even for a resent hold date")
 		}
 	})
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Follow-up to the auto-closure hold work-note fix (merged in #1648). Real-ServiceNow-dev-tenant verification found that the no-op dedup check added during that PR's review never actually fires: it's keyed on `autoclosureStep`/`autoclosureStateTime` read back via `GetCase`, but ServiceNow's own case-read (via the Ballerina integration layer) doesn't reliably populate those two fields — confirmed live: resending an identical hold date created a second, duplicate work note despite the dedup code being present.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Remove the dedup check entirely rather than build new plumbing to fix the read gap. This isn't a regression: the legacy ticketing UI's own equivalent "Set Auto-Closure On Hold" action has this exact same behavior — it re-posts an identical note on every resend too, with no dedup of its own. Removing the check restores parity with established behavior instead of depending on a data source that can't reliably support it.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

In `apps/csm-portal/backend/internal/handler/cases.go`'s `PatchCase`: removed the pre-PATCH `GetCase` call and `priorHoldDate` comparison that gated whether the work note gets recorded. The work note now fires unconditionally whenever a PATCH carries `autocloseHoldUntil` (still async/fire-and-forget via the detached-context goroutine from the prior fix — that part is unaffected). Updated tests: replaced the two dedup-specific subtests with one confirming a resend still records a note (parity, not a regression).

## User stories
> Summary of user stories addressed by this change>

As a CS engineer, when I set or resend an auto-closure hold, I want the same recorded behavior the legacy ticketing UI always had — a note per action — without the portal silently trying (and failing) to suppress duplicates behind the scenes.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Removed an internal dedup check on the auto-closure hold work note that never actually worked; the note now records on every hold-set/resend, matching legacy ticketing UI behavior.

## Documentation
N/A — no doc currently claims dedup behavior (help-doc update from the original PR, cs-tools#1656, doesn't mention it either).

## Training
N/A

## Certification
N/A — no certification exam content covers this.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Removed 2 dedup-specific subtests from `cases_test.go`, added 1 confirming a resend still records a note. Full `TestPatchCase` suite re-verified: `go build ./...`, `go vet ./...`, `go test ./internal/handler/... -run TestPatchCase -race -count=5` (stable), `go test ./...` (all packages ok).
 - Integration tests
   > Manually verified against a real ServiceNow dev-tenant case (`CS0441704`) before this PR: confirmed the underlying dedup bug this PR removes.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go codebase
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
#1648 (the feature this follows up on)

## Migrations (if applicable)
N/A

## Test environment
Verified with `go build`/`go vet`/`go test` (Go, macOS/Darwin). The dedup bug this PR fixes was found via a real local-stack run against `wso2sndev.service-now.com`.

## Learning
N/A
