### PR TITLE
[Customer Portal] Relabel time tracking date filter to "Case Created Date"

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
@@ -53,66 +53,60 @@ export default function TimeCardsDateFilter({
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          gap: 1.5,
-          flexWrap: "wrap",
-        }}
-      >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
         <Calendar size={18} />
         <Typography variant="body2" sx={{ fontWeight: 600 }}>
-          Time Range:
+          Case Created Date :
         </Typography>
-        <DatePicker
-          value={parsedStart}
-          disableFuture
-          maxDate={parsedEnd ?? undefined}
-          onChange={(date) => {
-            onStartDateChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");
-          }}
-          slotProps={{
-            textField: {
-              id: "time-cards-start-date",
-              size: "small",
-              sx: { minWidth: 160 },
-              slotProps: { htmlInput: { "aria-label": "Start date" } },
-            },
-            field: { clearable: true },
-          }}
-        />
-        <Typography variant="body2" color="text.secondary">
-          to
-        </Typography>
-        <DatePicker
-          value={parsedEnd}
-          disableFuture
-          minDate={parsedStart ?? undefined}
-          onChange={(date) => {
-            onEndDateChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");
-          }}
-          slotProps={{
-            textField: {
-              id: "time-cards-end-date",
-              size: "small",
-              sx: { minWidth: 160 },
-              slotProps: { htmlInput: { "aria-label": "End date" } },
-            },
-            field: { clearable: true },
-          }}
-        />
-        {hasFilters && onClear && (
-          <Button
-            variant="text"
-            size="small"
-            onClick={onClear}
-            startIcon={<X size={16} />}
-            sx={{ color: "text.secondary" }}
-          >
-            Clear
-          </Button>
-        )}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+          <DatePicker
+            label="From"
+            value={parsedStart}
+            disableFuture
+            maxDate={parsedEnd ?? undefined}
+            onChange={(date) => {
+              onStartDateChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");
+            }}
+            slotProps={{
+              textField: {
+                id: "time-cards-start-date",
+                size: "small",
+                sx: { minWidth: 160 },
+                slotProps: { htmlInput: { "aria-label": "Start date" } },
+              },
+              field: { clearable: true },
+            }}
+          />
+          <DatePicker
+            label="To"
+            value={parsedEnd}
+            disableFuture
+            minDate={parsedStart ?? undefined}
+            onChange={(date) => {
+              onEndDateChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");
+            }}
+            slotProps={{
+              textField: {
+                id: "time-cards-end-date",
+                size: "small",
+                sx: { minWidth: 160 },
+                slotProps: { htmlInput: { "aria-label": "End date" } },
+              },
+              field: { clearable: true },
+            }}
+          />
+          {hasFilters && onClear && (
+            <Button
+              variant="text"
+              size="small"
+              onClick={onClear}
+              startIcon={<X size={16} />}
+              sx={{ color: "text.secondary" }}
+            >
+              Clear
+            </Button>
+          )}
+        </Box>
       </Box>
     </LocalizationProvider>
   );

--- a/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
@@ -45,7 +45,7 @@ export const USAGE_TIME_RANGE_LABELS: Record<UsageTimeRange, string> = {
   [UsageTimeRange.CUSTOM]: "Custom range",
 };
 
-export const USAGE_METRICS_TIME_RANGE_HEADING = "Time Range:";
+export const USAGE_METRICS_TIME_RANGE_HEADING = "Time Range :";
 
 export const USAGE_METRICS_CUSTOM_RANGE_BUTTON = "Custom";
 


### PR DESCRIPTION
## Summary
- Relabel the time tracking tab's date range filter from "Time Range:" to "Case Created Date" to match the terminology used by the Cases list filters.
- Add explicit "From"/"To" labels on the individual date pickers instead of an inline "to" separator, consistent with the Cases date filter pattern.

## Changes
- `webapp/.../time-tracking/TimeCardsDateFilter.tsx` — updated heading label and picker labels

## Test plan
- [ ] Open a project's Time Tracking tab and confirm the filter now reads "Case Created Date" with "From"/"To" labeled pickers
- [ ] Verify filtering still works correctly (start/end date selection, Clear button, min/max date constraints)
