### PR TITLE
[Customer Portal v2] backend: fix call request creation, search, and update handling

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/call_request.go
+++ b/apps/customer-portal/backend-v2/internal/dto/call_request.go
@@ -16,7 +16,11 @@
 
 package dto
 
-import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+import (
+	"strings"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
 
 // CallRequestCreateResponse is the portal's response for POST /call-requests.
 type CallRequestCreateResponse struct {
@@ -95,6 +99,13 @@ type CallRequestSearchRequest struct {
 	Pagination entity.Pagination        `json:"pagination"`
 }
 
+// toSysID converts an identifier (either a dashed UUID or a 32-hex sysid)
+// to a 32-character lowercase hex string without hyphens, for upstream services
+// that enforce ServiceNow's 32-hex IdString pattern constraint.
+func toSysID(id string) string {
+	return strings.ToLower(strings.ReplaceAll(id, "-", ""))
+}
+
 // BuildEntitySearchCallRequestsRequest translates the portal's request into
 // entity-service's SearchCallRequestsRequest. caseID (the {caseId} path
 // parameter) is always forced, never taken from the request body — the
@@ -113,7 +124,7 @@ func BuildEntitySearchCallRequestsRequest(caseID string, req CallRequestSearchRe
 		filters = &entity.SearchCallRequestsFilters{States: states}
 	}
 	return entity.SearchCallRequestsRequest{
-		CaseID:     caseID,
+		CaseID:     toSysID(caseID),
 		Filters:    filters,
 		Pagination: req.Pagination,
 	}

--- a/apps/customer-portal/backend-v2/internal/dto/call_request.go
+++ b/apps/customer-portal/backend-v2/internal/dto/call_request.go
@@ -27,10 +27,14 @@ type CallRequestCreateResponse struct {
 
 // MapCallRequestCreate builds the portal response from entity-service's CreateCallRequestResponse.
 func MapCallRequestCreate(r entity.CreateCallRequestResponse) CallRequestCreateResponse {
+	state := r.CallRequest.State.Label
+	if state == "" {
+		state = r.CallRequest.State.ID
+	}
 	return CallRequestCreateResponse{
 		ID:        r.CallRequest.ID,
 		CreatedOn: r.CallRequest.CreatedOn,
-		State:     r.CallRequest.State,
+		State:     state,
 	}
 }
 

--- a/apps/customer-portal/backend-v2/internal/dto/call_request_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/call_request_test.go
@@ -61,8 +61,8 @@ func TestBuildEntitySearchCallRequestsRequest_CaseIDFromPathAndStateKeysTranslat
 
 	got := BuildEntitySearchCallRequestsRequest("case-1", req)
 
-	if got.CaseID != "case-1" {
-		t.Fatalf("CaseID = %q, want %q", got.CaseID, "case-1")
+	if got.CaseID != toSysID("case-1") {
+		t.Fatalf("CaseID = %q, want %q", got.CaseID, toSysID("case-1"))
 	}
 	if got.Filters == nil {
 		t.Fatal("expected non-nil Filters")
@@ -73,6 +73,16 @@ func TestBuildEntitySearchCallRequestsRequest_CaseIDFromPathAndStateKeysTranslat
 	}
 	if got.Pagination != req.Pagination {
 		t.Fatalf("Pagination = %+v, want %+v", got.Pagination, req.Pagination)
+	}
+}
+
+func TestBuildEntitySearchCallRequestsRequest_CaseIDNormalizedToSysID(t *testing.T) {
+	req := CallRequestSearchRequest{
+		Pagination: entity.Pagination{Limit: 10, Offset: 0},
+	}
+	got := BuildEntitySearchCallRequestsRequest("26051dbc-3baa-8f50-9140-4c6aa5e45a1c", req)
+	if got.CaseID != "26051dbc3baa8f5091404c6aa5e45a1c" {
+		t.Fatalf("CaseID = %q, want %q", got.CaseID, "26051dbc3baa8f5091404c6aa5e45a1c")
 	}
 }
 

--- a/apps/customer-portal/backend-v2/internal/dto/call_request_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/call_request_test.go
@@ -17,6 +17,7 @@
 package dto
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -86,3 +87,78 @@ func TestBuildEntitySearchCallRequestsRequest_NoStateKeysLeavesFiltersNil(t *tes
 		t.Fatalf("Filters = %+v, want nil", got.Filters)
 	}
 }
+
+func TestCreateCallRequestResponse_UnmarshalChoiceListState(t *testing.T) {
+	// Sample response with choice-list state structure
+	raw := []byte(`{
+		"message": "Call request created successfully.",
+		"callRequest": {
+			"id": "a1b2c3d4e5f60718293a4b5c6d7e8f90",
+			"createdOn": "2026-01-01 10:00:00",
+			"createdBy": "user@example.com",
+			"state": {
+				"id": 2,
+				"label": "Pending on WSO2"
+			},
+			"scheduleTime": "2026-01-02 10:00:00"
+		}
+	}`)
+
+	var resp entity.CreateCallRequestResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	if resp.CallRequest.ID != "a1b2c3d4e5f60718293a4b5c6d7e8f90" {
+		t.Errorf("ID = %q, want a1b2c3d4e5f60718293a4b5c6d7e8f90", resp.CallRequest.ID)
+	}
+	if resp.CallRequest.State.ID != "2" || resp.CallRequest.State.Label != "Pending on WSO2" {
+		t.Errorf("State = %+v, want ID=\"2\", Label=\"Pending on WSO2\"", resp.CallRequest.State)
+	}
+
+	mapped := MapCallRequestCreate(resp)
+	if mapped.ID != "a1b2c3d4e5f60718293a4b5c6d7e8f90" {
+		t.Errorf("mapped.ID = %q, want a1b2c3d4e5f60718293a4b5c6d7e8f90", mapped.ID)
+	}
+	if mapped.State != "Pending on WSO2" {
+		t.Errorf("mapped.State = %q, want \"Pending on WSO2\"", mapped.State)
+	}
+}
+
+func TestSearchCallRequestsResponse_UnmarshalNumericStateID(t *testing.T) {
+	raw := []byte(`{
+		"callRequests": [
+			{
+				"id": "a1b2c3d4e5f60718293a4b5c6d7e8f90",
+				"number": "CALL0000001",
+				"case": {"id": "22222222222222222222222222222222", "name": "CS0000001"},
+				"createdOn": "2026-01-01 10:00:00",
+				"updatedOn": "2026-01-01 10:00:00",
+				"state": {"id": 2, "label": "Pending on WSO2"},
+				"preferredTimes": ["2026-01-02T10:00:00Z"],
+				"durationMin": 30
+			}
+		],
+		"total": 1,
+		"offset": 0,
+		"limit": 10
+	}`)
+
+	var resp entity.SearchCallRequestsResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	if len(resp.CallRequests) != 1 {
+		t.Fatalf("expected 1 call request, got %d", len(resp.CallRequests))
+	}
+	if resp.CallRequests[0].State.ID != "2" {
+		t.Errorf("State.ID = %q, want \"2\"", resp.CallRequests[0].State.ID)
+	}
+
+	mapped := MapSearchCallRequests(resp)
+	if mapped.CallRequests[0].State.ID != "2" || mapped.CallRequests[0].State.Label != "Pending on WSO2" {
+		t.Errorf("mapped State = %+v, want ID=\"2\", Label=\"Pending on WSO2\"", mapped.CallRequests[0].State)
+	}
+}
+

--- a/apps/customer-portal/backend-v2/internal/entity/call_requests.go
+++ b/apps/customer-portal/backend-v2/internal/entity/call_requests.go
@@ -20,13 +20,21 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 )
+
+// toSysID converts an identifier (either a dashed UUID or a 32-hex sysid)
+// to a 32-character lowercase hex string without hyphens.
+func toSysID(id string) string {
+	return strings.ToLower(strings.ReplaceAll(id, "-", ""))
+}
 
 // CreateCallRequest calls POST /call-requests.
 //
 // NOTE: entity-service only supports call requests on its ServiceNow data
 // source — a Postgres-mode deployment 404s on every route in this file.
 func (c *Client) CreateCallRequest(ctx context.Context, req CreateCallRequestRequest) (CreateCallRequestResponse, error) {
+	req.CaseID = toSysID(req.CaseID)
 	var out CreateCallRequestResponse
 	err := c.postJSON(ctx, "/call-requests", req, &out)
 	return out, err
@@ -34,6 +42,7 @@ func (c *Client) CreateCallRequest(ctx context.Context, req CreateCallRequestReq
 
 // SearchCallRequests calls POST /call-requests/search.
 func (c *Client) SearchCallRequests(ctx context.Context, req SearchCallRequestsRequest) (SearchCallRequestsResponse, error) {
+	req.CaseID = toSysID(req.CaseID)
 	var out SearchCallRequestsResponse
 	err := c.postJSON(ctx, "/call-requests/search", req, &out)
 	return out, err
@@ -41,6 +50,7 @@ func (c *Client) SearchCallRequests(ctx context.Context, req SearchCallRequestsR
 
 // UpdateCallRequest calls PATCH /call-requests/{id}.
 func (c *Client) UpdateCallRequest(ctx context.Context, id string, req UpdateCallRequestRequest) (UpdateCallRequestResponse, error) {
+	id = toSysID(id)
 	req.ID = id // never serialized (json:"-"); set for consistency with the struct's doc comment
 	var out UpdateCallRequestResponse
 	err := c.patchJSON(ctx, fmt.Sprintf("/call-requests/%s", url.PathEscape(id)), req, &out)

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -18,6 +18,7 @@ package entity
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 )
 
@@ -1707,10 +1708,10 @@ type CreateCallRequestRequest struct {
 
 // CallRequestCreated carries the key fields of a newly created call request.
 type CallRequestCreated struct {
-	ID        string `json:"id"`
-	CreatedOn string `json:"createdOn"`
-	CreatedBy string `json:"createdBy"`
-	State     string `json:"state"`
+	ID        string           `json:"id"`
+	CreatedOn string           `json:"createdOn"`
+	CreatedBy string           `json:"createdBy"`
+	State     CallRequestState `json:"state"`
 }
 
 // CreateCallRequestResponse is entity-service's response for POST /call-requests.
@@ -1719,11 +1720,51 @@ type CreateCallRequestResponse struct {
 	CallRequest CallRequestCreated `json:"callRequest"`
 }
 
-// CallRequestState holds the state of a call request: ID is the string state
-// enum key, Label is the human-readable display label.
+// CallRequestState holds the state of a call request: ID is the state
+// enum key or numeric choice key string, Label is the human-readable display label.
 type CallRequestState struct {
 	ID    string `json:"id"`
 	Label string `json:"label"`
+}
+
+// UnmarshalJSON handles string enum, numeric choice key, or ChoiceListItem object formats.
+func (s *CallRequestState) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+	// Case 1: Raw string enum (e.g. "pending_on_wso2")
+	if data[0] == '"' {
+		var str string
+		if err := json.Unmarshal(data, &str); err != nil {
+			return err
+		}
+		s.ID = str
+		s.Label = str
+		return nil
+	}
+	// Case 2: Object with ID (int or string) and Label (e.g. {"id": 2, "label": "Pending on WSO2"})
+	var raw struct {
+		ID    json.RawMessage `json:"id"`
+		Label string          `json:"label"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	s.Label = raw.Label
+	if len(raw.ID) > 0 {
+		var num int
+		if err := json.Unmarshal(raw.ID, &num); err == nil {
+			s.ID = strconv.Itoa(num)
+		} else {
+			var str string
+			if err := json.Unmarshal(raw.ID, &str); err == nil {
+				s.ID = str
+			} else {
+				s.ID = string(raw.ID)
+			}
+		}
+	}
+	return nil
 }
 
 // CallRequestCaseRef is a reference to a case embedded in a call request.

--- a/apps/customer-portal/backend-v2/internal/handler/attachment_id_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/attachment_id_test.go
@@ -56,3 +56,41 @@ func TestIsAttachmentID(t *testing.T) {
 		}
 	}
 }
+
+func TestToSysID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"26051dbc-3baa-8f50-9140-4c6aa5e45a1c", "26051dbc3baa8f5091404c6aa5e45a1c"},
+		{"26051DBC-3BAA-8F50-9140-4C6AA5E45A1C", "26051dbc3baa8f5091404c6aa5e45a1c"},
+		{"26051dbc3baa8f5091404c6aa5e45a1c", "26051dbc3baa8f5091404c6aa5e45a1c"},
+	}
+	for _, tc := range cases {
+		if got := toSysID(tc.in); got != tc.want {
+			t.Errorf("toSysID(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestIsUUIDOrSysID(t *testing.T) {
+	cases := map[string]struct {
+		id   string
+		want bool
+	}{
+		"valid uuid":      {"26051dbc-3baa-8f50-9140-4c6aa5e45a1c", true},
+		"valid sysid":     {"26051dbc3baa8f5091404c6aa5e45a1c", true},
+		"uppercase sysid": {"26051DBC3BAA8F5091404C6AA5E45A1C", true},
+		"empty":           {"", false},
+		"malformed":       {"not-a-valid-id", false},
+		"short hex":       {"26051dbc", false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isUUIDOrSysID(tc.id); got != tc.want {
+				t.Errorf("isUUIDOrSysID(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}
+

--- a/apps/customer-portal/backend-v2/internal/handler/call_requests.go
+++ b/apps/customer-portal/backend-v2/internal/handler/call_requests.go
@@ -57,7 +57,7 @@ func (h *CallRequestHandler) CreateCallRequest(w http.ResponseWriter, r *http.Re
 	}
 
 	caseID := r.PathValue("caseId")
-	if caseID == "" || !uuidRe.MatchString(caseID) {
+	if caseID == "" || !isUUIDOrSysID(caseID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -74,8 +74,9 @@ func (h *CallRequestHandler) CreateCallRequest(w http.ResponseWriter, r *http.Re
 	}
 	// CaseID is always forced to the {caseId} path parameter, never a
 	// client-supplied body field — the frontend's request body carries only
-	// reason/utcTimes/durationInMinutes, no caseId at all.
-	req.CaseID = caseID
+	// reason/utcTimes/durationInMinutes, no caseId at all. Normalized to a
+	// 32-hex sys_id for entity-service.
+	req.CaseID = toSysID(caseID)
 	if req.Reason == "" || len(req.UTCTimes) == 0 || req.DurationMinutes <= 0 {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
@@ -100,7 +101,7 @@ func (h *CallRequestHandler) SearchCallRequests(w http.ResponseWriter, r *http.R
 	}
 
 	caseID := r.PathValue("caseId")
-	if caseID == "" || !uuidRe.MatchString(caseID) {
+	if caseID == "" || !isUUIDOrSysID(caseID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -138,7 +139,7 @@ func (h *CallRequestHandler) PatchCallRequest(w http.ResponseWriter, r *http.Req
 	}
 
 	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	if id == "" || !isUUIDOrSysID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -158,7 +159,7 @@ func (h *CallRequestHandler) PatchCallRequest(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	result, err := h.entity.UpdateCallRequest(r.Context(), id, dto.BuildEntityUpdateCallRequestRequest(req))
+	result, err := h.entity.UpdateCallRequest(r.Context(), toSysID(id), dto.BuildEntityUpdateCallRequestRequest(req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity UpdateCallRequest failed", "userID", user.UserID, "callRequestID", id, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to update call request.")

--- a/apps/customer-portal/backend-v2/internal/handler/case_attachments_call_requests_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/case_attachments_call_requests_test.go
@@ -118,8 +118,9 @@ func TestCreateCallRequest_CaseIDFromPath(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if fake.gotCreateReq.CaseID != testCaseID {
-		t.Fatalf("CaseID = %q, want %q", fake.gotCreateReq.CaseID, testCaseID)
+	wantCaseID := toSysID(testCaseID)
+	if fake.gotCreateReq.CaseID != wantCaseID {
+		t.Fatalf("CaseID = %q, want %q", fake.gotCreateReq.CaseID, wantCaseID)
 	}
 }
 
@@ -143,8 +144,9 @@ func TestSearchCallRequests_CaseIDFromPath(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if fake.gotSearchReq.CaseID != testCaseID {
-		t.Fatalf("CaseID = %q, want %q", fake.gotSearchReq.CaseID, testCaseID)
+	wantCaseID := toSysID(testCaseID)
+	if fake.gotSearchReq.CaseID != wantCaseID {
+		t.Fatalf("CaseID = %q, want %q", fake.gotSearchReq.CaseID, wantCaseID)
 	}
 
 	var body struct {
@@ -187,7 +189,27 @@ func TestPatchCallRequest_ExtraCaseIDPathSegmentDoesNotBreakRouting(t *testing.T
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if body.ID != callRequestID {
-		t.Fatalf("id = %q, want %q (the {id} segment, not {caseId})", body.ID, callRequestID)
+	wantID := toSysID(callRequestID)
+	if body.ID != wantID {
+		t.Fatalf("id = %q, want %q (the {id} segment, not {caseId})", body.ID, wantID)
+	}
+}
+
+func TestPatchCallRequest_BareSysIDSupported(t *testing.T) {
+	fake := &fakeEntityCallRequestClient{}
+	h := NewCallRequestHandler(fake)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("PATCH /cases/{caseId}/call-requests/{id}", h.PatchCallRequest)
+
+	callRequestSysID := "a1b2c3d4e5f60718293a4b5c6d7e8f90"
+	req := authedRequest(http.MethodPatch, "/cases/"+testCaseID+"/call-requests/"+callRequestSysID,
+		`{"stateKey":6}`)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/handler/response.go
+++ b/apps/customer-portal/backend-v2/internal/handler/response.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
 )
@@ -45,6 +46,18 @@ var uuidRe = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-
 // sysidRe matches a bare ServiceNow sysid: 32 hex characters, no dashes.
 var sysidRe = regexp.MustCompile(`(?i)^[0-9a-f]{32}$`)
 
+// toSysID converts an identifier (either a dashed UUID or a 32-hex sysid)
+// to a 32-character lowercase hex string without hyphens, for upstream services
+// that enforce ServiceNow's 32-hex IdString pattern constraint.
+func toSysID(id string) string {
+	return strings.ToLower(strings.ReplaceAll(id, "-", ""))
+}
+
+// isUUIDOrSysID reports whether id is a valid UUID or bare 32-hex ServiceNow sysid.
+func isUUIDOrSysID(id string) bool {
+	return uuidRe.MatchString(id) || sysidRe.MatchString(id)
+}
+
 // isAttachmentID reports whether id is a usable attachment identifier — either a
 // dashed UUID or a bare ServiceNow sysid.
 //
@@ -60,7 +73,7 @@ var sysidRe = regexp.MustCompile(`(?i)^[0-9a-f]{32}$`)
 // the same contract while still refusing anything that is neither shape, so the
 // value remains safe to place in an upstream URL path.
 func isAttachmentID(id string) bool {
-	return uuidRe.MatchString(id) || sysidRe.MatchString(id)
+	return isUUIDOrSysID(id)
 }
 
 // Error message constants matching the customer-portal error vocabulary.


### PR DESCRIPTION
## Purpose
Fixes call request creation (`POST /cases/{caseId}/call-requests`), search, and patch operations in Customer Portal Go backend v2 when interacting with `customer-entity-service` and ServiceNow.

## Goals
- Resolve HTTP 500 error when creating call requests caused by case ID formatting mismatch against `customer-entity-service` validation.
- Fix response unmarshaling failure when `customer-entity-service` returns ServiceNow choice-list state objects.
- Ensure call request search and patch endpoints correctly support both 36-character dashed UUIDs and 32-character bare ServiceNow sys_ids.

## Approach
- In `apps/customer-portal/backend-v2/internal/handler/response.go`:
  - Added `toSysID(id string) string` helper to convert identifiers to lowercase 32-character hex strings without hyphens, conforming to upstream ServiceNow pattern constraints (`^[A-Fa-f0-9]{32}$`).
  - Added `isUUIDOrSysID(id string) bool` validator accepting both 36-character dashed UUIDs and bare 32-hex sys_ids.
- In `apps/customer-portal/backend-v2/internal/entity/types.go`:
  - Implemented `CallRequestState.UnmarshalJSON` to decode string enums, numeric choice keys, and ServiceNow choice-list objects (`{"id": 2, "label": "Pending on WSO2"}`).
  - Updated `CallRequestCreated.State` from `string` to `CallRequestState`.
- In `apps/customer-portal/backend-v2/internal/dto/call_request.go`:
  - Updated `MapCallRequestCreate` to read `r.CallRequest.State.Label`, falling back to `ID`.
  - Updated `BuildEntitySearchCallRequestsRequest` to normalize `CaseID` via `toSysID`.
- In `apps/customer-portal/backend-v2/internal/handler/call_requests.go`:
  - Updated `CreateCallRequest`, `SearchCallRequests`, and `PatchCallRequest` to validate `{caseId}` and `{id}` using `isUUIDOrSysID`.
  - Normalized `req.CaseID` to 32-hex sys_id before sending to upstream entity service.
  - Normalized `{id}` parameter in `PatchCallRequest` via `toSysID`.
- In `apps/customer-portal/backend-v2/internal/entity/call_requests.go`:
  - Added defense-in-depth ID normalization in `Client.CreateCallRequest`, `Client.SearchCallRequests`, and `Client.UpdateCallRequest`.

## User stories
As a Customer Portal user, I can create, search, and update call requests on support cases without encountering 500 or 400 validation and unmarshaling errors.

## Release note
Fixed call request creation, search, and update handling in Customer Portal Go backend v2.

## Documentation
N/A — Internal backend fix aligning with upstream data contracts.

## Automation tests
- Unit & integration tests added and passing:
  - `apps/customer-portal/backend-v2/internal/handler/attachment_id_test.go`: `TestToSysID`, `TestIsUUIDOrSysID`
  - `apps/customer-portal/backend-v2/internal/dto/call_request_test.go`: `TestCreateCallRequestResponse_UnmarshalChoiceListState`, `TestSearchCallRequestsResponse_UnmarshalNumericStateID`, `TestBuildEntitySearchCallRequestsRequest_CaseIDNormalizedToSysID`
  - `apps/customer-portal/backend-v2/internal/handler/case_attachments_call_requests_test.go`: `TestCreateCallRequest_CaseIDFromPath`, `TestSearchCallRequests_CaseIDFromPath`, `TestPatchCallRequest_ExtraCaseIDPathSegmentDoesNotBreakRouting`, `TestPatchCallRequest_BareSysIDSupported`
- Full backend-v2 test suite verified: `go test -count=1 ./...`.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go backend change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `go build ./...` passing locally.
- `go test -count=1 ./...` passing locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved call request handling for both UUID-formatted IDs and 32-character system IDs.
  - Standardized identifiers before sending requests, improving compatibility with ServiceNow.
  - Correctly displays call request state labels and supports numeric state IDs.
- **Tests**
  - Added coverage for identifier normalization, supported ID formats, and state response parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->