### PR TITLE
[CSM Portal] handle empty start/end date on project detail without erroring

### DIFF
--- a/apps/csm-portal/microapp/src/types/project.dto.ts
+++ b/apps/csm-portal/microapp/src/types/project.dto.ts
@@ -35,8 +35,8 @@ export interface ProjectDto {
   // webapp's own csmProjects.ts, which carries the same correction.
   key?: string;
   subscriptionType: ProjectSubscriptionType;
-  startDate?: string;
-  endDate?: string;
+  startDate?: string | null;
+  endDate?: string | null;
   createdOn?: string;
   updatedOn?: string;
 }
@@ -76,8 +76,8 @@ export interface ProjectDetailDto {
   name: string;
   key?: string;
   subscriptionType: ProjectSubscriptionType;
-  startDate?: string;
-  endDate?: string;
+  startDate?: string | null;
+  endDate?: string | null;
   createdOn?: string;
   updatedOn?: string;
   account?: ProjectAccountRefDto;

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1679,8 +1679,8 @@ export interface BeProject {
   /** Whether this project is eligible to raise service requests, as
    *  precomputed by the backing data source. */
   hasSr?: boolean;
-  startDate?: string;
-  endDate?: string;
+  startDate?: string | null;
+  endDate?: string | null;
   createdAt?: string;
   updatedAt?: string;
 }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -457,10 +457,14 @@ type ProjectDetailsView struct {
 	Name             string            `json:"name"`
 	Key              string            `json:"key"`
 	SubscriptionType SubscriptionType  `json:"subscriptionType"`
-	StartDate        time.Time         `json:"startDate"`
-	EndDate          time.Time         `json:"endDate"`
-	CreatedOn        time.Time         `json:"createdOn"`
-	UpdatedOn        time.Time         `json:"updatedOn"`
+	// StartDate/EndDate are pointers: ServiceNow may legitimately leave either
+	// unset on a project, and a nil date must round-trip as JSON null rather
+	// than a fabricated zero-value timestamp. Matches ProjectView's StartDate/
+	// EndDate, and the other optional dates on this struct (GoLiveDate, etc.).
+	StartDate *time.Time `json:"startDate"`
+	EndDate   *time.Time `json:"endDate"`
+	CreatedOn time.Time  `json:"createdOn"`
+	UpdatedOn time.Time  `json:"updatedOn"`
 	ProjectEngagementFields
 	// HasSr is the backing data source's own precomputed answer to whether
 	// this project is eligible to raise service requests.

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -349,14 +349,14 @@ func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domai
 		return domain.ProjectDetailsView{}, fmt.Errorf("sn projects: parse createdOn %q: %w", sn.CreatedOn, err)
 	}
 
-	startDate, err := time.Parse(snDateLayout, sn.StartDate)
+	startDate, err := optionalSNProjectDate("startDate", &sn.StartDate)
 	if err != nil {
-		return domain.ProjectDetailsView{}, fmt.Errorf("sn projects: parse startDate %q: %w", sn.StartDate, err)
+		return domain.ProjectDetailsView{}, err
 	}
 
-	endDate, err := time.Parse(snDateLayout, sn.EndDate)
+	endDate, err := optionalSNProjectDate("endDate", &sn.EndDate)
 	if err != nil {
-		return domain.ProjectDetailsView{}, fmt.Errorf("sn projects: parse endDate %q: %w", sn.EndDate, err)
+		return domain.ProjectDetailsView{}, err
 	}
 
 	subType, err := snTypeNameToSubscriptionType(sn.Type.Name)

--- a/entity-service/internal/service/sn_project_service_test.go
+++ b/entity-service/internal/service/sn_project_service_test.go
@@ -405,3 +405,111 @@ func TestSNProjectService_GetProjectByID_OnboardingFieldsAbsent(t *testing.T) {
 		t.Errorf("GetProjectByID OnboardingOwner = %+v, want nil", got.OnboardingOwner)
 	}
 }
+
+// TestSNProjectService_GetProjectByID_MapsStartEndDate verifies that populated
+// startDate/endDate values are parsed into non-nil domain.ProjectDetailsView
+// dates, so the empty-string handling added below doesn't regress the normal
+// case.
+func TestSNProjectService_GetProjectByID_MapsStartEndDate(t *testing.T) {
+	projectSysid := sysid32('d')
+
+	client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": projectSysid, "name": "Dated Project", "key": "DTD", "sfId": "sf-4",
+			"createdOn": "2026-01-01 00:00:00", "startDate": "2026-01-01", "endDate": "2026-12-31",
+			"type":    map[string]any{"name": "Subscription"},
+			"account": map[string]any{"id": "", "name": ""},
+		})
+	}))
+
+	svc := NewServiceNowProjectService(client, nil)
+	got, err := svc.GetProjectByID(contextWithUserIDToken("token"), sysidToUUID(projectSysid))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.StartDate == nil || !got.StartDate.Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("GetProjectByID StartDate = %v, want 2026-01-01", got.StartDate)
+	}
+	if got.EndDate == nil || !got.EndDate.Equal(time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("GetProjectByID EndDate = %v, want 2026-12-31", got.EndDate)
+	}
+}
+
+// TestSNProjectService_GetProjectByID_EmptyStartEndDate is the regression guard
+// for the bug where ServiceNow legitimately returning "" for a project's
+// startDate/endDate (field genuinely not set on that record) crashed
+// GetProjectByID with a time.Parse error instead of mapping to nil — a project
+// read must return normally with the date fields absent, not 500.
+func TestSNProjectService_GetProjectByID_EmptyStartEndDate(t *testing.T) {
+	projectSysid := sysid32('e')
+
+	client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": projectSysid, "name": "Undated Project", "key": "UND", "sfId": "sf-5",
+			"createdOn": "2026-01-01 00:00:00", "startDate": "", "endDate": "",
+			"type":    map[string]any{"name": "Subscription"},
+			"account": map[string]any{"id": "", "name": ""},
+		})
+	}))
+
+	svc := NewServiceNowProjectService(client, nil)
+	got, err := svc.GetProjectByID(contextWithUserIDToken("token"), sysidToUUID(projectSysid))
+	if err != nil {
+		t.Fatalf("GetProjectByID returned error for empty startDate/endDate (should map to nil, not error): %v", err)
+	}
+	if got.StartDate != nil {
+		t.Errorf("GetProjectByID StartDate = %v, want nil for empty upstream startDate", *got.StartDate)
+	}
+	if got.EndDate != nil {
+		t.Errorf("GetProjectByID EndDate = %v, want nil for empty upstream endDate", *got.EndDate)
+	}
+}
+
+// TestSNProjectService_GetProjectByID_EmptyOptionalDates is an audit-driven
+// regression guard for every other optional date on the project-detail
+// response — goLiveDate, goLivePlanDate, onboardingExpiryDate, and the
+// account's activationDate/deactivationDate. All five already routed through
+// optionalSNProjectDate before the startDate/endDate fix, so this pins that
+// they actually behave: empty string maps to nil, not a parse error or a
+// zero-value timestamp.
+func TestSNProjectService_GetProjectByID_EmptyOptionalDates(t *testing.T) {
+	projectSysid := sysid32('f')
+
+	client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": projectSysid, "name": "No Optional Dates", "key": "NOD", "sfId": "sf-6",
+			"createdOn": "2026-01-01 00:00:00", "startDate": "2026-01-01", "endDate": "2026-12-31",
+			"type": map[string]any{"name": "Subscription"},
+			"account": map[string]any{
+				"id": "", "name": "", "activationDate": "", "deactivationDate": "",
+			},
+			"goLiveDate":           "",
+			"goLivePlanDate":       "",
+			"onboardingExpiryDate": "",
+		})
+	}))
+
+	svc := NewServiceNowProjectService(client, nil)
+	got, err := svc.GetProjectByID(contextWithUserIDToken("token"), sysidToUUID(projectSysid))
+	if err != nil {
+		t.Fatalf("GetProjectByID returned error for empty optional dates (should map to nil, not error): %v", err)
+	}
+	if got.GoLiveDate != nil {
+		t.Errorf("GetProjectByID GoLiveDate = %v, want nil for empty upstream goLiveDate", *got.GoLiveDate)
+	}
+	if got.GoLivePlanDate != nil {
+		t.Errorf("GetProjectByID GoLivePlanDate = %v, want nil for empty upstream goLivePlanDate", *got.GoLivePlanDate)
+	}
+	if got.OnboardingExpiryDate != nil {
+		t.Errorf("GetProjectByID OnboardingExpiryDate = %v, want nil for empty upstream onboardingExpiryDate", *got.OnboardingExpiryDate)
+	}
+	if got.Account.ActivationDate != nil {
+		t.Errorf("GetProjectByID Account.ActivationDate = %v, want nil for empty upstream activationDate", *got.Account.ActivationDate)
+	}
+	if got.Account.DeactivationDate != nil {
+		t.Errorf("GetProjectByID Account.DeactivationDate = %v, want nil for empty upstream deactivationDate", *got.Account.DeactivationDate)
+	}
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -6204,9 +6204,15 @@ components:
         startDate:
           type: string
           format: date-time
+          nullable: true
+          description: >
+            Start of the project's current renewed period. Null when the backing
+            data source has no start date recorded.
         endDate:
           type: string
           format: date-time
+          nullable: true
+          description: End of the project's current renewed period.
         createdOn:
           type: string
           format: date-time

--- a/integrations/csm-integration-service/openapi.yaml
+++ b/integrations/csm-integration-service/openapi.yaml
@@ -542,9 +542,11 @@ components:
         startDate:
           type: string
           format: date-time
+          nullable: true
         endDate:
           type: string
           format: date-time
+          nullable: true
         createdOn:
           type: string
           format: date-time


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

`GET /projects/{id}` on the Go entity-service (`GetProjectByID`) returns a 500 whenever a project's backing data source leaves `startDate` or `endDate` unset, because both were parsed unconditionally with no empty-value guard. Every other optional project date field (`goLiveDate`, `goLivePlanDate`, `onboardingExpiryDate`, account `activationDate`/`deactivationDate`) was already guarded against this; `startDate`/`endDate` in this one method were not.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

`startDate`/`endDate` on `ProjectDetailsView` are now nullable, matching every other optional date on the same struct and the sibling `ProjectView` schema (used by `SearchProjects`, which already handled this correctly). An absent value now serializes as `null` instead of failing the whole request.

## Approach
> Describe how you are implementing the solutions.

`ProjectDetailsView.StartDate`/`.EndDate` changed from `time.Time` to `*time.Time`. `GetProjectByID` now routes both through the existing `optionalSNProjectDate` helper (already used elsewhere in this file) instead of calling `time.Parse` directly. `openapi.yaml`'s `ProjectDetailsView` schema marks both fields `nullable: true`.

Audited every other date field on the project entity, and the same class of bug across the other three Go components in this stack (CSM backend, CSM integration service, customer-portal backend v2) — no other instance found. Everything else was already guarded, passthrough, or relies on Go's null-safe `time.Time.UnmarshalJSON`.

Two mandatory, platform-populated timestamps (`createdOn`, `updatedOn`) were deliberately left unguarded: an empty value there means the underlying record itself is corrupt, not a legitimate absence, so failing loudly is correct.

## User stories
> Summary of user stories addressed by this change

N/A — bug fix, no new user-facing capability.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed a 500 error on project detail retrieval when a project has no recorded start or end date; the date now returns as null instead of failing the request.

## Documentation
> Link(s) to product documentation...

N/A — internal API error-handling fix, no user-facing documentation to update.

## Training
N/A — not applicable to training content.

## Certification
N/A — no exam impact.

## Marketing
N/A — bug fix, not a marketing-relevant feature.

## Automation tests
 - Unit tests
   > Added `TestSNProjectService_GetProjectByID_EmptyStartEndDate` and `TestSNProjectService_GetProjectByID_MapsStartEndDate` (regression guard for the populated-date case), plus `TestSNProjectService_GetProjectByID_EmptyOptionalDates` proving the already-guarded fields (`goLiveDate`, `goLivePlanDate`, `onboardingExpiryDate`, account `activationDate`/`deactivationDate`) behave the same way.
 - Integration tests
   > None added — this is a pure entity-service unit-level fix; no integration harness exists for this path in this repo.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go project — ran `gosec -fmt=text ./...` instead: 0 issues across 125 files/35474 lines; also `go vet ./...` clean)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample code affected.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data migration; this only changes response serialization for a field that was previously erroring, so no existing consumer can depend on `startDate`/`endDate` being always-present in a case where the request previously failed outright.

## Test environment
Verified via `go build ./...`, `go vet ./...`, `go test ./...` (all clean) and `gosec ./...` (0 issues) on the entity-service module. No live-cluster/browser testing needed for this backend-only change.

## Learning
> Describe the research phase...

Traced from a live 500 on staging (`customer-portal-backend-v` → `customer-entity-service`) via application logs, confirmed via `git blame` that the unguarded parse was a ~12-week-old dormant bug (not a recent regression), and confirmed via a full repo-wide consumer grep that no downstream caller (CSM/customer-portal backends, both webapps) assumes this field is non-nullable — one of them (`customer-portal-backend-v2`) already had defensive handling anticipating exactly this case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project details now handle missing start and end dates without errors.
  * Recorded dates continue to be parsed correctly, while malformed dates still report errors.
  * Other optional project and account dates now safely support empty values.

* **Documentation**
  * API documentation now identifies project start and end dates as nullable when unavailable.
  * Project data types now support explicitly null start and end dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->