### PR TITLE
[Customer Portal] Accept Watch List emails, not UUIDs on POST and PATCH /cases

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2134,9 +2134,11 @@ type CreateCaseRequest struct {
 	CatalogItemID string     `json:"catalogItemId"`
 	Variables     []Variable `json:"variables"`
 	// Optional fields
-	RelatedCaseID  string   `json:"relatedCaseId"`
-	ConversationID string   `json:"conversationId"`
-	WatchList      []string `json:"watchList"`
+	RelatedCaseID  string `json:"relatedCaseId"`
+	ConversationID string `json:"conversationId"`
+	// WatchList is watcher emails (Customer Portal / Ballerina). Platform user
+	// UUIDs are still accepted and resolved to emails for CSM callers.
+	WatchList []string `json:"watchList"`
 	// For security_report_analysis type
 	Attachments []CaseAttachment `json:"attachments"`
 	// For engagement type

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1916,10 +1916,11 @@ type UpdateCaseRequest struct {
 	// CreateCaseRequest.Variables. Optional even when transferring into
 	// service_request -- a catalog item with no questions has nothing to answer.
 	Variables []Variable `json:"variables"`
-	// WatchList replaces the case's watch list wholesale with the given platform
-	// user UUIDs. It is a pointer so an absent field and an explicitly empty list
-	// are distinguishable: nil leaves the watch list untouched, while an empty
-	// list clears it.
+	// WatchList replaces the case's watch list wholesale with the given watcher
+	// emails (Customer Portal / Ballerina). Platform user UUIDs are still
+	// accepted and resolved to emails for CSM callers. It is a pointer so an
+	// absent field and an explicitly empty list are distinguishable: nil leaves
+	// the watch list untouched, while an empty list clears it.
 	WatchList      *[]string           `json:"watchList"`
 	AssigneeEmail  *string             `json:"assigneeEmail"`
 	ResolutionCode *CaseResolutionCode `json:"resolutionCode"`

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -2369,7 +2369,8 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	}
 	if req.WatchList != nil {
 		// As on create, the backing service's case-update payload declares the
-		// watch list as email addresses, and it replaces the whole list, so an
+		// watch list as email addresses (incoming emails forwarded as-is;
+		// platform UUIDs resolved first), and it replaces the whole list, so an
 		// explicitly empty list must still be sent to clear it rather than be
 		// skipped.
 		emails, err := watchListEmails(ctx, s.client, token, "watchList", *req.WatchList)

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -946,8 +946,8 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 
 	if len(req.WatchList) > 0 {
 		// The backing service's case-create payload declares the watch list as
-		// email addresses, not user ids, so the incoming platform UUIDs are
-		// resolved to emails first.
+		// email addresses. Incoming emails are forwarded as-is; platform UUIDs
+		// are resolved to emails first.
 		emails, err := watchListEmails(ctx, s.client, token, "watchList", req.WatchList)
 		if err != nil {
 			return domain.CreateCaseResponse{}, err

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -690,8 +690,8 @@ func (s *snIncidentService) CreateIncident(ctx context.Context, req domain.Creat
 	token := middleware.UserIDTokenFromContext(ctx)
 
 	// The backing service's incident-create payload declares the watch list as
-	// email addresses, not user ids, so the incoming platform UUIDs are resolved
-	// to emails first.
+	// email addresses. Incoming emails are forwarded as-is; platform UUIDs are
+	// resolved to emails first.
 	watchList, err := watchListEmails(ctx, s.client, token, "watchList", req.WatchList)
 	if err != nil {
 		return domain.CreateIncidentResponse{}, err

--- a/entity-service/internal/service/sn_watch_list.go
+++ b/entity-service/internal/service/sn_watch_list.go
@@ -25,13 +25,15 @@ import (
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
 )
 
-// Watch lists arrive at this service as platform user UUIDs, but the backing
-// service's write payloads are not keyed by id at all: the case create, case
-// update and incident create payloads declare the watch list as email
-// addresses, and the incident update payload declares it as usernames.
-// Forwarding the ids verbatim is silently accepted upstream and drops every
-// watcher, so each id is resolved to the identity value its target payload
-// actually declares before the write goes out.
+// Watch lists on case create/update (and incident create) arrive either as
+// watcher emails — the Customer Portal / Ballerina contract — or as platform
+// user UUIDs from CSM. The backing service's write payloads are not keyed by
+// id at all: those three payloads declare the watch list as email addresses,
+// and the incident update payload declares it as usernames. Forwarding UUIDs
+// verbatim is silently accepted upstream and drops every watcher, so each id
+// is resolved to the identity value its target payload actually declares
+// before the write goes out. Emails are already the declared shape and are
+// forwarded as-is.
 //
 // snWatchListIdentity holds both values from the one lookup, so a caller can
 // pick the one its payload needs without a second round trip.
@@ -113,13 +115,59 @@ func resolveWatchListIdentities(
 	return out, nil
 }
 
-// watchListEmails resolves watch-list user UUIDs to email addresses, for the
-// payloads that declare the watch list that way. The returned slice is non-nil
-// and in the caller's order.
+// watchListEmails returns the email addresses the backing service's case
+// create, case update, and incident create payloads declare. Incoming emails
+// (Customer Portal) are forwarded in the caller's order with no lookup.
+// Incoming platform UUIDs (CSM) are resolved to emails first — forwarding
+// ids verbatim is silently accepted upstream and drops every watcher.
+// A mixed list, or a value that is neither an email nor a UUID, is a
+// validation error. The returned slice is non-nil and in the caller's order.
 func watchListEmails(
-	ctx context.Context, client *integrationservice.Client, token, field string, ids []string,
+	ctx context.Context, client *integrationservice.Client, token, field string, values []string,
 ) ([]string, error) {
-	identities, err := resolveWatchListIdentities(ctx, client, token, field, ids)
+	if len(values) == 0 {
+		return []string{}, nil
+	}
+	if len(values) > maxUserLimit {
+		return nil, &apierror.ValidationError{
+			Msg: fmt.Sprintf("%s cannot contain more than %d values", field, maxUserLimit),
+		}
+	}
+
+	allEmail := true
+	allUUID := true
+	var firstInvalid string
+	for _, v := range values {
+		isEmail := emailRE.MatchString(v)
+		isUUID := uuidRE.MatchString(v)
+		if !isEmail {
+			allEmail = false
+		}
+		if !isUUID {
+			allUUID = false
+		}
+		if !isEmail && !isUUID && firstInvalid == "" {
+			firstInvalid = v
+		}
+	}
+
+	if allEmail {
+		out := make([]string, len(values))
+		copy(out, values)
+		return out, nil
+	}
+	if !allUUID {
+		if firstInvalid != "" {
+			return nil, &apierror.ValidationError{
+				Msg: fmt.Sprintf("%s contains invalid email: %q", field, firstInvalid),
+			}
+		}
+		return nil, &apierror.ValidationError{
+			Msg: fmt.Sprintf("%s items must all be email addresses or all be user identifiers", field),
+		}
+	}
+
+	identities, err := resolveWatchListIdentities(ctx, client, token, field, values)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +176,7 @@ func watchListEmails(
 	for i, identity := range identities {
 		if identity.Email == "" {
 			return nil, &apierror.ValidationError{
-				Msg: fmt.Sprintf("%s contains a user with no email address: %q", field, ids[i]),
+				Msg: fmt.Sprintf("%s contains a user with no email address: %q", field, values[i]),
 			}
 		}
 		emails = append(emails, identity.Email)

--- a/entity-service/internal/service/sn_watch_list_test.go
+++ b/entity-service/internal/service/sn_watch_list_test.go
@@ -17,6 +17,7 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -118,6 +119,91 @@ func TestSNCaseService_CreateCase_WatchListResolvedToEmails(t *testing.T) {
 		EngagementType:        domain.EngagementTypeMigration,
 		EngagementPaymentType: domain.EngagementPaymentTypePaid,
 		WatchList:             []string{testIncidentWatcherUUID1, testIncidentWatcherUUID2},
+	}
+
+	if _, err := svc.CreateCase(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertWatchListPayload(t, gotBody, []string{testWatcherEmail1, testWatcherEmail2})
+}
+
+// TestWatchListEmails_ForwardsEmailsWithoutLookup is the Customer Portal /
+// Ballerina contract: watchList is EmailString[], forwarded as-is. A user
+// lookup would 400 those values as invalid UUIDs (issues 3001 / 3002).
+func TestWatchListEmails_ForwardsEmailsWithoutLookup(t *testing.T) {
+	in := []string{testWatcherEmail1, testWatcherEmail2}
+	got, err := watchListEmails(context.Background(), nil, "token", "watchList", in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(in) {
+		t.Fatalf("got %d emails, want %d", len(got), len(in))
+	}
+	for i, w := range in {
+		if got[i] != w {
+			t.Fatalf("got[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+// TestWatchListEmails_RejectsNeitherEmailNorUUID covers the 400 the portal
+// used to hit with emails, now reserved for values that are neither.
+func TestWatchListEmails_RejectsNeitherEmailNorUUID(t *testing.T) {
+	_, err := watchListEmails(context.Background(), nil, "token", "watchList", []string{"not-an-email"})
+	verr, ok := err.(*apierror.ValidationError)
+	if !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+	if !strings.Contains(verr.Msg, "invalid email") {
+		t.Fatalf("error %q does not name an invalid email", verr.Msg)
+	}
+}
+
+// TestWatchListEmails_RejectsMixedEmailAndUUID keeps a single list in one
+// identity shape so CSM ids and portal emails cannot be interleaved.
+func TestWatchListEmails_RejectsMixedEmailAndUUID(t *testing.T) {
+	_, err := watchListEmails(context.Background(), nil, "token", "watchList", []string{
+		testWatcherEmail1, testIncidentWatcherUUID1,
+	})
+	if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
+// TestSNCaseService_CreateCase_WatchListEmailsForwarded verifies POST /cases
+// accepts watcher emails and sends them to the backing service without a
+// user-id lookup.
+func TestSNCaseService_CreateCase_WatchListEmailsForwarded(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/search", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("email watch lists must not trigger a user lookup")
+	})
+	mux.HandleFunc("/cases", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+			"message": "Case created successfully",
+			"case": {"id": "` + testWLCaseSysid + `", "number": "CS0000010", "createdBy": "engineer@example.com", "createdOn": "2026-01-02 10:00:00", "state": {"id": 1, "label": "Open"}}
+		}`))
+	})
+
+	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil)
+
+	req := domain.CreateCaseRequest{
+		Type:                  "engagement",
+		ProjectID:             testProjectUUID,
+		DeploymentID:          testDeploymentUUID,
+		DeployedProductID:     testDeployedProdID,
+		Subject:               "Migration planning",
+		Description:           "Plan the migration",
+		EngagementType:        domain.EngagementTypeMigration,
+		EngagementPaymentType: domain.EngagementPaymentTypePaid,
+		WatchList:             []string{testWatcherEmail1, testWatcherEmail2},
 	}
 
 	if _, err := svc.CreateCase(contextWithUserIDToken("token"), req); err != nil {

--- a/entity-service/internal/service/sn_watch_list_test.go
+++ b/entity-service/internal/service/sn_watch_list_test.go
@@ -247,6 +247,43 @@ func TestSNCaseService_UpdateCase_WatchListResolvedToEmails(t *testing.T) {
 	assertWatchListPayload(t, gotBody, []string{testWatcherEmail1, testWatcherEmail2})
 }
 
+// TestSNCaseService_UpdateCase_WatchListEmailsForwarded verifies PATCH /cases
+// accepts watcher emails (service-request / case edit) without treating them
+// as user UUIDs.
+func TestSNCaseService_UpdateCase_WatchListEmailsForwarded(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/search", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("email watch lists must not trigger a user lookup")
+	})
+	mux.HandleFunc("/cases/"+testWLCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"message": "Case updated successfully",
+			"case": {"id": "` + testWLCaseSysid + `", "updatedOn": "2026-01-03 10:00:00", "updatedBy": "engineer@example.com"}
+		}`))
+	})
+
+	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil, nil)
+
+	watchList := []string{testWatcherEmail1, testWatcherEmail2}
+	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
+		ID:        sysidToUUID(testWLCaseSysid),
+		WatchList: &watchList,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertWatchListPayload(t, gotBody, []string{testWatcherEmail1, testWatcherEmail2})
+}
+
 // TestSNIncidentService_UpdateIncident_WatchListClearedByEmptyList verifies an
 // explicitly empty watch list still reaches the backing service as an empty list.
 // The incident-update payload replaces the whole watch list, so an empty list is

--- a/entity-service/internal/service/user_service.go
+++ b/entity-service/internal/service/user_service.go
@@ -32,6 +32,10 @@ import (
 
 var uuidRE = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
+// emailRE matches the Ballerina `Email` constraint used by the Customer Portal
+// backend (`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`).
+var emailRE = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+
 // validateUUIDs returns a ValidationError if any element of ids is not a valid UUID.
 func validateUUIDs(field string, ids []string) error {
 	for _, id := range ids {

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -7491,10 +7491,10 @@ components:
           type: array
           items:
             type: string
-            format: email
           description: |
-            Optional list of watcher email addresses to add to the case watch list.
-            Platform user UUIDs are still accepted and resolved to emails.
+            Optional initial watch list (ServiceNow only). Each item is a watcher
+            email (Customer Portal) or a platform user UUID (CSM); the list must be
+            all emails or all UUIDs.
 
     CreateCaseResponse:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -7491,8 +7491,10 @@ components:
           type: array
           items:
             type: string
-            format: uuid
-          description: Optional list of identifiers of the users to add to the case watch list.
+            format: email
+          description: |
+            Optional list of watcher email addresses to add to the case watch list.
+            Platform user UUIDs are still accepted and resolved to emails.
 
     CreateCaseResponse:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -7096,11 +7096,11 @@ components:
           type: array
           items:
             type: string
-            format: uuid
           description: |
-            The full set of user identifiers to set as the case watch list, replacing
-            whatever is there (ServiceNow only). An empty array clears the watch list,
-            and counts as providing the field.
+            The full set of watchers to set on the case, replacing whatever is there
+            (ServiceNow only). Each item is a watcher email (Customer Portal) or a
+            platform user UUID (CSM); the list must be all emails or all UUIDs. An
+            empty array clears the watch list, and counts as providing the field.
         assigneeEmail:
           type: string
           format: email


### PR DESCRIPTION
## Purpose
Customer Portal v2 sends Watch List items as emails (`EmailString[]`, same as Ballerina). Go entity-service treated `watchList` as platform user UUIDs, so create and edit failed with `400 watchList contains invalid UUID`.

- https://github.com/wso2-enterprise/digiops-cs/issues/3002 (POST `/cases`)
- https://github.com/wso2-enterprise/digiops-cs/issues/3001 (PATCH `/cases/{id}`)

## Goals
- POST `/cases` with a `watchList` of emails succeeds and those emails are stored as watchers in ServiceNow.
- PATCH `/cases/{id}` with the same email list replaces the watch list without a UUID 400.
- CSM callers that still send user UUIDs keep working: UUIDs are resolved to emails before the ServiceNow write.

## Approach
- `watchListEmails` forwards a list of emails as-is (no `/users/search`).
- A list of UUIDs is still resolved to emails (existing CSM path).
- A mixed list, or a value that is neither email nor UUID, is a validation error.
- OpenAPI `UpdateCaseRequest.watchList` describes emails or UUIDs (not `format: email` alone). Create still documents emails with UUIDs accepted at runtime.
- GET watch-list shape is unchanged (`id`, `userName`, `name`, `email`). The portal continues to save emails, not ids.
- Unremovable Watch List chips are a separate frontend issue and are not in this PR.

## User stories
As a Customer Portal user, I can add watchers by email when creating or editing a case or service request, and the save succeeds.

As a CSM caller, I can still send watch-list user UUIDs and they are stored as emails in ServiceNow.

## Release note
Go entity-service now accepts Watch List emails on POST and PATCH `/cases`, matching Customer Portal / Ballerina, while still resolving CSM user UUIDs to emails.

## Documentation
N/A — API behaviour is described in `entity-service/openapi.yaml`; no product doc change.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A

## Automation tests
- Unit tests in `entity-service/internal/service/sn_watch_list_test.go`:
  - `TestWatchListEmails_ForwardsEmailsWithoutLookup`
  - `TestWatchListEmails_RejectsNeitherEmailNorUUID`
  - `TestWatchListEmails_RejectsMixedEmailAndUUID`
  - `TestSNCaseService_CreateCase_WatchListEmailsForwarded`
  - `TestSNCaseService_UpdateCase_WatchListEmailsForwarded`
  - Existing UUID-resolution tests for create/update still pass.
- Ran `go test ./internal/service/ -count=1 -run WatchList` in `entity-service`.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A — watch-list writes still send emails to ServiceNow.

## Test environment
- Go 1.26 locally
- Unit tests against mocked ServiceNow integration client (no live SN)

## Learning
N/A

Fix: 
https://github.com/wso2-enterprise/digiops-cs/issues/3001 
https://github.com/wso2-enterprise/digiops-cs/issues/3002


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Watch lists now support watcher email addresses in addition to platform user UUIDs.
  * Email addresses are forwarded directly, while UUIDs are resolved to email addresses.
  * Watch lists must contain either all emails or all UUIDs; invalid and mixed entries are rejected.

* **Documentation**
  * API documentation now reflects the supported watch-list formats and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->