### PR TITLE
[Customer Portal v2] backend: support starting new conversations over WebSocket

### DIFF
--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -48,12 +48,14 @@ const wsMaxMessageBytes = 64 << 10 // 64 KiB
 // an idle peer before closing the connection.
 const wsIdleTimeout = 5 * time.Minute
 
-// entityCommentCreator is the subset of the entity client needed to persist
-// conversation messages as comments and auto-resolve a conversation.
+// entityCommentCreator is the subset of the entity client needed to create
+// conversations, persist conversation messages as comments, and auto-resolve a
+// conversation.
 // GetProject resolves the project's owning account (and doubles as the
 // caller's access-control gate for that project) — see HandleWebSocket.
 type entityCommentCreator interface {
 	CreateComment(ctx context.Context, req entity.CreateCommentRequest) (entity.CreateCommentResponse, error)
+	CreateConversation(ctx context.Context, req entity.CreateConversationRequest) (entity.CreateConversationResponse, error)
 	UpdateConversation(ctx context.Context, id string, req entity.UpdateConversationRequest) (entity.UpdateConversationResponse, error)
 	GetConversation(ctx context.Context, id string) (entity.ConversationDetails, error)
 	GetProject(ctx context.Context, id string) (entity.ProjectDetailsView, error)
@@ -100,13 +102,10 @@ type wsTokenValidator interface {
 }
 
 // WebSocketHandler proxies real-time chat messages between the browser and
-// the upstream AI chat agent for an existing conversation.
-//
-// NOTE: entity-service has no createConversation exposed over this
-// connection, so a WebSocket message that doesn't carry an existing
-// conversationId cannot start a brand-new conversation here — the caller
-// must first create one via
-// POST /projects/{id}/conversations (see handler.AIChatHandler.CreateConversation).
+// the upstream AI chat agent. When an incoming message does not carry an
+// existing conversationId, a new conversation is dynamically created via
+// entity-service and its ID is returned to the client in a conversation_created
+// event before streaming begins.
 // The AI agent's own reply IS persisted as a comment here (see
 // handleMessage), attributed to the assistant rather than to the customer
 // whose token relayed it, via entity.CreatedByAgent — the same as
@@ -322,6 +321,7 @@ func (h *WebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http.Reques
 
 	conn.SetReadLimit(wsMaxMessageBytes)
 
+	var activeConvID string
 	for {
 		if err := conn.SetReadDeadline(time.Now().Add(wsIdleTimeout)); err != nil {
 			slog.WarnContext(r.Context(), "websocket set read deadline failed", "userID", user.UserID, "err", summarizeErr(err))
@@ -334,11 +334,11 @@ func (h *WebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http.Reques
 			}
 			return
 		}
-		h.handleMessage(r.Context(), conn, user, projectID, accountID, data)
+		h.handleMessage(r.Context(), conn, user, projectID, accountID, &activeConvID, data)
 	}
 }
 
-func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Conn, user *middleware.UserInfo, projectID, accountID string, data []byte) {
+func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Conn, user *middleware.UserInfo, projectID, accountID string, activeConvID *string, data []byte) {
 	trimmed := strings.TrimSpace(strings.ToLower(string(data)))
 	var parsed map[string]any
 	_ = json.Unmarshal(data, &parsed)
@@ -378,21 +378,59 @@ func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Co
 	// a write-after-close race, and it would diverge from the Ballerina backend,
 	// whose onMessage also forwards these inline.
 	if msgType, _ := parsed["type"].(string); msgType == msgTypeFeedback || msgType == msgTypeTokenIncreaseRequest {
-		h.handleSideChannel(ctx, conn, user, projectID, msgType, parsed)
+		h.handleSideChannel(ctx, conn, user, projectID, activeConvID, msgType, parsed)
 		return
 	}
 
 	conversationID, _ := parsed["conversationId"].(string)
-	if conversationID == "" || !uuidRe.MatchString(conversationID) {
-		_ = writeWSJSON(conn, wsEvent{
-			Type: "error",
-			Message: "Starting a new conversation over this connection isn't supported yet — " +
-				"include the conversationId of an existing conversation to resume it.",
-		})
-		return
-	}
-
 	userMessage, _ := parsed["message"].(string)
+
+	if conversationID != "" {
+		if !uuidRe.MatchString(conversationID) {
+			_ = writeWSJSON(conn, wsEvent{
+				Type:    "error",
+				Message: "Invalid conversation ID.",
+			})
+			return
+		}
+		if activeConvID != nil {
+			*activeConvID = conversationID
+		}
+	} else if activeConvID != nil && *activeConvID != "" {
+		conversationID = *activeConvID
+	} else {
+		// New conversation: create conversation dynamically in entity-service
+		if strings.TrimSpace(userMessage) == "" {
+			_ = writeWSJSON(conn, wsEvent{
+				Type:    "error",
+				Message: "Message is required to start a new conversation.",
+			})
+			return
+		}
+		convResp, err := h.entity.CreateConversation(ctx, entity.CreateConversationRequest{
+			ProjectID:      projectID,
+			InitialMessage: userMessage,
+		})
+		if err != nil {
+			slog.ErrorContext(ctx, "entity CreateConversation failed", "userID", user.UserID, "projectID", projectID, "err", summarizeErr(err))
+			_ = writeWSJSON(conn, wsEvent{
+				Type:    "error",
+				Message: "Failed to create a new conversation.",
+			})
+			return
+		}
+		conversationID = convResp.Conversation.ID
+		if activeConvID != nil {
+			*activeConvID = conversationID
+		}
+		if err := writeWSJSON(conn, wsEvent{
+			Type:           "conversation_created",
+			ConversationID: conversationID,
+		}); err != nil {
+			slog.WarnContext(ctx, "failed to send conversation_created event", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
+			return
+		}
+	}
 	enriched, err := buildUpstreamPayload(parsed, conversationID, accountID)
 	if err != nil {
 		_ = writeWSJSON(conn, wsEvent{Type: "error", Message: "Failed to process message."})
@@ -486,8 +524,11 @@ func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Co
 // name into a durable audit row. So the field is either this session's user or
 // absent, never client-supplied — the upstream falls back to the account when it
 // is absent. Mirrors the Ballerina backend's onMessage side-channel branch.
-func (h *WebSocketHandler) handleSideChannel(ctx context.Context, conn *websocket.Conn, user *middleware.UserInfo, projectID, msgType string, parsed map[string]any) {
+func (h *WebSocketHandler) handleSideChannel(ctx context.Context, conn *websocket.Conn, user *middleware.UserInfo, projectID string, activeConvID *string, msgType string, parsed map[string]any) {
 	conversationID, _ := parsed["conversationId"].(string)
+	if conversationID == "" && activeConvID != nil && *activeConvID != "" {
+		conversationID = *activeConvID
+	}
 	if conversationID == "" || !uuidRe.MatchString(conversationID) {
 		// The client knows which answer it is rating even when this connection
 		// has not carried a turn yet, so a missing id is a client bug, not a

--- a/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
@@ -22,8 +22,12 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/gorilla/websocket"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/aichatagent"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
@@ -267,6 +271,8 @@ func TestHandleWebSocket_RejectsUnauthenticated(t *testing.T) {
 
 // stubEntity is an entityCommentCreator whose GetProject result is scripted.
 type stubEntity struct {
+	mu sync.Mutex
+
 	project entity.ProjectDetailsView
 	err     error
 	calls   int
@@ -278,24 +284,118 @@ type stubEntity struct {
 	// updatedStates records every state UpdateConversation was asked to set, so
 	// a test can assert the transition was skipped rather than merely reordered.
 	updatedStates []string
+
+	createdConversation     entity.CreateConversationResponse
+	createdConversationErr  error
+	createConversationCalls int
+	lastCreateReq           entity.CreateConversationRequest
+
+	commentsCreated []entity.CreateCommentRequest
 }
 
 func (s *stubEntity) GetProject(_ context.Context, _ string) (entity.ProjectDetailsView, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.calls++
 	return s.project, s.err
 }
 
-func (s *stubEntity) CreateComment(_ context.Context, _ entity.CreateCommentRequest) (entity.CreateCommentResponse, error) {
+func (s *stubEntity) CreateComment(_ context.Context, req entity.CreateCommentRequest) (entity.CreateCommentResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.commentsCreated = append(s.commentsCreated, req)
 	return entity.CreateCommentResponse{}, nil
 }
 
+func (s *stubEntity) CreateConversation(_ context.Context, req entity.CreateConversationRequest) (entity.CreateConversationResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.createConversationCalls++
+	s.lastCreateReq = req
+	if s.createdConversationErr != nil {
+		return entity.CreateConversationResponse{}, s.createdConversationErr
+	}
+	if s.createdConversation.Conversation.ID == "" {
+		return entity.CreateConversationResponse{
+			Conversation: entity.CreatedConversation{ID: "33333333-3333-3333-3333-333333333333"},
+		}, nil
+	}
+	return s.createdConversation, nil
+}
+
 func (s *stubEntity) UpdateConversation(_ context.Context, _ string, req entity.UpdateConversationRequest) (entity.UpdateConversationResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.updatedStates = append(s.updatedStates, req.State)
 	return entity.UpdateConversationResponse{}, nil
 }
 
 func (s *stubEntity) GetConversation(_ context.Context, _ string) (entity.ConversationDetails, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.conversation, s.conversationErr
+}
+
+func (s *stubEntity) getCreateConversationCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.createConversationCalls
+}
+
+func (s *stubEntity) getLastCreateReq() entity.CreateConversationRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastCreateReq
+}
+
+// stubStreamer is a mock wsStreamer for WebSocket tests.
+type stubStreamer struct {
+	mu sync.Mutex
+
+	lastSessionID string
+	lastPayload   string
+	streamCalls   int
+	streamErr     error
+	result        map[string]json.RawMessage
+}
+
+func (s *stubStreamer) StreamChat(_ context.Context, sessionID, payload string, caller aichatagent.BrowserConn) (map[string]json.RawMessage, error) {
+	s.mu.Lock()
+	s.streamCalls++
+	s.lastSessionID = sessionID
+	s.lastPayload = payload
+	err := s.streamErr
+	res := s.result
+	s.mu.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
+	// Emit a final event so the client knows the turn is complete
+	_ = caller.WriteMessage(websocket.TextMessage, []byte(`{"type":"final","payload":{"message":"response text"}}`))
+
+	if res != nil {
+		return res, nil
+	}
+	return map[string]json.RawMessage{
+		"message": json.RawMessage(`"response text"`),
+	}, nil
+}
+
+func (s *stubStreamer) SendSideChannel(_ context.Context, _ string, _ string, _ aichatagent.BrowserConn) error {
+	return nil
+}
+
+func (s *stubStreamer) getCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.streamCalls
+}
+
+func (s *stubStreamer) getLastSessionID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastSessionID
 }
 
 // TestHandleWebSocket_ProjectAccessGatesTheUpgrade asserts the account lookup
@@ -338,5 +438,302 @@ func TestHandleWebSocket_ValidatesSessionIDAfterAuth(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+// TestHandleWebSocket_CreateConversation asserts that an incoming message with an
+// empty conversationId dynamically creates a new conversation, returns a
+// conversation_created event, and streams the AI agent's response.
+func TestHandleWebSocket_CreateConversation(t *testing.T) {
+	const projectID = "11111111-1111-1111-1111-111111111111"
+	const createdConvID = "33333333-3333-3333-3333-333333333333"
+
+	v := &stubValidator{accept: "good-token"}
+	e := &stubEntity{
+		project: entity.ProjectDetailsView{
+			ID:      projectID,
+			Account: entity.ProjectAccountRef{ID: "acc-1"},
+		},
+		createdConversation: entity.CreateConversationResponse{
+			Conversation: entity.CreatedConversation{ID: createdConvID},
+		},
+	}
+	ai := &stubStreamer{}
+	h := NewWebSocketHandler(ai, e, v, nil)
+
+	s := httptest.NewServer(http.HandlerFunc(h.HandleWebSocket))
+	defer s.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(s.URL, "http") + "/ws?sessionId=" + projectID
+	dialer := websocket.Dialer{
+		Subprotocols: []string{"cs-customer-portal", "good-token"},
+	}
+
+	conn, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// 1. Send user_message with empty conversationId
+	msg := map[string]any{
+		"type":           "user_message",
+		"conversationId": "",
+		"message":        "Hello, I need help",
+	}
+	msgBytes, _ := json.Marshal(msg)
+	if err := conn.WriteMessage(websocket.TextMessage, msgBytes); err != nil {
+		t.Fatalf("write message failed: %v", err)
+	}
+
+	// 2. Expect conversation_created event
+	_, respData, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read message failed: %v", err)
+	}
+	var evt wsEvent
+	if err := json.Unmarshal(respData, &evt); err != nil {
+		t.Fatalf("unmarshal event failed: %v", err)
+	}
+	if evt.Type != "conversation_created" {
+		t.Errorf("type = %q, want conversation_created", evt.Type)
+	}
+	if evt.ConversationID != createdConvID {
+		t.Errorf("conversationId = %q, want %q", evt.ConversationID, createdConvID)
+	}
+
+	// Read the stream response from turn 1 so turn 1 completes
+	_, respData2, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read turn 1 final message failed: %v", err)
+	}
+	var evtFinal wsEvent
+	if err := json.Unmarshal(respData2, &evtFinal); err != nil {
+		t.Fatalf("unmarshal turn 1 final failed: %v", err)
+	}
+	if evtFinal.Type != "final" {
+		t.Errorf("type = %q, want final", evtFinal.Type)
+	}
+
+	// Verify CreateConversation was called with projectID and initial message
+	if e.getCreateConversationCalls() != 1 {
+		t.Errorf("CreateConversation called %d times, want 1", e.getCreateConversationCalls())
+	}
+	lastReq := e.getLastCreateReq()
+	if lastReq.ProjectID != projectID {
+		t.Errorf("CreateConversation ProjectID = %q, want %q", lastReq.ProjectID, projectID)
+	}
+	if lastReq.InitialMessage != "Hello, I need help" {
+		t.Errorf("CreateConversation InitialMessage = %q, want 'Hello, I need help'", lastReq.InitialMessage)
+	}
+
+	// Verify StreamChat was called with sessionID = projectID + ":" + createdConvID
+	expectedSessionID := projectID + ":" + createdConvID
+	if ai.getLastSessionID() != expectedSessionID {
+		t.Errorf("StreamChat sessionID = %q, want %q", ai.getLastSessionID(), expectedSessionID)
+	}
+
+	// 3. Send follow-up turn omitting conversationId (connection reuses active conversation)
+	msg2 := map[string]any{
+		"type":           "user_message",
+		"conversationId": "",
+		"message":        "Second question",
+	}
+	msg2Bytes, _ := json.Marshal(msg2)
+	if err := conn.WriteMessage(websocket.TextMessage, msg2Bytes); err != nil {
+		t.Fatalf("write follow-up failed: %v", err)
+	}
+
+	// Read turn 2 stream response
+	_, respData3, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read turn 2 final message failed: %v", err)
+	}
+	var evtFinal2 wsEvent
+	if err := json.Unmarshal(respData3, &evtFinal2); err != nil {
+		t.Fatalf("unmarshal turn 2 final failed: %v", err)
+	}
+	if evtFinal2.Type != "final" {
+		t.Errorf("type = %q, want final", evtFinal2.Type)
+	}
+
+	// Verify CreateConversation was NOT called again (calls remain 1)
+	if e.getCreateConversationCalls() != 1 {
+		t.Errorf("CreateConversation called %d times on follow-up, want 1", e.getCreateConversationCalls())
+	}
+	if ai.getCalls() != 2 {
+		t.Errorf("StreamChat called %d times, want 2", ai.getCalls())
+	}
+	if ai.getLastSessionID() != expectedSessionID {
+		t.Errorf("StreamChat sessionID on follow-up = %q, want %q", ai.getLastSessionID(), expectedSessionID)
+	}
+}
+
+// TestHandleWebSocket_EmptyMessageOnNewConversation asserts that sending an empty
+// message when starting a conversation returns an error event.
+func TestHandleWebSocket_EmptyMessageOnNewConversation(t *testing.T) {
+	const projectID = "11111111-1111-1111-1111-111111111111"
+
+	v := &stubValidator{accept: "good-token"}
+	e := &stubEntity{
+		project: entity.ProjectDetailsView{
+			ID:      projectID,
+			Account: entity.ProjectAccountRef{ID: "acc-1"},
+		},
+	}
+	ai := &stubStreamer{}
+	h := NewWebSocketHandler(ai, e, v, nil)
+
+	s := httptest.NewServer(http.HandlerFunc(h.HandleWebSocket))
+	defer s.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(s.URL, "http") + "/ws?sessionId=" + projectID
+	dialer := websocket.Dialer{
+		Subprotocols: []string{"cs-customer-portal", "good-token"},
+	}
+
+	conn, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	msg := map[string]any{
+		"type":           "user_message",
+		"conversationId": "",
+		"message":        "   ",
+	}
+	msgBytes, _ := json.Marshal(msg)
+	if err := conn.WriteMessage(websocket.TextMessage, msgBytes); err != nil {
+		t.Fatalf("write message failed: %v", err)
+	}
+
+	_, respData, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read message failed: %v", err)
+	}
+	var evt wsEvent
+	if err := json.Unmarshal(respData, &evt); err != nil {
+		t.Fatalf("unmarshal event failed: %v", err)
+	}
+	if evt.Type != "error" {
+		t.Errorf("type = %q, want error", evt.Type)
+	}
+	if evt.Message != "Message is required to start a new conversation." {
+		t.Errorf("message = %q, want 'Message is required to start a new conversation.'", evt.Message)
+	}
+	if e.createConversationCalls != 0 {
+		t.Errorf("CreateConversation was called %d times, want 0", e.createConversationCalls)
+	}
+}
+
+// TestHandleWebSocket_InvalidConversationID asserts that an invalid UUID conversationId
+// returns an error event.
+func TestHandleWebSocket_InvalidConversationID(t *testing.T) {
+	const projectID = "11111111-1111-1111-1111-111111111111"
+
+	v := &stubValidator{accept: "good-token"}
+	e := &stubEntity{
+		project: entity.ProjectDetailsView{
+			ID:      projectID,
+			Account: entity.ProjectAccountRef{ID: "acc-1"},
+		},
+	}
+	ai := &stubStreamer{}
+	h := NewWebSocketHandler(ai, e, v, nil)
+
+	s := httptest.NewServer(http.HandlerFunc(h.HandleWebSocket))
+	defer s.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(s.URL, "http") + "/ws?sessionId=" + projectID
+	dialer := websocket.Dialer{
+		Subprotocols: []string{"cs-customer-portal", "good-token"},
+	}
+
+	conn, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	msg := map[string]any{
+		"type":           "user_message",
+		"conversationId": "not-a-valid-uuid",
+		"message":        "Hello",
+	}
+	msgBytes, _ := json.Marshal(msg)
+	if err := conn.WriteMessage(websocket.TextMessage, msgBytes); err != nil {
+		t.Fatalf("write message failed: %v", err)
+	}
+
+	_, respData, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read message failed: %v", err)
+	}
+	var evt wsEvent
+	if err := json.Unmarshal(respData, &evt); err != nil {
+		t.Fatalf("unmarshal event failed: %v", err)
+	}
+	if evt.Type != "error" {
+		t.Errorf("type = %q, want error", evt.Type)
+	}
+	if evt.Message != "Invalid conversation ID." {
+		t.Errorf("message = %q, want 'Invalid conversation ID.'", evt.Message)
+	}
+}
+
+// TestHandleWebSocket_CreateConversationError asserts that a failure in entity
+// CreateConversation emits an error event to the client.
+func TestHandleWebSocket_CreateConversationError(t *testing.T) {
+	const projectID = "11111111-1111-1111-1111-111111111111"
+
+	v := &stubValidator{accept: "good-token"}
+	e := &stubEntity{
+		project: entity.ProjectDetailsView{
+			ID:      projectID,
+			Account: entity.ProjectAccountRef{ID: "acc-1"},
+		},
+		createdConversationErr: errors.New("upstream entity service down"),
+	}
+	ai := &stubStreamer{}
+	h := NewWebSocketHandler(ai, e, v, nil)
+
+	s := httptest.NewServer(http.HandlerFunc(h.HandleWebSocket))
+	defer s.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(s.URL, "http") + "/ws?sessionId=" + projectID
+	dialer := websocket.Dialer{
+		Subprotocols: []string{"cs-customer-portal", "good-token"},
+	}
+
+	conn, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	msg := map[string]any{
+		"type":           "user_message",
+		"conversationId": "",
+		"message":        "Hello, I need help",
+	}
+	msgBytes, _ := json.Marshal(msg)
+	if err := conn.WriteMessage(websocket.TextMessage, msgBytes); err != nil {
+		t.Fatalf("write message failed: %v", err)
+	}
+
+	_, respData, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read message failed: %v", err)
+	}
+	var evt wsEvent
+	if err := json.Unmarshal(respData, &evt); err != nil {
+		t.Fatalf("unmarshal event failed: %v", err)
+	}
+	if evt.Type != "error" {
+		t.Errorf("type = %q, want error", evt.Type)
+	}
+	if evt.Message != "Failed to create a new conversation." {
+		t.Errorf("message = %q, want 'Failed to create a new conversation.'", evt.Message)
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
@@ -469,11 +469,14 @@ func TestHandleWebSocket_CreateConversation(t *testing.T) {
 		Subprotocols: []string{"cs-customer-portal", "good-token"},
 	}
 
-	conn, _, err := dialer.Dial(wsURL, nil)
+	conn, resp, err := dialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)
 	}
-	defer conn.Close()
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	defer func() { _ = conn.Close() }()
 
 	// 1. Send user_message with empty conversationId
 	msg := map[string]any{
@@ -592,11 +595,14 @@ func TestHandleWebSocket_EmptyMessageOnNewConversation(t *testing.T) {
 		Subprotocols: []string{"cs-customer-portal", "good-token"},
 	}
 
-	conn, _, err := dialer.Dial(wsURL, nil)
+	conn, resp, err := dialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)
 	}
-	defer conn.Close()
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	defer func() { _ = conn.Close() }()
 
 	msg := map[string]any{
 		"type":           "user_message",
@@ -622,8 +628,8 @@ func TestHandleWebSocket_EmptyMessageOnNewConversation(t *testing.T) {
 	if evt.Message != "Message is required to start a new conversation." {
 		t.Errorf("message = %q, want 'Message is required to start a new conversation.'", evt.Message)
 	}
-	if e.createConversationCalls != 0 {
-		t.Errorf("CreateConversation was called %d times, want 0", e.createConversationCalls)
+	if got := e.getCreateConversationCalls(); got != 0 {
+		t.Errorf("CreateConversation was called %d times, want 0", got)
 	}
 }
 
@@ -650,11 +656,14 @@ func TestHandleWebSocket_InvalidConversationID(t *testing.T) {
 		Subprotocols: []string{"cs-customer-portal", "good-token"},
 	}
 
-	conn, _, err := dialer.Dial(wsURL, nil)
+	conn, resp, err := dialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)
 	}
-	defer conn.Close()
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	defer func() { _ = conn.Close() }()
 
 	msg := map[string]any{
 		"type":           "user_message",
@@ -706,11 +715,14 @@ func TestHandleWebSocket_CreateConversationError(t *testing.T) {
 		Subprotocols: []string{"cs-customer-portal", "good-token"},
 	}
 
-	conn, _, err := dialer.Dial(wsURL, nil)
+	conn, resp, err := dialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)
 	}
-	defer conn.Close()
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	defer func() { _ = conn.Close() }()
 
 	msg := map[string]any{
 		"type":           "user_message",


### PR DESCRIPTION
## Purpose
Enables starting brand-new chat conversations over the WebSocket connection in Customer Portal Go backend v2. When a client initiates a chat without an existing `conversationId`, backend v2 dynamically creates a new conversation via `entity-service`, returns a `conversation_created` event with the conversation ID, and streams the AI agent's response.

## Goals
- Match behavioral parity with the Ballerina Customer Portal backend for real-time WebSocket chat.
- Allow webapp users initiating chat via "Ask Novera", "Get Help", or "Describe Issue" to start and continue chat sessions over WebSocket without requiring a pre-existing conversation ID.

## Approach
- In `apps/customer-portal/backend-v2/internal/handler/websocket.go`:
  - Extended `entityCommentCreator` to include `CreateConversation(ctx context.Context, req entity.CreateConversationRequest) (entity.CreateConversationResponse, error)`.
  - Maintained an `activeConvID` pointer within `HandleWebSocket`'s connection read loop.
  - In `handleMessage`, when an incoming message has an empty `conversationId`:
    - Reuses `activeConvID` if the connection has already created or resumed a conversation.
    - Otherwise validates non-empty message text and calls `h.entity.CreateConversation(...)` with `projectID` and `userMessage`.
    - Writes `{"type": "conversation_created", "conversationId": "<uuid>"}` back to the client.
    - Sets `activeConvID` for the connection session and continues with streaming and comment persistence.
  - When `conversationId` is non-empty: validates UUID format and sets `activeConvID`.
  - In `handleSideChannel`, falls back to `activeConvID` when `conversationId` is omitted on feedback messages.
- In `apps/customer-portal/backend-v2/internal/handler/websocket_test.go`:
  - Added thread-safe methods to `stubEntity` and implemented mock `stubStreamer`.
  - Added unit tests covering dynamic conversation creation (`conversation_created` event emission, initial message forwarding, turn streaming), active conversation ID reuse on follow-up turns, empty message validation, invalid UUID rejection, and upstream entity creation failure handling.

## User stories
As a Customer Portal user, I can start new chat sessions with the AI assistant over the WebSocket connection without encountering unsupported connection errors.

## Release note
Supported dynamic conversation creation over WebSocket connections in Customer Portal Go backend v2.

## Documentation
N/A — Internal backend behavior alignment matching the webapp's chat protocol.

## Automation tests
- Unit tests added and passing in `apps/customer-portal/backend-v2/internal/handler/websocket_test.go`:
  - `TestHandleWebSocket_CreateConversation`
  - `TestHandleWebSocket_EmptyMessageOnNewConversation`
  - `TestHandleWebSocket_InvalidConversationID`
  - `TestHandleWebSocket_CreateConversationError`
- Full package test suite verified: `go test -count=1 -race ./internal/handler/...` and `go test -race ./...`.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go backend change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `go build ./...` passing locally.
- `go test -count=1 -race ./...` passing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket conversations can now be created automatically when a message does not include a conversation ID.
  * Newly created conversations are announced before message streaming begins.
  * Follow-up messages and related requests can continue using the active conversation automatically.

* **Bug Fixes**
  * Empty messages, invalid conversation IDs, and conversation-creation errors are now handled and reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->