### PR TITLE
[Customer Portal] Cap search endpoint pagination limit at 50

### DIFF
--- a/apps/customer-portal/backend/modules/entity/constants.bal
+++ b/apps/customer-portal/backend/modules/entity/constants.bal
@@ -17,6 +17,8 @@
 # Default pagination values.
 const DEFAULT_OFFSET = 0;
 const DEFAULT_LIMIT = 10;
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 50;
 
 # Valid call request update state values.
 public const PENDING_ON_WSO2 = 2;

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -42,7 +42,8 @@ public type Pagination record {|
     int offset = DEFAULT_OFFSET;
     # Limit for pagination
     @constraint:Int {
-        minValue: 1
+        minValue: MIN_LIMIT,
+        maxValue: MAX_LIMIT
     }
     int 'limit = DEFAULT_LIMIT;
     json...;

--- a/apps/customer-portal/webapp/src/features/usage-metrics/api/fetchAllCaseTimeCards.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/api/fetchAllCaseTimeCards.ts
@@ -21,7 +21,7 @@ import type {
 } from "@features/usage-metrics/types/timeTracking";
 import type { AuthFetchFn } from "@features/support/api/fetchProjectCaseSearchResults";
 
-const PAGE_SIZE = 100;
+const PAGE_SIZE = 50;
 
 /**
  * Fetches all pages of case time cards for a project, used for CSV/PDF export.


### PR DESCRIPTION
## Summary
- Add `MIN_LIMIT`/`MAX_LIMIT` constants (`modules/entity/constants.bal`) and use them in the `@constraint:Int` annotation on `entity:Pagination.limit` (`modules/entity/types.bal`), so every API-facing type that embeds `entity:Pagination` rejects a request with `limit` outside `1`–`50` at the framework validation layer.
- Lower `fetchAllCaseTimeCards`'s `PAGE_SIZE` from `100` to `50` to match the new cap — its fetch loop already self-corrects from the server's echoed `limit`/`offset`, but keeping the requested page size within the cap avoids unnecessary extra round trips.

## Test plan
- [x] `bal build` passes
- [ ] Manually verify a case time-card CSV/PDF export still returns the full dataset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pagination now enforces both minimum and maximum limits, helping prevent invalid page-size requests.
  - Usage metrics requests now retrieve up to 50 case time cards per page for consistent pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->