### PR TITLE
[Entity-Service] Map customer-visible changeRequests on service requests

### DIFF
--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -192,17 +192,14 @@ type snCase struct {
 	// this must tolerate absence.
 	Variables []snCaseVariableAnswer `json:"variables"`
 	// ChangeRequests carries the change requests raised from this case, keyed as
-	// `changeRequests` upstream. Only populated for service-request cases.
-	//
-	// Deprecated: the upstream `changeRequests` field is filtered to a subset of change
-	// request states by the backing service. Case mapping below reads ChangeRequestsAll
-	// instead, which is unfiltered. This field is kept only because it is still present
-	// on the upstream response; nothing in this service reads it.
+	// ChangeRequests carries the change requests raised from this case, keyed as
+	// `changeRequests` upstream. Populated for service-request cases only; filtered
+	// to customer-visible states by the backing service (excluding New, Assess, and
+	// Authorize). Case mapping reads this field so draft/internal change requests are
+	// filtered out for customer-facing consumers.
 	ChangeRequests []snLinkedChangeRequestRef `json:"changeRequests"`
 	// ChangeRequestsAll carries the same change requests as ChangeRequests but unfiltered by
-	// state, keyed as `changeRequestsAll` upstream. Same item shape as `changeRequests`. Case
-	// mapping reads this field so linked change requests in New/Assess/Authorize states are
-	// no longer silently dropped before they reach the outward `linkedChangeRequests` field.
+	// state, keyed as `changeRequestsAll` upstream. Same item shape as `changeRequests`.
 	ChangeRequestsAll []snLinkedChangeRequestRef `json:"changeRequestsAll"`
 	ResolutionCode    *struct {
 		ID    json.Number `json:"id"`
@@ -1556,9 +1553,9 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		}
 		cv.LinkedServiceRequests = lsr
 	}
-	if len(c.ChangeRequestsAll) > 0 {
-		lcr := make([]domain.LinkedChangeRequestRef, 0, len(c.ChangeRequestsAll))
-		for _, r := range c.ChangeRequestsAll {
+	if len(c.ChangeRequests) > 0 {
+		lcr := make([]domain.LinkedChangeRequestRef, 0, len(c.ChangeRequests))
+		for _, r := range c.ChangeRequests {
 			// An absent upstream subject becomes null, not "" — see the note on
 			// LinkedChangeRequestRef.Name.
 			var name *string

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -2514,9 +2514,10 @@ func TestCaseService_SearchTags_ServiceUnavailable(t *testing.T) {
 }
 
 // TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests covers the reverse side of the
-// service-request <-> change-request link. Upstream sends the list under `changeRequestsAll`
-// (unfiltered by change-request state, unlike the older `changeRequests` field) with 32-hex
-// ids; the domain exposes it as `linkedChangeRequests` with canonical UUIDs.
+// service-request <-> change-request link. Upstream sends customer-visible change requests
+// under `changeRequests` (filtered by change-request state, excluding New/Assess/Authorize)
+// and unfiltered change requests under `changeRequestsAll`. The domain exposes the customer-
+// visible list as `linkedChangeRequests` with canonical UUIDs.
 //
 // The cardinality cases matter: a service request can have several change requests (one per
 // environment the change is promoted to), so a single-value mapping would look correct
@@ -2525,7 +2526,7 @@ func TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests(t *testing.T) {
 	crSysidA := sysid32('1')
 	crSysidB := sysid32('2')
 
-	newBody := func(changeRequests string) string {
+	newBody := func(changeRequests string, changeRequestsAll string) string {
 		return `{
 			"id": "` + testWLCaseSysid + `",
 			"internalId": "WSO2-001",
@@ -2539,15 +2540,16 @@ func TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests(t *testing.T) {
 			"deployment": {"id": "", "name": ""},
 			"deployedProduct": {"id": "", "name": "", "version": ""},
 			"state": {"id": 1, "label": "Open"},
-			"changeRequestsAll": ` + changeRequests + `
+			"changeRequests": ` + changeRequests + `,
+			"changeRequestsAll": ` + changeRequestsAll + `
 		}`
 	}
 
-	get := func(t *testing.T, changeRequests string) domain.CaseView {
+	get := func(t *testing.T, changeRequests string, changeRequestsAll string) domain.CaseView {
 		t.Helper()
 		client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(newBody(changeRequests)))
+			_, _ = w.Write([]byte(newBody(changeRequests, changeRequestsAll)))
 		})
 		svc := NewServiceNowCaseService(client, nil, nil)
 
@@ -2559,14 +2561,21 @@ func TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests(t *testing.T) {
 	}
 
 	t.Run("null stays empty", func(t *testing.T) {
-		cv := get(t, "null")
+		cv := get(t, "null", "null")
 		if len(cv.LinkedChangeRequests) != 0 {
 			t.Fatalf("expected no linked change requests, got %+v", cv.LinkedChangeRequests)
 		}
 	})
 
+	t.Run("null changeRequests filters out draft changes present in changeRequestsAll", func(t *testing.T) {
+		cv := get(t, "null", `[{"id": "`+crSysidA+`", "number": "CHG0000001", "name": "Draft change"}]`)
+		if len(cv.LinkedChangeRequests) != 0 {
+			t.Fatalf("expected draft change requests in changeRequestsAll to be filtered out, got %+v", cv.LinkedChangeRequests)
+		}
+	})
+
 	t.Run("single entry maps with a canonical UUID", func(t *testing.T) {
-		cv := get(t, `[{"id": "`+crSysidA+`", "number": "CHG0000001", "name": "Promote to dev"}]`)
+		cv := get(t, `[{"id": "`+crSysidA+`", "number": "CHG0000001", "name": "Promote to dev"}]`, `[{"id": "`+crSysidA+`", "number": "CHG0000001", "name": "Promote to dev"}]`)
 		if len(cv.LinkedChangeRequests) != 1 {
 			t.Fatalf("expected 1 linked change request, got %d", len(cv.LinkedChangeRequests))
 		}
@@ -2581,6 +2590,9 @@ func TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests(t *testing.T) {
 
 	t.Run("several entries all map, order preserved", func(t *testing.T) {
 		cv := get(t, `[
+			{"id": "`+crSysidA+`", "number": "CHG0000001", "name": "Promote to dev"},
+			{"id": "`+crSysidB+`", "number": "CHG0000002", "name": ""}
+		]`, `[
 			{"id": "`+crSysidA+`", "number": "CHG0000001", "name": "Promote to dev"},
 			{"id": "`+crSysidB+`", "number": "CHG0000002", "name": ""}
 		]`)


### PR DESCRIPTION
## Purpose
Filters out internal draft change requests from `linkedChangeRequests` on service requests by reading the filtered `changeRequests` array from the upstream ServiceNow response instead of `changeRequestsAll`.

## Goals
- Ensure internal/draft change requests (`New`, `Assess`, `Authorize`) are excluded from customer-facing service request views.
- Align the Go entity-service case detail mapping with the Ballerina entity service contract.

## Approach
- In `entity-service/internal/service/sn_case_service.go`, update `snCaseService.GetCaseByID` to map `cv.LinkedChangeRequests` from `c.ChangeRequests` instead of `c.ChangeRequestsAll`.
- Updated struct comments on `snCase.ChangeRequests` and `snCase.ChangeRequestsAll` to document the customer-visibility filtering behavior.
- In `entity-service/internal/service/sn_case_service_test.go`, updated `TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests` and added a subtest verifying that draft changes present in `changeRequestsAll` are filtered out when `changeRequests` is null.

## User stories
As a Customer Portal user, I only see approved/customer-visible change requests linked to my service requests, without exposing internal draft changes.

## Release note
Excluded internal draft change requests from `linkedChangeRequests` on service request cases in entity-service.

## Documentation
N/A — Internal API field mapping alignment, no public documentation changes.

## Automation tests
- Unit tests: Added and passing in `entity-service/internal/service/sn_case_service_test.go` (`TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests`).
- Verified against staging: Verified with live case requests against local Go entity-service proxying ServiceNow dev.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go backend change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `go vet ./...` passing locally.
- `go test -v ./internal/service -run TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests` passing locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Customer-facing case views now show only eligible change requests, excluding drafts and requests in New, Assess, or Authorize states.
  - Linked change requests are displayed with consistent ordering and identifier mapping.
  - Change requests without a name continue to be handled correctly without disrupting case displays.
- **Tests**
  - Added coverage verifying that internal or draft requests are excluded while visible requests remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->