### PR TITLE
[CSM Portal] Raise dashboard widget query staleTime to 5 minutes

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useDashboard.ts
@@ -41,6 +41,6 @@ export function useDashboard(
       return api.get<BeDashboard>(`/dashboards/${dashboardId}`);
     },
     enabled: dashboardId !== undefined,
-    staleTime: 30_000,
+    staleTime: 300_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
@@ -203,6 +203,6 @@ export function useWidgetData(
     // the 2-arg `(failureCount, error)` form, so `isTeamIndependent` has to
     // be closed over here instead of threaded through react-query itself.
     retry: (failureCount, error) => shouldRetryWidgetFetch(failureCount, error, isTeamIndependent),
-    staleTime: 60_000,
+    staleTime: 300_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
@@ -161,7 +161,7 @@ export function useWidgetGroupByData(
     // same reason useWidgetData wraps it — react-query's own `retry` option
     // only calls the 2-arg form.
     retry: (failureCount, error) => shouldRetryWidgetFetch(failureCount, error, isTeamIndependent),
-    staleTime: 60_000,
+    staleTime: 300_000,
   });
 
   // Mirrors useWidgetPieData's own isLoading semantics: `!enabled` or a

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
@@ -172,7 +172,7 @@ export function useWidgetPieData(
         // form.
         retry: (failureCount: number, error: Error) =>
           shouldRetryWidgetFetch(failureCount, error, isTeamIndependent),
-        staleTime: 60_000,
+        staleTime: 300_000,
       };
     }),
   });


### PR DESCRIPTION
## Purpose
> CS-engineer feedback (mifraz): the dashboard (home page) reloads all widgets every time a case is closed and the user returns to it, taking considerable time. Compared to ServiceNow's home page, which never refreshes at all.

## Goals
> Reduce unnecessary widget reloads on dashboard revisit within a normal case-handling cycle, without going as stale as "never refreshes."

## Approach
> Raised React Query `staleTime` from 60s (widgets) / 30s (dashboard config) to 5 minutes in `useWidgetData.ts`, `useWidgetPieData.ts`, `useWidgetGroupByData.ts`, and `useDashboard.ts`. Confirmed this is not masking a cache-key bug: TanStack Query's default `queryKeyHashFn` hashes by content, not object reference, so these widgets' query keys already hash stably across renders — the only issue was staleTime being shorter than a real open/work/close case cycle. `gcTime` left at its default (300_000ms), which already covers the new staleTime. No UI change.

## User stories
> As a CS engineer, returning to the dashboard after closing a case should not force a full widget reload if I was only away briefly.

## Release note
> Dashboard widgets no longer reload on every visit within a 5-minute window.

## Documentation
> N/A — internal caching behavior only, no user-facing flow, field, or nav change.

## Training
> N/A

## Certification
> N/A — not exam-relevant.

## Marketing
> N/A

## Automation tests
 - Unit tests
   > No new tests added — plain constant-value change to existing, already-tested query hooks; a dedicated test for a staleTime number would be low-value churn.
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (JS/TS change, no Java)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> None

## Migrations (if applicable)
> N/A

## Test environment
> `npx tsc -b` clean; `npx eslint .` — 0 errors, 2 pre-existing unrelated warnings.

## Learning
> N/A
