### PR TITLE
[Entity-Service] detect a "patch" tag on an S4 case as a billable-status override (log only)

### DIFF
--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -120,18 +120,23 @@ EventPublisherService` field for this (nil the same way `snCaseService`'s
 own `publisher` can be), wired from `routes.go`'s existing `eventPublisher`
 var.
 
-**Special case, same inert posture**: `caseService.AddCaseTag` calls
-`detectPatchTagBillableOverride`, which forces `isBillable=false` (logged
-only, same as above) when a case tagged `"patch"` (case/whitespace-
-insensitive) is currently at LOW severity — WSO2 still covers a patch under
-support even for an otherwise best-efforts S4 case, overriding the normal
-"entering S4 makes time cards billable" rule. One-directional: removing the
-tag never reverses it. **TEMPORARY**: case tags have no real Postgres
-storage at all yet (no `case_tags` table/repo — `AddCaseTag`/`RemoveCaseTag`/
-`SearchTags` are ServiceNow-only, see `sn_case_service.go`'s own real
-implementations), so this override runs and logs ahead of the tag itself
-ever actually being persisted on this data source — added at explicit
-request, to be wired into a real `AddCaseTag` once `case_tags` exists.
+**Special case, detects and logs only — no behavior change yet**:
+`caseService.AddCaseTag` calls `detectPatchTagBillableOverride`, which
+*detects and logs* (nothing more) when a case tagged `"patch"`
+(case/whitespace-insensitive) is currently at LOW severity — the eventual
+intent is that WSO2 still covers a patch under support even for an
+otherwise best-efforts S4 case, so such a case's time cards should one day
+become non-billable regardless (one-directionally: removing the tag would
+never reverse it), overriding the normal "entering S4 makes time cards
+billable" rule. **Today this changes nothing**: no time card's billable
+status is altered, no event is published, and no tag is ever persisted.
+**TEMPORARY**: case tags have no real Postgres storage at all yet (no
+`case_tags` table/repo — `AddCaseTag`/`RemoveCaseTag`/`SearchTags` are
+ServiceNow-only, see `sn_case_service.go`'s own real implementations), so
+`AddCaseTag` on this data source still always returns a 503 regardless of
+this detection — added at explicit request, ahead of both real tag storage
+and a real time-card reaction, so the rule's logic is demonstrable now and
+easy to wire up for real once both exist.
 
 - **`snCaseService.CreateCase`** publishes `case.created` via a private
   `publishCaseCreated` helper, called after the SN create call succeeds.

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -120,6 +120,19 @@ EventPublisherService` field for this (nil the same way `snCaseService`'s
 own `publisher` can be), wired from `routes.go`'s existing `eventPublisher`
 var.
 
+**Special case, same inert posture**: `caseService.AddCaseTag` calls
+`detectPatchTagBillableOverride`, which forces `isBillable=false` (logged
+only, same as above) when a case tagged `"patch"` (case/whitespace-
+insensitive) is currently at LOW severity — WSO2 still covers a patch under
+support even for an otherwise best-efforts S4 case, overriding the normal
+"entering S4 makes time cards billable" rule. One-directional: removing the
+tag never reverses it. **TEMPORARY**: case tags have no real Postgres
+storage at all yet (no `case_tags` table/repo — `AddCaseTag`/`RemoveCaseTag`/
+`SearchTags` are ServiceNow-only, see `sn_case_service.go`'s own real
+implementations), so this override runs and logs ahead of the tag itself
+ever actually being persisted on this data source — added at explicit
+request, to be wired into a real `AddCaseTag` once `case_tags` exists.
+
 - **`snCaseService.CreateCase`** publishes `case.created` via a private
   `publishCaseCreated` helper, called after the SN create call succeeds.
   Rather than building the payload from `req`/the create response (which

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -872,38 +872,44 @@ func (s *caseService) GetAttachment(_ context.Context, _ string) (domain.Attachm
 
 // AddCaseTag implements CaseService.
 //
-// TEMPORARY: case tags have no real Postgres storage yet — no case_tags
-// table/migration/repository exists on this data source, so this remains a
-// stub that reports the tag itself as unsupported (matching the two
-// sibling stubs below). The one exception, added ahead of real tag
-// storage at explicit request: a "patch" label on a case currently at LOW
-// severity (S4) is a special-case override of
-// detectBillableStatusChange's normal "entering S4 makes time cards
-// billable" rule — see detectPatchTagBillableOverride's own doc comment.
-// That check runs (and logs its result) even though the tag itself is
-// never actually persisted here, so the override logic is real and
-// demonstrable ahead of full Postgres tag support — wire this into a real
-// AddCaseTag once case_tags exists, rather than leaving it stranded here.
+// TEMPORARY, DETECTION-ONLY: case tags have no real Postgres storage yet —
+// no case_tags table/migration/repository exists on this data source, so
+// this remains a stub that reports the tag itself as unsupported (matching
+// the two sibling stubs below) — no tag is ever persisted, and no time
+// card's billable status is ever actually changed by this method. The one
+// addition, ahead of real tag storage at explicit request: a "patch" label
+// on a case currently at LOW severity (S4) is DETECTED (and only logged,
+// nothing more) as a special case of detectBillableStatusChange's normal
+// "entering S4 makes time cards billable" rule — see
+// detectPatchTagBillableOverride's own doc comment for exactly what this
+// does and doesn't do yet.
 func (s *caseService) AddCaseTag(ctx context.Context, caseID, label string) (domain.Tag, error) {
 	s.detectPatchTagBillableOverride(ctx, caseID, label)
 	return domain.Tag{}, &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
 }
 
-// detectPatchTagBillableOverride is a special-case override of
-// detectBillableStatusChange's normal "entering LOW/S4 severity makes time
-// cards billable" rule: a case tagged "patch" while at LOW severity should
-// have its time cards non-billable regardless — WSO2 still covers a patch
-// under support even for an otherwise best-efforts S4 case. Label matching
-// is case/whitespace-insensitive, same reasoning as this codebase's other
-// free-text label lookups (e.g. slaSeverityLabelAndColor in
-// csm-notification-service). Unlike detectBillableStatusChange, this is
-// one-directional: removing the tag (or adding any other label) never
-// reverses it — this only ever forces isBillable=false, never back to
-// true, since there's no natural "un-patch" event to react to.
+// detectPatchTagBillableOverride DETECTS AND LOGS ONLY — it does not
+// itself change any time card's billable status, publish an event, or
+// persist the tag (see AddCaseTag's own doc comment). It is a special case
+// of detectBillableStatusChange's normal "entering LOW/S4 severity makes
+// time cards billable" rule: a case tagged "patch" while at LOW severity
+// should eventually have its time cards non-billable regardless — WSO2
+// still covers a patch under support even for an otherwise best-efforts S4
+// case — but nothing in this codebase acts on that yet (see the TODO
+// below). Label matching is case/whitespace-insensitive, same reasoning as
+// this codebase's other free-text label lookups (e.g.
+// slaSeverityLabelAndColor in csm-notification-service). Unlike
+// detectBillableStatusChange, the eventual reaction is meant to be
+// one-directional: removing the tag (or adding any other label) should
+// never reverse it — only ever set isBillable=false, never back to true,
+// since there's no natural "un-patch" event to react to.
 //
 // Same commented-out-publish posture as detectBillableStatusChange: logs
 // only, since there is still no time_cards consumer to act on
-// events.TypeCaseBillableStatusChanged (see that type's own doc comment).
+// events.TypeCaseBillableStatusChanged (see that type's own doc comment) —
+// and, unlike detectBillableStatusChange, no way to even publish from a
+// real code path yet, since AddCaseTag itself never succeeds on this data
+// source (see its own doc comment).
 func (s *caseService) detectPatchTagBillableOverride(ctx context.Context, caseID, label string) {
 	if !strings.EqualFold(strings.TrimSpace(label), "patch") {
 		return
@@ -918,9 +924,11 @@ func (s *caseService) detectPatchTagBillableOverride(ctx context.Context, caseID
 		return
 	}
 
-	// TODO: enable once a consumer exists for events.TypeCaseBillableStatusChanged
-	// (bulk-flipping every time card's IsBillable for caseId) — see that
-	// type's own doc comment for what's still missing.
+	// TODO: enable once (a) case tags have real Postgres storage so
+	// AddCaseTag can actually succeed, and (b) a consumer exists for
+	// events.TypeCaseBillableStatusChanged (bulk-flipping every time
+	// card's IsBillable for caseId) — see that type's own doc comment for
+	// what's still missing there.
 	//
 	// payload, err := json.Marshal(events.CaseBillableStatusChangedPayload{CaseID: caseID, IsBillable: false})
 	// if err != nil {
@@ -934,7 +942,7 @@ func (s *caseService) detectPatchTagBillableOverride(ctx context.Context, caseID
 	// 	slog.ErrorContext(ctx, "add case tag: publish case.billable_status_changed failed", "caseId", caseID)
 	// }
 
-	slog.InfoContext(ctx, "add case tag: patch tag on an S4 case, time cards should be non-billable, event hub publish not yet enabled", "caseId", caseID, "isBillable", false)
+	slog.InfoContext(ctx, "add case tag: patch tag detected on an S4 case, time cards would need to become non-billable once a real tag/time-card path exists (detection only, no action taken)", "caseId", caseID, "isBillable", false)
 }
 
 func (s *caseService) RemoveCaseTag(_ context.Context, _, _ string) error {

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -870,8 +870,71 @@ func (s *caseService) GetAttachment(_ context.Context, _ string) (domain.Attachm
 	return domain.Attachment{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
 }
 
-func (s *caseService) AddCaseTag(_ context.Context, _, _ string) (domain.Tag, error) {
+// AddCaseTag implements CaseService.
+//
+// TEMPORARY: case tags have no real Postgres storage yet — no case_tags
+// table/migration/repository exists on this data source, so this remains a
+// stub that reports the tag itself as unsupported (matching the two
+// sibling stubs below). The one exception, added ahead of real tag
+// storage at explicit request: a "patch" label on a case currently at LOW
+// severity (S4) is a special-case override of
+// detectBillableStatusChange's normal "entering S4 makes time cards
+// billable" rule — see detectPatchTagBillableOverride's own doc comment.
+// That check runs (and logs its result) even though the tag itself is
+// never actually persisted here, so the override logic is real and
+// demonstrable ahead of full Postgres tag support — wire this into a real
+// AddCaseTag once case_tags exists, rather than leaving it stranded here.
+func (s *caseService) AddCaseTag(ctx context.Context, caseID, label string) (domain.Tag, error) {
+	s.detectPatchTagBillableOverride(ctx, caseID, label)
 	return domain.Tag{}, &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
+}
+
+// detectPatchTagBillableOverride is a special-case override of
+// detectBillableStatusChange's normal "entering LOW/S4 severity makes time
+// cards billable" rule: a case tagged "patch" while at LOW severity should
+// have its time cards non-billable regardless — WSO2 still covers a patch
+// under support even for an otherwise best-efforts S4 case. Label matching
+// is case/whitespace-insensitive, same reasoning as this codebase's other
+// free-text label lookups (e.g. slaSeverityLabelAndColor in
+// csm-notification-service). Unlike detectBillableStatusChange, this is
+// one-directional: removing the tag (or adding any other label) never
+// reverses it — this only ever forces isBillable=false, never back to
+// true, since there's no natural "un-patch" event to react to.
+//
+// Same commented-out-publish posture as detectBillableStatusChange: logs
+// only, since there is still no time_cards consumer to act on
+// events.TypeCaseBillableStatusChanged (see that type's own doc comment).
+func (s *caseService) detectPatchTagBillableOverride(ctx context.Context, caseID, label string) {
+	if !strings.EqualFold(strings.TrimSpace(label), "patch") {
+		return
+	}
+
+	cv, err := s.repo.GetCaseByID(ctx, caseID)
+	if err != nil {
+		slog.ErrorContext(ctx, "add case tag: patch billable override not evaluated, get case failed", "caseId", caseID)
+		return
+	}
+	if cv.Severity != domain.CaseSeverityLow {
+		return
+	}
+
+	// TODO: enable once a consumer exists for events.TypeCaseBillableStatusChanged
+	// (bulk-flipping every time card's IsBillable for caseId) — see that
+	// type's own doc comment for what's still missing.
+	//
+	// payload, err := json.Marshal(events.CaseBillableStatusChangedPayload{CaseID: caseID, IsBillable: false})
+	// if err != nil {
+	// 	slog.ErrorContext(ctx, "add case tag: encode case.billable_status_changed payload failed", "caseId", caseID, "error", err)
+	// 	return
+	// }
+	// if s.publisher == nil {
+	// 	return
+	// }
+	// if err := s.publisher.Publish(ctx, events.TypeCaseBillableStatusChanged, caseID, payload); err != nil {
+	// 	slog.ErrorContext(ctx, "add case tag: publish case.billable_status_changed failed", "caseId", caseID)
+	// }
+
+	slog.InfoContext(ctx, "add case tag: patch tag on an S4 case, time cards should be non-billable, event hub publish not yet enabled", "caseId", caseID, "isBillable", false)
 }
 
 func (s *caseService) RemoveCaseTag(_ context.Context, _, _ string) error {


### PR DESCRIPTION
## Summary
- Detects (and only logs) a special case of the existing severity-crossing billable-status detection: a case tagged `"patch"` (case/whitespace-insensitive) while at LOW severity should eventually make its time cards non-billable regardless — WSO2 still covers a patch under support even for an otherwise best-efforts S4 case, overriding the normal "entering S4 makes time cards billable" rule. One-directional: removing the tag would never reverse it.
- **This changes no behavior today.** `AddCaseTag` on the Postgres data source still always returns `ServiceUnavailableError` (case tags have no real Postgres storage at all — `case_tags` table/repo doesn't exist; `AddCaseTag`/`RemoveCaseTag`/`SearchTags` are ServiceNow-only). No tag is ever persisted, no time card's billable status is ever changed, and the `case.billable_status_changed` publish remains commented out (same posture as the existing severity-crossing detection — no consumer exists yet either).
- Added at explicit request, ahead of both real tag storage and a real time-card reaction, so the rule's logic is demonstrable now and easy to wire up for real once both exist.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean on `entity-service`
- [x] `gosec ./...` clean (0 issues)
- [x] `govulncheck ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)