### PR TITLE
[CSM Portal] Show onboarding owner on case overview and project detail

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -8791,6 +8791,31 @@ components:
               description: >
                 Whether this project is eligible to raise service requests, per the
                 backing data source's own project classification.
+            onboardingStatus:
+              type: string
+              nullable: true
+              enum:
+                - Not-Started
+                - In-Progress
+                - OnHold
+                - Completed
+                - Expired
+                - Cancelled
+                - Not-Applicable
+              description: >
+                The project's onboarding engagement status. Null when the project has
+                no onboarding engagement at all. "Not-Applicable" (and null) both mean
+                there is no active onboarding to surface for this project; treat either
+                as "onboarding not enabled" when deciding whether to show
+                onboardingOwner. ServiceNow data source only.
+            onboardingOwner:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/PersonRef'
+              description: >
+                The WSO2 staff member assigned to lead this project's onboarding. Null
+                when no owner is assigned (most projects, since it is only set for
+                onboarding-enabled projects). ServiceNow data source only.
 
     ProjectAccountRef:
       type: object

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
@@ -699,6 +699,50 @@ describe("CustomerContextWidget", () => {
     expect(screen.getByText("SRE Beta")).toBeInTheDocument();
     expect(screen.queryByText("CRE Alpha")).not.toBeInTheDocument();
   });
+
+  it("renders the onboarding owner row when onboarding is enabled and an owner is set", () => {
+    renderWithRouter(
+      <CustomerContextWidget
+        ctx={CTX}
+        project={{
+          ...PROJECT,
+          onboardingStatus: "In-Progress",
+          onboardingOwner: {
+            id: "user-1",
+            name: "Jane Doe",
+            email: "jane.doe@example.com",
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("Onboarding Owner")).toBeInTheDocument();
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+
+  it("hides the onboarding owner row when onboardingStatus is Not-Applicable", () => {
+    renderWithRouter(
+      <CustomerContextWidget
+        ctx={CTX}
+        project={{
+          ...PROJECT,
+          onboardingStatus: "Not-Applicable",
+          onboardingOwner: {
+            id: "user-1",
+            name: "Jane Doe",
+            email: "jane.doe@example.com",
+          },
+        }}
+      />,
+    );
+    expect(screen.queryByText("Onboarding Owner")).not.toBeInTheDocument();
+  });
+
+  it("hides the onboarding owner row when there is no onboarding engagement at all", () => {
+    renderWithRouter(
+      <CustomerContextWidget ctx={CTX} project={{ ...PROJECT }} />,
+    );
+    expect(screen.queryByText("Onboarding Owner")).not.toBeInTheDocument();
+  });
 });
 
 describe("RequestDetailsWidget", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -312,6 +312,19 @@ export function CustomerContextWidget({
           </MetaRow>
           {/* No subscription-status field exists on the project record today
               (only start/end dates) — omitted rather than inferring one. */}
+          {project.onboardingStatus &&
+            project.onboardingStatus !== "Not-Applicable" &&
+            project.onboardingOwner && (
+              <MetaRow label="Onboarding Owner">
+                <Typography variant="body2">
+                  <UserRefLink
+                    name={project.onboardingOwner.name}
+                    email={project.onboardingOwner.email || undefined}
+                    userId={project.onboardingOwner.id}
+                  />
+                </Typography>
+              </MetaRow>
+            )}
         </>
       )}
     </WidgetCard>

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.test.tsx
@@ -36,6 +36,15 @@ vi.mock("@features/csm-projects/components/WorkItemsTab", () => ({
   default: ({ projectId }: { projectId: string }) => <div>Work items for {projectId}</div>,
 }));
 
+// The backend client reads runtime config at module load, which isn't
+// present under vitest. `UserRefLink` (used for the Onboarding Owner cell)
+// resolves an unknown id through `useBackendApi` — same approach as
+// ProjectContactsTab.test.tsx. Every test here passes a known `userId`, so
+// the mocked `post` is never actually invoked.
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: vi.fn() }),
+}));
+
 import CsmProjectDetailPage from "@features/csm-projects/pages/CsmProjectDetailPage";
 
 const PROJECT: ProjectDetails = {
@@ -151,5 +160,54 @@ describe("CsmProjectDetailPage — tab state", () => {
         from: "/customers/projects/proj-1?tab=workItems&subTab=engagements",
       }),
     );
+  });
+});
+
+describe("CsmProjectDetailPage — Onboarding Owner", () => {
+  it("renders the onboarding owner cell when onboarding is enabled and an owner is set", () => {
+    mockUseGetProject.mockReturnValue({
+      data: {
+        ...PROJECT,
+        onboardingStatus: "In-Progress",
+        onboardingOwner: {
+          id: "user-1",
+          name: "Jane Doe",
+          email: "jane.doe@example.com",
+        },
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+    expect(screen.getByText("Onboarding Owner")).toBeInTheDocument();
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+
+  it("hides the onboarding owner cell when onboardingStatus is Not-Applicable", () => {
+    mockUseGetProject.mockReturnValue({
+      data: {
+        ...PROJECT,
+        onboardingStatus: "Not-Applicable",
+        onboardingOwner: {
+          id: "user-1",
+          name: "Jane Doe",
+          email: "jane.doe@example.com",
+        },
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+    expect(screen.queryByText("Onboarding Owner")).not.toBeInTheDocument();
+  });
+
+  it("hides the onboarding owner cell when there is no onboarding engagement at all", () => {
+    mockUseGetProject.mockReturnValue({
+      data: { ...PROJECT },
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+    expect(screen.queryByText("Onboarding Owner")).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
@@ -29,6 +29,7 @@ import {
 import { ArrowLeft, ChevronDown, Plus } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX, type MouseEvent, type ReactNode } from "react";
 import { Link as RouterLink, useLocation, useParams } from "react-router";
+import UserRefLink from "@components/UserRefLink";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import ClosureStateChip from "@features/csm-projects/components/ClosureStateChip";
 import DeploymentsTab from "@features/csm-projects/components/DeploymentsTab";
@@ -351,6 +352,19 @@ export default function CsmProjectDetailPage(): JSX.Element {
             <MetaCell label={endDateLabel(p.endDate)}>
               <Typography variant="body2">{formatDate(p.endDate)}</Typography>
             </MetaCell>
+            {p.onboardingStatus &&
+              p.onboardingStatus !== "Not-Applicable" &&
+              p.onboardingOwner && (
+                <MetaCell label="Onboarding Owner">
+                  <Typography variant="body2">
+                    <UserRefLink
+                      name={p.onboardingOwner.name}
+                      email={p.onboardingOwner.email || undefined}
+                      userId={p.onboardingOwner.id}
+                    />
+                  </Typography>
+                </MetaCell>
+              )}
           </Box>
         </Card>
       )}

--- a/apps/csm-portal/webapp/src/features/csm-projects/types/csmProjects.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/types/csmProjects.ts
@@ -92,6 +92,28 @@ export interface ProjectDetails {
   /** Whether this project is eligible to raise service requests, as
    *  precomputed by the backing data source. */
   hasSr?: boolean;
+  /** Onboarding engagement status (ServiceNow data source only; `null`/absent
+   *  elsewhere and when the project has no onboarding engagement at all).
+   *  Treat the project as onboarding-enabled — and only then show
+   *  {@link onboardingOwner} — when this is present and not `"Not-Applicable"`. */
+  onboardingStatus?:
+    | "Not-Started"
+    | "In-Progress"
+    | "OnHold"
+    | "Completed"
+    | "Expired"
+    | "Cancelled"
+    | "Not-Applicable"
+    | null;
+  /** The onboarding consultant/owner assigned to this project. `null` for
+   *  most projects — only set for onboarding-enabled ones. Only meaningful
+   *  when {@link onboardingStatus} indicates onboarding is enabled.
+   *  Mirrors the shared {@link UserReference} shape (id/name/email), except
+   *  `email` here can genuinely be `null` (unlike `UserReference.email`,
+   *  which the backend always populates with something, even a non-email
+   *  placeholder) — this is a raw ServiceNow-sourced contact and may have no
+   *  email on file. */
+  onboardingOwner?: { id: string; name: string; email: string | null } | null;
 }
 
 export interface SearchProjectsRequest {

--- a/apps/csm-portal/webapp/src/features/help/content/customers.md
+++ b/apps/csm-portal/webapp/src/features/help/content/customers.md
@@ -28,7 +28,9 @@ state and start/end dates.
 Opening a project takes you to its detail page, with four tabs:
 
 - **Overview**: project key, closure state, subscription type, a link back to the owning
-  account, Salesforce ID, and the created/updated/start/end dates.
+  account, Salesforce ID, and the created/updated/start/end dates. An **Onboarding Owner**
+  field appears here too, but only for onboarding-enabled projects — it names the onboarding
+  consultant assigned to the project. It's absent for projects with no onboarding engagement.
 - **Deployments**: see below.
 - **Project contacts**: see below.
 - **Work items**: cases, service requests, and other work items filed against this project.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -466,6 +466,15 @@ type ProjectDetailsView struct {
 	// this project is eligible to raise service requests.
 	HasSr bool `json:"hasSr"`
 	ProjectClosureFields
+	// OnboardingStatus is the project's onboarding engagement status. Nil
+	// when the project has no onboarding engagement at all (the common
+	// case). Currently populated only from the ServiceNow data source.
+	OnboardingStatus *string `json:"onboardingStatus,omitempty"`
+	// OnboardingOwner is the person assigned to run this project's
+	// onboarding. Nil when no owner is assigned — most projects, since only
+	// onboarding-enabled projects have one. Currently populated only from
+	// the ServiceNow data source.
+	OnboardingOwner *PersonRef `json:"onboardingOwner,omitempty"`
 }
 
 // ProjectUpdateRequest is the input for PATCH /projects/{id} (ServiceNow data

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -466,10 +466,6 @@ type ProjectDetailsView struct {
 	// this project is eligible to raise service requests.
 	HasSr bool `json:"hasSr"`
 	ProjectClosureFields
-	// OnboardingStatus is the project's onboarding engagement status. Nil
-	// when the project has no onboarding engagement at all (the common
-	// case). Currently populated only from the ServiceNow data source.
-	OnboardingStatus *string `json:"onboardingStatus,omitempty"`
 	// OnboardingOwner is the person assigned to run this project's
 	// onboarding. Nil when no owner is assigned — most projects, since only
 	// onboarding-enabled projects have one. Currently populated only from

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -289,11 +289,10 @@ type snProjectDetailsResponse struct {
 	OnboardingStatus         *string  `json:"onboardingStatus"`
 	HasSr                    bool     `json:"hasSr"`
 	snProjectClosureFields
-	// OnboardingStatus and OnboardingOwner are absent/empty for projects
-	// with no onboarding engagement at all, and detail-endpoint-only —
-	// never present on the search/list response.
-	OnboardingStatus *string      `json:"onboardingStatus"`
-	OnboardingOwner  *snPersonRef `json:"onboardingOwner"`
+	// OnboardingOwner is absent/empty for projects with no onboarding
+	// engagement at all, and detail-endpoint-only — never present on the
+	// search/list response.
+	OnboardingOwner *snPersonRef `json:"onboardingOwner"`
 }
 
 type snProjectAccount struct {
@@ -386,11 +385,6 @@ func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domai
 		return domain.ProjectDetailsView{}, err
 	}
 
-	var onboardingStatus *string
-	if sn.OnboardingStatus != nil && *sn.OnboardingStatus != "" {
-		onboardingStatus = sn.OnboardingStatus
-	}
-
 	var onboardingOwner *domain.PersonRef
 	if sn.OnboardingOwner != nil && sn.OnboardingOwner.ID != "" {
 		onboardingOwner = &domain.PersonRef{
@@ -443,8 +437,7 @@ func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domai
 			OwnerEmail:          sn.Account.OwnerEmail,
 			TechnicalOwnerEmail: sn.Account.TechnicalOwnerEmail,
 		},
-		OnboardingStatus: onboardingStatus,
-		OnboardingOwner:  onboardingOwner,
+		OnboardingOwner: onboardingOwner,
 	}, nil
 }
 

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -289,6 +289,11 @@ type snProjectDetailsResponse struct {
 	OnboardingStatus         *string  `json:"onboardingStatus"`
 	HasSr                    bool     `json:"hasSr"`
 	snProjectClosureFields
+	// OnboardingStatus and OnboardingOwner are absent/empty for projects
+	// with no onboarding engagement at all, and detail-endpoint-only —
+	// never present on the search/list response.
+	OnboardingStatus *string      `json:"onboardingStatus"`
+	OnboardingOwner  *snPersonRef `json:"onboardingOwner"`
 }
 
 type snProjectAccount struct {
@@ -381,6 +386,20 @@ func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domai
 		return domain.ProjectDetailsView{}, err
 	}
 
+	var onboardingStatus *string
+	if sn.OnboardingStatus != nil && *sn.OnboardingStatus != "" {
+		onboardingStatus = sn.OnboardingStatus
+	}
+
+	var onboardingOwner *domain.PersonRef
+	if sn.OnboardingOwner != nil && sn.OnboardingOwner.ID != "" {
+		onboardingOwner = &domain.PersonRef{
+			ID:    sysidToUUID(sn.OnboardingOwner.ID),
+			Name:  sn.OnboardingOwner.Name,
+			Email: nilIfEmpty(sn.OnboardingOwner.Email),
+		}
+	}
+
 	return domain.ProjectDetailsView{
 		ID:               sysidToUUID(sn.ID),
 		SfID:             sn.SfID,
@@ -424,6 +443,8 @@ func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domai
 			OwnerEmail:          sn.Account.OwnerEmail,
 			TechnicalOwnerEmail: sn.Account.TechnicalOwnerEmail,
 		},
+		OnboardingStatus: onboardingStatus,
+		OnboardingOwner:  onboardingOwner,
 	}, nil
 }
 

--- a/entity-service/internal/service/sn_project_service_test.go
+++ b/entity-service/internal/service/sn_project_service_test.go
@@ -335,3 +335,73 @@ func TestSNProjectService_GetProjectByID_MapsHasSr(t *testing.T) {
 		t.Errorf("GetProjectByID HasSr = false, want true (passthrough of SN's hasSr)")
 	}
 }
+
+// TestSNProjectService_GetProjectByID_MapsOnboardingFields verifies that the
+// detail-only onboardingStatus and onboardingOwner fields are parsed from the
+// project-detail response and mapped into domain.ProjectDetailsView, with the
+// owner's sys_id converted to the service's UUID form.
+func TestSNProjectService_GetProjectByID_MapsOnboardingFields(t *testing.T) {
+	projectSysid := sysid32('a')
+	ownerSysid := sysid32('b')
+
+	client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": projectSysid, "name": "Onboarding Project", "key": "ONB", "sfId": "sf-2",
+			"createdOn": "2026-01-01 00:00:00", "startDate": "2026-01-01", "endDate": "2026-12-31",
+			"type":             map[string]any{"name": "Subscription"},
+			"account":          map[string]any{"id": "", "name": ""},
+			"onboardingStatus": "In-Progress",
+			"onboardingOwner":  map[string]any{"id": ownerSysid, "name": "Jane Doe", "email": "jane.doe@example.com"},
+		})
+	}))
+
+	svc := NewServiceNowProjectService(client, nil)
+	got, err := svc.GetProjectByID(contextWithUserIDToken("token"), sysidToUUID(projectSysid))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.OnboardingStatus == nil || *got.OnboardingStatus != "In-Progress" {
+		t.Errorf("GetProjectByID OnboardingStatus = %v, want \"In-Progress\"", got.OnboardingStatus)
+	}
+	wantOwnerID := sysidToUUID(ownerSysid)
+	if got.OnboardingOwner == nil {
+		t.Fatalf("GetProjectByID OnboardingOwner = nil, want non-nil")
+	}
+	if got.OnboardingOwner.ID != wantOwnerID || got.OnboardingOwner.Name != "Jane Doe" {
+		t.Errorf("GetProjectByID OnboardingOwner = %+v, want id=%s name=Jane Doe", got.OnboardingOwner, wantOwnerID)
+	}
+	if got.OnboardingOwner.Email == nil || *got.OnboardingOwner.Email != "jane.doe@example.com" {
+		t.Errorf("GetProjectByID OnboardingOwner.Email = %v, want jane.doe@example.com", got.OnboardingOwner.Email)
+	}
+}
+
+// TestSNProjectService_GetProjectByID_OnboardingFieldsAbsent verifies that
+// projects with no onboarding engagement at all (the common case) map to nil
+// OnboardingStatus and nil OnboardingOwner, rather than empty-string/zero-value
+// placeholders.
+func TestSNProjectService_GetProjectByID_OnboardingFieldsAbsent(t *testing.T) {
+	projectSysid := sysid32('c')
+
+	client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": projectSysid, "name": "No Onboarding", "key": "NOB", "sfId": "sf-3",
+			"createdOn": "2026-01-01 00:00:00", "startDate": "2026-01-01", "endDate": "2026-12-31",
+			"type":    map[string]any{"name": "Subscription"},
+			"account": map[string]any{"id": "", "name": ""},
+		})
+	}))
+
+	svc := NewServiceNowProjectService(client, nil)
+	got, err := svc.GetProjectByID(contextWithUserIDToken("token"), sysidToUUID(projectSysid))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.OnboardingStatus != nil {
+		t.Errorf("GetProjectByID OnboardingStatus = %v, want nil", *got.OnboardingStatus)
+	}
+	if got.OnboardingOwner != nil {
+		t.Errorf("GetProjectByID OnboardingOwner = %+v, want nil", got.OnboardingOwner)
+	}
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -6144,6 +6144,28 @@ components:
         suspensionProcessState:
           type: object
           additionalProperties: true
+        onboardingStatus:
+          type: string
+          nullable: true
+          enum:
+            - Not-Started
+            - In-Progress
+            - OnHold
+            - Completed
+            - Expired
+            - Cancelled
+            - Not-Applicable
+          description: >
+            The project's onboarding engagement status. Null when the project
+            has no onboarding engagement at all.
+        onboardingOwner:
+          allOf:
+            - $ref: '#/components/schemas/PersonRef'
+          nullable: true
+          description: >
+            The person assigned to run this project's onboarding. Null when
+            no owner is assigned — most projects, since only
+            onboarding-enabled projects have one.
           nullable: true
           description: >
             Free-form, per-dimension Account Closure Process (ACP) suspension-process

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -6144,20 +6144,12 @@ components:
         suspensionProcessState:
           type: object
           additionalProperties: true
-        onboardingStatus:
-          type: string
           nullable: true
-          enum:
-            - Not-Started
-            - In-Progress
-            - OnHold
-            - Completed
-            - Expired
-            - Cancelled
-            - Not-Applicable
           description: >
-            The project's onboarding engagement status. Null when the project
-            has no onboarding engagement at all.
+            Free-form, per-dimension Account Closure Process (ACP) suspension-process
+            state (event type + action results) written by an existing ServiceNow
+            suspension flow. This is opaque JSON passed through as-is — its shape is
+            not defined or validated by this layer.
         onboardingOwner:
           allOf:
             - $ref: '#/components/schemas/PersonRef'
@@ -6166,12 +6158,6 @@ components:
             The person assigned to run this project's onboarding. Null when
             no owner is assigned — most projects, since only
             onboarding-enabled projects have one.
-          nullable: true
-          description: >
-            Free-form, per-dimension Account Closure Process (ACP) suspension-process
-            state (event type + action results) written by an existing ServiceNow
-            suspension flow. This is opaque JSON passed through as-is — its shape is
-            not defined or validated by this layer.
 
     ProjectView:
       type: object


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The CSM portal's case overview and project detail views have no way to show a project's onboarding owner, and no indication of whether a project has an onboarding engagement at all. Tracked internally; resolves a reported gap in onboarding visibility for CS engineers handling onboarding-enabled projects.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

We are adding an "Onboarding Owner" field to the project-detail response and surfacing it in two places: the case overview's customer/project widget, and the project detail page. It only appears when the project actually has an active onboarding engagement.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- `entity-service`: added `OnboardingOwner *PersonRef` to `ProjectDetailsView` (detail-endpoint only, matching how the existing onboarding-hours fields are already scoped), reusing the existing `PersonRef`/`snPersonRef` shapes already used for other project-account contacts. Sourced from the backing data source's existing project-details call, which now includes this field — purely additive.
- `apps/csm-portal/backend`: no code change (the project handler already streams the entity-service's JSON straight through); documented the two new fields (`onboardingStatus`, `onboardingOwner`) in this app's own `openapi.yaml`.
- `apps/csm-portal/webapp`: added `onboardingStatus`/`onboardingOwner` to the `ProjectDetails` TS type, and a gated "Onboarding Owner" row in `CustomerContextWidget` (case overview) and `CsmProjectDetailPage` (project detail), shown only when `onboardingStatus` is present and not `"Not-Applicable"` and an owner is assigned. Updated the in-app `/help` guide's Projects Overview topic with a short note about the new field.

Screenshot (project detail page, Overview tab, showing the new "Onboarding Owner" row populated from a real test project against a non-production backend):

not attached here — verified live via manual walkthrough (see Automation tests below); happy to attach on request.

## User stories
> Summary of user stories addressed by this change

As a CS engineer viewing a case or its project, I can see the onboarding owner assigned to that project, when onboarding is enabled, so I know who to loop in for onboarding-related questions.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

The CSM portal now shows the assigned onboarding owner on a project's detail page and in a case's project summary, for projects with an active onboarding engagement.

## Documentation
N/A — the in-app `/help` guide (`features/help/content/customers.md`) was updated as part of this PR; no other product documentation covers this surface.

## Training
N/A — no training content covers this internal-tool feature.

## Certification
N/A — no certification exam content covers this internal-tool feature.

## Marketing
N/A — internal CS-tooling change, not a customer-facing product launch.

## Automation tests
 - Unit tests
   - `entity-service`: `go test ./...` — all packages pass; added 2 new table-driven test cases to `sn_project_service_test.go` covering the field present/absent cases.
   - `webapp`: `npx vitest run` — full suite 251 files / 2592 tests passing; added 3 new test cases each to `CaseDetailWidgets.test.tsx` and `CsmProjectDetailPage.test.tsx` covering the gating logic (shown when enabled+owner present, hidden when the engagement status indicates onboarding is not applicable, hidden when there's no engagement at all).
 - Integration tests
   Manually verified end-to-end against a real, non-production backing data source (local entity-service + backend + webapp stack, real IdP login): confirmed the field renders correctly on both the project detail page and the case overview widget for a real test project with an assigned onboarding owner, and confirmed it does not render for projects without one.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for Go/TS — ran `go vet ./...` (clean) and `gosec -fmt=text ./...` on `entity-service` (0 issues, 123 files / 35190 lines scanned) instead; `eslint` on the touched webapp files (clean).
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample apps consume this field.

## Related PRs
A corresponding backend-data-source PR (private repo, not linkable here) adds the underlying field this depends on.

## Migrations (if applicable)
N/A — no schema or data migration; purely additive API field and UI change.

## Test environment
- Go: go1.23.4 darwin/arm64
- Node: v24.5.0
- OS: macOS 26.6.2 (build 25G83)
- Browser: Chrome (latest stable), manual walkthrough of both affected pages

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Traced the missing field from the UI gap down through the entity-service response and its origin, confirming it as a genuinely new, previously-unconsumed data-source field rather than a UI oversight, before adding the plumbing through each layer.
