### PR TITLE
[CSM Portal] CS Monitor Dashboard: alias "Escalated Cases" to "Escalations"

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/wallboardMetricStyle.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/wallboardMetricStyle.test.ts
@@ -106,6 +106,7 @@ describe("resolveDisplayNameAlias", () => {
     expect(resolveDisplayNameAlias("Open Service Request")).toBe("Open SR");
     expect(resolveDisplayNameAlias("Service Request - In-Progress")).toBe("In-Progress SR");
     expect(resolveDisplayNameAlias("Escalated")).toBe("Escalations");
+    expect(resolveDisplayNameAlias("Escalated Cases")).toBe("Escalations");
     expect(resolveDisplayNameAlias("SRE - SLA Violations")).toBe("SLA Violations");
     expect(resolveDisplayNameAlias("30+ Days")).toBe("30+ Days Cases");
   });
@@ -119,9 +120,10 @@ describe("resolveDisplayNameAlias", () => {
     expect(order.indexOf(resolveDisplayNameAlias("30+ Days"))).toBe(order.indexOf("30+ Days Cases"));
   });
 
-  it("resolves aliased 'Escalated' -> 'Escalations' into CRE_PRIMARY_ORDER's own 4th slot (right of SLA Violations)", () => {
+  it("resolves aliased 'Escalated' / 'Escalated Cases' -> 'Escalations' into CRE_PRIMARY_ORDER's own 4th slot (right of SLA Violations)", () => {
     const order: readonly string[] = CRE_PRIMARY_ORDER;
     expect(order.indexOf(resolveDisplayNameAlias("Escalated"))).toBe(order.indexOf("Escalations"));
+    expect(order.indexOf(resolveDisplayNameAlias("Escalated Cases"))).toBe(order.indexOf("Escalations"));
     expect(order.indexOf("Escalations")).toBe(order.indexOf("SLA Violations") + 1);
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/wallboardMetricStyle.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/wallboardMetricStyle.ts
@@ -254,11 +254,13 @@ const DISPLAY_NAME_ALIASES: Record<string, string> = {
   "Customer Approval CR": "Cust. Approval CR",
   "Open Service Request": "Open SR",
   "Service Request - In-Progress": "In-Progress SR",
-  // CRE's own — "Escalated" here instead of "Escalations" meant it never
-  // matched CRE_PRIMARY_ORDER's exact "Escalations" entry, so it fell
-  // into the secondary tier instead of its correct 4th primary-grid
-  // position (right of SLA Violations).
+  // CRE's own — the live config has spelled this "Escalated" and, more
+  // recently, "Escalated Cases"; either must alias to "Escalations" so it
+  // matches CRE_PRIMARY_ORDER's exact "Escalations" entry and lands in its
+  // correct 4th primary-grid slot (right of SLA Violations, per
+  // CS_Monitor_Dashboard.png), not the plain secondary tier.
   Escalated: "Escalations",
+  "Escalated Cases": "Escalations",
   // CRE's own — the live widget is named "30+ Days" (see
   // CRE_SECONDARY_ORDER's own note on this), but should DISPLAY as the
   // original's full "30+ Days Cases" text.


### PR DESCRIPTION
## Purpose
On `/cs-monitor-dashboard`, the CRE "Escalations" tile was rendering in the plain
secondary tier with the label "ESCALATED CASES", instead of its intended amber-glow
slot in the primary 2×2 grid (4th position, right of SLA Violations — per
`CS_Monitor_Dashboard.png`).

Root cause: the live `cs-overview` dashboard config names this widget
`"Escalated Cases"`, but `DISPLAY_NAME_ALIASES` in `wallboardMetricStyle.ts` only
had the older `"Escalated"` spelling — so `resolveDisplayNameAlias` didn't map it to
the canonical `"Escalations"` that `CRE_PRIMARY_ORDER` and the emphasis-colour table
match on.

Follow-up to #1655.

## Goals
The CRE escalations widget renders as `ESCALATIONS`, amber-emphasised, in the
primary grid slot right of `SLA VIOLATIONS`, regardless of whether the backend
config spells it `"Escalated"` or `"Escalated Cases"`.

## Approach
Add `"Escalated Cases": "Escalations"` to `DISPLAY_NAME_ALIASES` (exact-string
entry, matching the existing convention in that table — no fuzzy matching).
`CRE_PRIMARY_ORDER` already lists `"Escalations"` as slot 4 and the colour table
already maps `cre → Escalations → AMBER`, so no other change is needed.

No visual change beyond the one tile moving to its correct position/label/colour.

## User stories
As someone watching the CS monitor wallboard, I see the escalations count in the
same prominent position and styling as the reference design, so it reads
consistently with the other primary CRE metrics.

## Release note
Fixed the CS Monitor Dashboard rendering the CRE escalations metric as a plain
"Escalated Cases" tile instead of the emphasised "Escalations" primary tile.

## Documentation
N/A — internal CSM portal, no product documentation impact.

## Training
N/A

## Certification
N/A — no functional/API change, display-label mapping only.

## Marketing
N/A

## Automation tests
 - Unit tests
   > `wallboardMetricStyle.test.ts` — added assertions that
   > `resolveDisplayNameAlias("Escalated Cases")` → `"Escalations"` and that the
   > result lands in `CRE_PRIMARY_ORDER`'s 4th slot (right of "SLA Violations").
 - Integration tests
   > N/A — covered by the existing `WallboardCreSection` / `WallboardStatTile`
   > tests, which exercise the aliased name through to the rendered primary grid.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — frontend TS, no Java
 - Confirmed no keys/passwords/tokens/secrets committed? yes

## Samples
N/A

## Related PRs
- #1655 (the PR this follows up)

## Migrations (if applicable)
N/A

## Test environment
- Node 24 / pnpm 10, Vitest (jsdom)
- Chrome, `localhost:3001/cs-monitor-dashboard` against the dev backend

## Learning
N/A — one-line addition to an existing alias table; the pattern (live-config
label drift handled by exact-string aliases) is documented in
`wallboardMetricStyle.ts`'s own comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated dashboard metric recognition so “Escalated Cases” displays as “Escalations.”
  - Ensured the metric appears in the correct fourth position in the primary dashboard layout.
  - Added coverage to verify both supported escalation labels resolve consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->