### PR TITLE
[CSM Portal] Add saved filter views to Operations sub-tabs

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
@@ -169,6 +169,7 @@ export default function ChangeRequestsFilterBar({
             ).toString()
           }
           activeCount={activeCount}
+          hasSearch={filters.search.trim().length > 0}
           onApply={(qs) => onChange(readChangeRequestFiltersFromUrl(new URLSearchParams(qs)))}
           store={changeRequestsSavedViews}
         />

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
@@ -44,6 +44,12 @@ import {
   countActiveCRFilters,
   type ChangeRequestFilters,
 } from "@features/csm-operations/utils/changeRequests";
+import {
+  readChangeRequestFiltersFromUrl,
+  writeChangeRequestFiltersToUrl,
+} from "@features/csm-operations/utils/changeRequestsFiltersUrl";
+import { changeRequestsSavedViews } from "@features/csm-operations/utils/changeRequestsSavedViews";
+import SavedViewsMenu from "@features/csm-operations/components/SavedViewsMenu";
 import MultiSelectField from "@components/MultiSelectField";
 
 const { DatePicker, LocalizationProvider } = DatePickers;
@@ -154,6 +160,18 @@ export default function ChangeRequestsFilterBar({
             }}
           />
         </Box>
+
+        <SavedViewsMenu
+          currentQs={writeChangeRequestFiltersToUrl(filters).toString()}
+          canonicalizeQs={(qs) =>
+            writeChangeRequestFiltersToUrl(
+              readChangeRequestFiltersFromUrl(new URLSearchParams(qs)),
+            ).toString()
+          }
+          activeCount={activeCount}
+          onApply={(qs) => onChange(readChangeRequestFiltersFromUrl(new URLSearchParams(qs)))}
+          store={changeRequestsSavedViews}
+        />
 
         <Button
           variant="outlined"

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.tsx
@@ -214,6 +214,7 @@ export default function IncidentsFilterBar({
             writeIncidentFiltersToUrl(readIncidentFiltersFromUrl(new URLSearchParams(qs))).toString()
           }
           activeCount={activeCount}
+          hasSearch={filters.search.trim().length > 0}
           onApply={(qs) => onChange(readIncidentFiltersFromUrl(new URLSearchParams(qs)))}
           store={incidentsSavedViews}
         />

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.tsx
@@ -39,7 +39,13 @@ import {
   INCIDENT_PRIORITIES,
   type IncidentFilters,
 } from "@features/csm-operations/utils/incidents";
+import {
+  readIncidentFiltersFromUrl,
+  writeIncidentFiltersToUrl,
+} from "@features/csm-operations/utils/incidentsFiltersUrl";
+import { incidentsSavedViews } from "@features/csm-operations/utils/incidentsSavedViews";
 import IncidentProductMultiSelect from "@features/csm-operations/components/IncidentProductMultiSelect";
+import SavedViewsMenu from "@features/csm-operations/components/SavedViewsMenu";
 import MultiSelectField from "@components/MultiSelectField";
 
 const { DatePicker, LocalizationProvider } = DatePickers;
@@ -201,6 +207,16 @@ export default function IncidentsFilterBar({
             }}
           />
         </Box>
+
+        <SavedViewsMenu
+          currentQs={writeIncidentFiltersToUrl(filters).toString()}
+          canonicalizeQs={(qs) =>
+            writeIncidentFiltersToUrl(readIncidentFiltersFromUrl(new URLSearchParams(qs))).toString()
+          }
+          activeCount={activeCount}
+          onApply={(qs) => onChange(readIncidentFiltersFromUrl(new URLSearchParams(qs)))}
+          store={incidentsSavedViews}
+        />
 
         <Button
           variant="outlined"

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.tsx
@@ -133,6 +133,7 @@ export default function ProblemsFilterBar({
             writeProblemFiltersToUrl(readProblemFiltersFromUrl(new URLSearchParams(qs))).toString()
           }
           activeCount={activeCount}
+          hasSearch={filters.search.trim().length > 0}
           onApply={(qs) => onChange(readProblemFiltersFromUrl(new URLSearchParams(qs)))}
           store={problemsSavedViews}
         />

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.tsx
@@ -34,6 +34,12 @@ import {
   problemStateLabel,
   type ProblemFilters,
 } from "@features/csm-operations/utils/problems";
+import {
+  readProblemFiltersFromUrl,
+  writeProblemFiltersToUrl,
+} from "@features/csm-operations/utils/problemsFiltersUrl";
+import { problemsSavedViews } from "@features/csm-operations/utils/problemsSavedViews";
+import SavedViewsMenu from "@features/csm-operations/components/SavedViewsMenu";
 import MultiSelectField from "@components/MultiSelectField";
 
 interface ProblemsFilterBarProps {
@@ -120,6 +126,16 @@ export default function ProblemsFilterBar({
             }}
           />
         </Box>
+
+        <SavedViewsMenu
+          currentQs={writeProblemFiltersToUrl(filters).toString()}
+          canonicalizeQs={(qs) =>
+            writeProblemFiltersToUrl(readProblemFiltersFromUrl(new URLSearchParams(qs))).toString()
+          }
+          activeCount={activeCount}
+          onApply={(qs) => onChange(readProblemFiltersFromUrl(new URLSearchParams(qs)))}
+          store={problemsSavedViews}
+        />
 
         <Button
           variant="outlined"

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.test.tsx
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Regression coverage for the problems tab's filter state now living in the
+ * URL (`prob...`-prefixed params) instead of local component state — same
+ * pattern the change-requests/incidents tabs already have their own coverage
+ * for (`OperationsTabFiltersUrl.test.tsx`), plus a smoke test for the new
+ * "Saved views" menu this tab now shares with them.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useSearchParams } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { JSX } from "react";
+import ProblemsTab from "@features/csm-operations/components/ProblemsTab";
+import { useSearchProblems } from "@features/csm-operations/api/useSearchProblems";
+
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {},
+  useBackendApi: () => ({ post: vi.fn() }),
+}));
+
+vi.mock("@features/csm-operations/api/useSearchProblems", () => ({
+  useSearchProblems: vi.fn(),
+}));
+
+// The filter bar's SRE Team control goes through the shared team registry
+// query — stub it out, same as ChangeRequestsTab.test.tsx's own mock.
+vi.mock("@features/csm-dashboard/api/useTeams", () => ({
+  useTeams: () => ({ data: [], isLoading: false }),
+}));
+
+const mockedUseSearch = vi.mocked(useSearchProblems);
+
+function mockResult(overrides: Partial<ReturnType<typeof useSearchProblems>>): void {
+  mockedUseSearch.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    dataUpdatedAt: 0,
+    ...overrides,
+  } as unknown as ReturnType<typeof useSearchProblems>);
+}
+
+/** Exposes the live query string alongside the tab, so a test can assert on
+ * it without reaching into `MemoryRouter` internals — mirrors
+ * `OperationsTabFiltersUrl.test.tsx`'s own harness. */
+function ProblemsTabHarness(): JSX.Element {
+  const [params] = useSearchParams();
+  return (
+    <>
+      <div data-testid="url">{params.toString()}</div>
+      <ProblemsTab />
+    </>
+  );
+}
+
+function renderTab(initialEntry = "/operations?tab=problems") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <ProblemsTabHarness />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockedUseSearch.mockReset();
+  window.localStorage.clear();
+  mockResult({});
+});
+
+describe("ProblemsTab — filters live in the URL", () => {
+  it("writes a search into the URL under its own `prob`-prefixed param", () => {
+    renderTab();
+    const search = screen.getByPlaceholderText("Search by number or subject…");
+    fireEvent.change(search, { target: { value: "outage" } });
+    expect(screen.getByTestId("url").textContent).toContain("probQ=outage");
+  });
+
+  it("reads an already-filtered query string back on mount (bookmark/share case)", () => {
+    renderTab("/operations?tab=problems&probQ=outage&probStates=NEW");
+    expect(
+      screen.getByPlaceholderText("Search by number or subject…"),
+    ).toHaveValue("outage");
+    expect(screen.getByRole("button", { name: /filters \(1\)/i })).toBeInTheDocument();
+  });
+
+  it("tolerates a malformed/stale query string instead of crashing", () => {
+    renderTab("/operations?tab=problems&probStates=not_a_real_state");
+    expect(
+      screen.getByPlaceholderText("Search by number or subject…"),
+    ).toHaveValue("");
+  });
+});
+
+describe("ProblemsTab — Saved views", () => {
+  it("renders the shared Saved views menu, scoped to this tab's own store", () => {
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: /saved views/i }));
+    expect(screen.getByText(/no saved views yet/i)).toBeInTheDocument();
+  });
+
+  it("applying a saved problems view updates the URL", () => {
+    window.localStorage.setItem(
+      "csm.savedFilters.problems.v1",
+      JSON.stringify([{ name: "New problems", qs: "probStates=NEW" }]),
+    );
+    renderTab();
+
+    fireEvent.click(screen.getByRole("button", { name: /saved views/i }));
+    fireEvent.click(screen.getByText("New problems"));
+
+    expect(screen.getByTestId("url").textContent).toContain("probStates=NEW");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
@@ -29,8 +29,8 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
-import { useMemo, useState, type ChangeEvent, type JSX } from "react";
-import { useLocation } from "react-router";
+import { useCallback, useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useLocation, useSearchParams } from "react-router";
 import { useNavTransition } from "@hooks/useNavTransition";
 import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
@@ -42,6 +42,11 @@ import {
   problemStateLabel,
   type ProblemFilters,
 } from "@features/csm-operations/utils/problems";
+import {
+  PROBLEM_FILTER_PARAM_KEYS,
+  readProblemFiltersFromUrl,
+  writeProblemFiltersToUrl,
+} from "@features/csm-operations/utils/problemsFiltersUrl";
 import ProblemsFilterBar from "@features/csm-operations/components/ProblemsFilterBar";
 import RefreshButton from "@components/RefreshButton";
 
@@ -51,12 +56,19 @@ const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
 /**
  * Problems listing for the Operations → Problem management tab. Searches
  * `POST /problems/search` with server-side pagination, free-text search, and
- * a state filter.
+ * a state filter. Filter state lives in the URL (tab-prefixed `prob...`
+ * params) rather than local state, so a plain tab switch doesn't reset it and
+ * a filtered list can be bookmarked or shared — same pattern as the
+ * Incidents/Change Requests tabs.
  */
 export default function ProblemsTab(): JSX.Element {
   const navigate = useNavTransition();
   const location = useLocation();
-  const [filters, setFilters] = useState<ProblemFilters>(DEFAULT_PROBLEM_FILTERS);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = useMemo<ProblemFilters>(
+    () => readProblemFiltersFromUrl(searchParams),
+    [searchParams],
+  );
   const [isFiltersOpen, setIsFiltersOpen] = useState(true);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
@@ -76,14 +88,28 @@ export default function ProblemsTab(): JSX.Element {
   const problems = data?.problems ?? [];
   const total = data?.total ?? 0;
 
+  const setFilters = useCallback(
+    (next: ProblemFilters) => {
+      setPage(0);
+      // Preserve any non-filter params (e.g. the active operations tab) and
+      // any other tab's own filter params (e.g. the incidents tab's), rather
+      // than resetting the whole query string.
+      const merged = new URLSearchParams(searchParams);
+      PROBLEM_FILTER_PARAM_KEYS.forEach((k) => merged.delete(k));
+      writeProblemFiltersToUrl(next).forEach((v, k) => merged.set(k, v));
+      // `replace: true` so switching tabs / paging doesn't spam browser
+      // history — same rationale as the shared cases list view.
+      setSearchParams(merged, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
   const handleFiltersChange = (next: ProblemFilters): void => {
     setFilters(next);
-    setPage(0);
   };
 
   const handleReset = (): void => {
     setFilters(DEFAULT_PROBLEM_FILTERS);
-    setPage(0);
   };
 
   const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/SavedViewsMenu.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/SavedViewsMenu.test.tsx
@@ -32,6 +32,7 @@ function renderMenu(overrides: Partial<React.ComponentProps<typeof SavedViewsMen
       currentQs="q=hello"
       canonicalizeQs={canonicalizeQs}
       activeCount={1}
+      hasSearch={false}
       onApply={onApply}
       store={store}
       {...overrides}
@@ -111,6 +112,28 @@ describe("SavedViewsMenu", () => {
       .filter((el) => el.textContent?.match(/First|Second/));
     expect(items[0]).toHaveTextContent("First");
     expect(items[1]).toHaveTextContent("Second");
+  });
+
+  it("does not claim 'all records' in the save dialog when only a search term is active", () => {
+    // activeCount excludes search (see each tab's countActive*Filters), but a
+    // search-only view still restores that search on apply — the helper text
+    // must not tell the user it will show everything.
+    renderMenu({ activeCount: 0, hasSearch: true });
+
+    fireEvent.click(screen.getByRole("button", { name: /saved views/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /save current view/i }));
+
+    expect(screen.queryByText(/will show all records/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/captures the 0 active filters and the current search/i)).toBeInTheDocument();
+  });
+
+  it("shows the 'all records' tip only when there is neither an active filter nor a search", () => {
+    renderMenu({ activeCount: 0, hasSearch: false });
+
+    fireEvent.click(screen.getByRole("button", { name: /saved views/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /save current view/i }));
+
+    expect(screen.getByText(/will show all records/i)).toBeInTheDocument();
   });
 
   it("deletes a saved view via its delete icon button", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/SavedViewsMenu.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/SavedViewsMenu.test.tsx
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type * as React from "react";
+import SavedViewsMenu from "@features/csm-operations/components/SavedViewsMenu";
+import { createSavedFilterViewsStore } from "@features/csm-operations/utils/savedFilterViews";
+
+const STORAGE_KEY = "csm.savedFilters.test.v1";
+
+function renderMenu(overrides: Partial<React.ComponentProps<typeof SavedViewsMenu>> = {}) {
+  const store = createSavedFilterViewsStore(STORAGE_KEY);
+  const onApply = vi.fn();
+  const canonicalizeQs = (qs: string) => qs;
+  const utils = render(
+    <SavedViewsMenu
+      currentQs="q=hello"
+      canonicalizeQs={canonicalizeQs}
+      activeCount={1}
+      onApply={onApply}
+      store={store}
+      {...overrides}
+    />,
+  );
+  return { ...utils, store, onApply };
+}
+
+describe("SavedViewsMenu", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("saves the current view via the dialog, persisting it to the tab's store", () => {
+    renderMenu();
+
+    fireEvent.click(screen.getByRole("button", { name: /saved views/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /save current view/i }));
+
+    const nameField = screen.getByLabelText(/view name/i);
+    fireEvent.change(nameField, { target: { value: "My open S1s" } });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    // The Dialog's own close transition means the "Saved views" button isn't
+    // reliably re-queryable (aria-hidden while unmounting) right after this
+    // synchronous click — assert against the store the menu itself reads
+    // from instead of reopening the menu.
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "[]")).toContainEqual({
+      name: "My open S1s",
+      qs: "q=hello",
+    });
+  });
+
+  it("applying a saved view calls onApply with its stored qs", () => {
+    const store = createSavedFilterViewsStore(STORAGE_KEY);
+    store.saveFilterView("Critical only", "severities=S1");
+    const onApply = vi.fn();
+    renderMenu({ store, onApply });
+
+    fireEvent.click(screen.getByRole("button", { name: /saved views/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /critical only/i }));
+
+    expect(onApply).toHaveBeenCalledWith("severities=S1");
+  });
+
+  it("highlights the saved view matching the current qs as active", () => {
+    const store = createSavedFilterViewsStore(STORAGE_KEY);
+    store.saveFilterView("Matches current", "q=hello");
+    store.saveFilterView("Different", "q=other");
+    renderMenu({ store, currentQs: "q=hello" });
+
+    fireEvent.click(screen.getByRole("button", { name: /saved views/i }));
+    expect(screen.getByText("Matches current").closest('[role="menuitem"]')).toHaveClass(
+      "Mui-selected",
+    );
+    expect(screen.getByText("Different").closest('[role="menuitem"]')).not.toHaveClass(
+      "Mui-selected",
+    );
+  });
+
+  it("reorders saved views with the up/down icon buttons", () => {
+    const store = createSavedFilterViewsStore(STORAGE_KEY);
+    store.saveFilterView("First", "q=1");
+    store.saveFilterView("Second", "q=2");
+    // Most-recently-saved first: ["Second", "First"].
+    renderMenu({ store });
+
+    fireEvent.click(screen.getByRole("button", { name: /saved views/i }));
+    fireEvent.click(screen.getByRole("button", { name: /move saved view second down/i }));
+
+    // The menu itself stays open across a move (`store.moveFilterView` never
+    // closes it) — re-query it in place rather than re-clicking "Saved
+    // views" (which the modal's own aria-hidden handling would hide anyway
+    // while it's still open).
+    const items = screen
+      .getAllByRole("menuitem")
+      .filter((el) => el.textContent?.match(/First|Second/));
+    expect(items[0]).toHaveTextContent("First");
+    expect(items[1]).toHaveTextContent("Second");
+  });
+
+  it("deletes a saved view via its delete icon button", () => {
+    const store = createSavedFilterViewsStore(STORAGE_KEY);
+    store.saveFilterView("Temp view", "q=temp");
+    renderMenu({ store });
+
+    fireEvent.click(screen.getByRole("button", { name: /saved views/i }));
+    fireEvent.click(screen.getByRole("button", { name: /delete saved view temp view/i }));
+
+    // Same reasoning as the reorder test above — the menu stays open across
+    // a delete, so assert in place instead of reopening it.
+    expect(screen.queryByText("Temp view")).not.toBeInTheDocument();
+    expect(screen.getByText(/no saved views yet/i)).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/SavedViewsMenu.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/SavedViewsMenu.tsx
@@ -55,6 +55,12 @@ interface SavedViewsMenuProps {
   canonicalizeQs: (qs: string) => string;
   /** Active (non-search) filter count, shown in the save dialog's helper text. */
   activeCount: number;
+  /** Whether a search term is currently active. `activeCount` deliberately
+   * excludes search (see each tab's `countActive*Filters`), but a saved
+   * view's `qs` still captures it — the save dialog's "will show all
+   * records" message must only appear when neither is set, or applying that
+   * view would silently restore a search the message said wasn't there. */
+  hasSearch: boolean;
   /** Apply a saved view's `qs` — the caller parses it back into its own
    * filter shape and feeds it through the same `onChange` the filter bar
    * already has. */
@@ -78,6 +84,7 @@ export default function SavedViewsMenu({
   currentQs,
   canonicalizeQs,
   activeCount,
+  hasSearch,
   onApply,
   store,
 }: SavedViewsMenuProps): JSX.Element {
@@ -215,9 +222,11 @@ export default function SavedViewsMenu({
               }
             }}
             helperText={
-              activeCount === 0
+              activeCount === 0 && !hasSearch
                 ? "Tip: no filters are active — this view will show all records."
-                : `Captures the ${activeCount} active filter${activeCount === 1 ? "" : "s"}.`
+                : `Captures the ${activeCount} active filter${activeCount === 1 ? "" : "s"}${
+                    hasSearch ? " and the current search" : ""
+                  }.`
             }
           />
         </DialogContent>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/SavedViewsMenu.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/SavedViewsMenu.tsx
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  ListSubheader,
+  Menu,
+  MenuItem,
+  TextField,
+} from "@wso2/oxygen-ui";
+import {
+  Bookmark,
+  BookmarkPlus,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Trash2,
+} from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+import type { SavedFilterViewsStore } from "@features/csm-operations/utils/savedFilterViews";
+
+interface SavedViewsMenuProps {
+  /** This tab's own serialized-filters query string right now (no leading
+   * `?`) — what "Save current view…" captures, and what an already-saved
+   * view is compared against for the active-view highlight. */
+  currentQs: string;
+  /**
+   * Round-trip a saved view's `qs` through this tab's own filter codec
+   * (read then write) so the "is this view currently active" check matches
+   * regardless of param order/encoding differences between how a view's
+   * `qs` was authored and what `writeXFiltersToUrl` itself emits — same
+   * reasoning as `CasesFilterBar`'s own `canonicalQs`.
+   */
+  canonicalizeQs: (qs: string) => string;
+  /** Active (non-search) filter count, shown in the save dialog's helper text. */
+  activeCount: number;
+  /** Apply a saved view's `qs` — the caller parses it back into its own
+   * filter shape and feeds it through the same `onChange` the filter bar
+   * already has. */
+  onApply: (qs: string) => void;
+  /** The tab-scoped saved-views store (its own `localStorage` key) — see
+   * `changeRequestsSavedViews.ts` / `incidentsSavedViews.ts` /
+   * `problemsSavedViews.ts`. */
+  store: SavedFilterViewsStore;
+}
+
+/**
+ * "Saved views" button + menu shared by the Change Requests, Incidents, and
+ * Problems filter bars — a named, reusable filter set for high-volume
+ * triage, same UI shape as the Cases list's own saved-views block
+ * (`CasesFilterBar.tsx`, search for "Saved views") for consistency. Each
+ * caller supplies its own tab-scoped `store` so views never leak across
+ * tabs (or into/out of the separate Cases list feature, which keeps its own
+ * inline implementation untouched).
+ */
+export default function SavedViewsMenu({
+  currentQs,
+  canonicalizeQs,
+  activeCount,
+  onApply,
+  store,
+}: SavedViewsMenuProps): JSX.Element {
+  const savedViews = store.useSavedFilterViews();
+  const currentCanonical = canonicalizeQs(currentQs);
+  const isActiveView = (qs: string): boolean => canonicalizeQs(qs) === currentCanonical;
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [newViewName, setNewViewName] = useState("");
+
+  const applyView = (qs: string): void => {
+    setAnchor(null);
+    onApply(qs);
+  };
+
+  const handleSaveView = (): void => {
+    if (!newViewName.trim()) return;
+    store.saveFilterView(newViewName, currentQs);
+    setNewViewName("");
+    setSaveDialogOpen(false);
+    setAnchor(null);
+  };
+
+  return (
+    <>
+      <Button
+        variant="outlined"
+        size="small"
+        color="inherit"
+        onClick={(e) => setAnchor(e.currentTarget)}
+        startIcon={<Bookmark size={16} />}
+        endIcon={<ChevronDown size={16} />}
+        aria-haspopup="true"
+        aria-expanded={Boolean(anchor)}
+      >
+        Saved views
+      </Button>
+      <Menu
+        anchorEl={anchor}
+        open={Boolean(anchor)}
+        onClose={() => setAnchor(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      >
+        <MenuItem
+          onClick={() => {
+            setAnchor(null);
+            setSaveDialogOpen(true);
+          }}
+        >
+          <ListItemIcon>
+            <BookmarkPlus size={16} />
+          </ListItemIcon>
+          <ListItemText primary="Save current view…" />
+        </MenuItem>
+        <Divider />
+        <ListSubheader sx={{ lineHeight: "32px" }}>Saved</ListSubheader>
+        {savedViews.length === 0 ? (
+          <MenuItem disabled>
+            <ListItemText
+              primary="No saved views yet"
+              slotProps={{ primary: { variant: "body2" } }}
+            />
+          </MenuItem>
+        ) : (
+          savedViews.map((v, i) => (
+            <MenuItem
+              key={`saved-${v.name}`}
+              selected={isActiveView(v.qs)}
+              onClick={() => applyView(v.qs)}
+            >
+              <ListItemIcon>{isActiveView(v.qs) ? <Check size={16} /> : null}</ListItemIcon>
+              <ListItemText primary={v.name} />
+              <IconButton
+                size="small"
+                edge="end"
+                aria-label={`Move saved view ${v.name} up`}
+                disabled={i === 0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  store.moveFilterView(v.name, "up");
+                }}
+                sx={{ ml: 1 }}
+              >
+                <ChevronUp size={15} />
+              </IconButton>
+              <IconButton
+                size="small"
+                edge="end"
+                aria-label={`Move saved view ${v.name} down`}
+                disabled={i === savedViews.length - 1}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  store.moveFilterView(v.name, "down");
+                }}
+              >
+                <ChevronDown size={15} />
+              </IconButton>
+              <IconButton
+                size="small"
+                edge="end"
+                aria-label={`Delete saved view ${v.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  store.deleteFilterView(v.name);
+                }}
+              >
+                <Trash2 size={15} />
+              </IconButton>
+            </MenuItem>
+          ))
+        )}
+      </Menu>
+
+      <Dialog
+        open={saveDialogOpen}
+        onClose={() => setSaveDialogOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Save current view</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            margin="dense"
+            label="View name"
+            placeholder="e.g. My open records"
+            value={newViewName}
+            onChange={(e) => setNewViewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleSaveView();
+              }
+            }}
+            helperText={
+              activeCount === 0
+                ? "Tip: no filters are active — this view will show all records."
+                : `Captures the ${activeCount} active filter${activeCount === 1 ? "" : "s"}.`
+            }
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button color="inherit" onClick={() => setSaveDialogOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="contained" onClick={handleSaveView} disabled={!newViewName.trim()}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestsSavedViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestsSavedViews.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { createSavedFilterViewsStore } from "@features/csm-operations/utils/savedFilterViews";
+
+/** Saved views for the Change Requests tab, on their own `localStorage` key —
+ * independent of the Cases list's and the other Operations sub-tabs' own
+ * saved views. */
+export const changeRequestsSavedViews = createSavedFilterViewsStore(
+  "csm.savedFilters.changeRequests.v1",
+);

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentsSavedViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentsSavedViews.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { createSavedFilterViewsStore } from "@features/csm-operations/utils/savedFilterViews";
+
+/** Saved views for the Incidents tab, on their own `localStorage` key —
+ * independent of the Cases list's and the other Operations sub-tabs' own
+ * saved views. */
+export const incidentsSavedViews = createSavedFilterViewsStore(
+  "csm.savedFilters.incidents.v1",
+);

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/problemsFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/problemsFiltersUrl.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { DEFAULT_PROBLEM_FILTERS } from "@features/csm-operations/utils/problems";
+import {
+  readProblemFiltersFromUrl,
+  writeProblemFiltersToUrl,
+} from "./problemsFiltersUrl";
+
+describe("readProblemFiltersFromUrl", () => {
+  it("returns the defaults for an empty query string", () => {
+    expect(readProblemFiltersFromUrl(new URLSearchParams())).toEqual(
+      DEFAULT_PROBLEM_FILTERS,
+    );
+  });
+
+  it("parses a fully-populated query string", () => {
+    const params = new URLSearchParams(
+      "probQ=timeout&probStates=NEW,ASSESS&probSreTeams=team-apollo,team-atlas",
+    );
+    expect(readProblemFiltersFromUrl(params)).toEqual({
+      search: "timeout",
+      states: ["NEW", "ASSESS"],
+      sreTeamIds: ["team-apollo", "team-atlas"],
+    });
+  });
+
+  it("drops values outside the allowed state enum", () => {
+    const params = new URLSearchParams("probStates=NEW,BOGUS");
+    expect(readProblemFiltersFromUrl(params).states).toEqual(["NEW"]);
+  });
+
+  it("drops blank/whitespace SRE team entries", () => {
+    const params = new URLSearchParams("probSreTeams=team-apollo,%20%20,,team-atlas");
+    expect(readProblemFiltersFromUrl(params).sreTeamIds).toEqual([
+      "team-apollo",
+      "team-atlas",
+    ]);
+  });
+
+  it("does not read the incidents tab's own `inc...` params", () => {
+    const params = new URLSearchParams("incQ=foo&incPriorities=HIGH");
+    expect(readProblemFiltersFromUrl(params)).toEqual(DEFAULT_PROBLEM_FILTERS);
+  });
+});
+
+describe("writeProblemFiltersToUrl", () => {
+  it("omits default-valued fields to keep the URL clean", () => {
+    expect(writeProblemFiltersToUrl(DEFAULT_PROBLEM_FILTERS).toString()).toBe("");
+  });
+
+  it("round-trips a fully-populated filter set", () => {
+    const filters: typeof DEFAULT_PROBLEM_FILTERS = {
+      search: "timeout",
+      states: ["NEW", "ASSESS"],
+      sreTeamIds: ["team-apollo", "team-atlas"],
+    };
+    const round = readProblemFiltersFromUrl(writeProblemFiltersToUrl(filters));
+    expect(round).toEqual(filters);
+  });
+
+  it("omits probSreTeams when no SRE team is selected", () => {
+    const params = writeProblemFiltersToUrl({
+      ...DEFAULT_PROBLEM_FILTERS,
+      sreTeamIds: [],
+    });
+    expect(params.has("probSreTeams")).toBe(false);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/problemsFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/problemsFiltersUrl.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { PROBLEM_STATES, type ProblemFilters } from "@features/csm-operations/utils/problems";
+
+// URL params owned by the problem filter state. Prefixed (`prob...`) so they
+// can't collide with the same-named params the shared cases view and the
+// change-requests/incidents tabs keep in the same `?tab=`-switched URL.
+export const PROBLEM_FILTER_PARAM_KEYS = ["probQ", "probStates", "probSreTeams"] as const;
+
+/**
+ * Parse a comma-separated URL param into a list restricted to `allowed`. An
+ * unrecognised entry is dropped rather than passed through, so a hand-edited or
+ * stale query string can never send the backend a value outside the enum. The
+ * type predicate is what narrows the result to `T[]` for the caller. Mirrors
+ * `changeRequestsFiltersUrl.ts`/`incidentsFiltersUrl.ts`'s own `parseCsv`.
+ */
+function parseCsv<T extends string>(raw: string | null, allowed: T[]): T[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is T => (allowed as string[]).includes(s));
+}
+
+/**
+ * Comma-separated SRE team ids (`sreGroupId` UUIDs) — not a fixed enum,
+ * blank entries dropped. Mirrors `parseTeamIdsCsv` in
+ * `incidentsFiltersUrl.ts`/`changeRequestsFiltersUrl.ts`.
+ */
+function parseTeamIdsCsv(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Read problem filters from the URL. Unknown/malformed values (a
+ * hand-edited or stale query string) are dropped rather than passed through,
+ * so they fall back to the default (unfiltered) behaviour instead of being
+ * silently sent to the backend.
+ */
+export function readProblemFiltersFromUrl(params: URLSearchParams): ProblemFilters {
+  return {
+    search: params.get("probQ") ?? "",
+    states: parseCsv(params.get("probStates"), PROBLEM_STATES),
+    sreTeamIds: parseTeamIdsCsv(params.get("probSreTeams")),
+  };
+}
+
+/**
+ * Build the search-params representing these filters. Default values are
+ * omitted so the URL stays clean.
+ */
+export function writeProblemFiltersToUrl(f: ProblemFilters): URLSearchParams {
+  const out = new URLSearchParams();
+  if (f.search) out.set("probQ", f.search);
+  if (f.states.length) out.set("probStates", f.states.join(","));
+  if (f.sreTeamIds.length) out.set("probSreTeams", f.sreTeamIds.join(","));
+  return out;
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/problemsSavedViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/problemsSavedViews.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { createSavedFilterViewsStore } from "@features/csm-operations/utils/savedFilterViews";
+
+/** Saved views for the Problem management tab, on their own `localStorage`
+ * key — independent of the Cases list's and the other Operations sub-tabs'
+ * own saved views. */
+export const problemsSavedViews = createSavedFilterViewsStore(
+  "csm.savedFilters.problems.v1",
+);

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/savedFilterViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/savedFilterViews.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState } from "react";
+
+/**
+ * Named, reusable filter set for an Operations sub-tab (Change Requests,
+ * Incidents, Problems). Same shape as the Cases list's own
+ * `SavedFilterView` (`csm-cases/utils/savedFilterViews.ts`) — a saved view is
+ * just a label pointing at that tab's own serialized query string, so the
+ * URL stays the single source of truth and no second filter format is
+ * invented.
+ */
+export interface SavedFilterView {
+  name: string;
+  /** Serialized filters: the tab's own query string (no leading `?`). */
+  qs: string;
+}
+
+/** The reactive-hook + mutator surface a saved-views-backed `localStorage`
+ * key exposes — one instance per Operations sub-tab, each on its own key
+ * (see `changeRequestsSavedViews.ts` / `incidentsSavedViews.ts` /
+ * `problemsSavedViews.ts`), so views never leak across tabs. */
+export interface SavedFilterViewsStore {
+  /** Reactive list of the user's saved views for this tab (updates across
+   * components + browser tabs). */
+  useSavedFilterViews: () => SavedFilterView[];
+  /**
+   * Save (or overwrite by name) a view. Most-recently-saved first. No-op for
+   * an empty name. Returns the trimmed name actually stored.
+   */
+  saveFilterView: (name: string, qs: string) => string;
+  /** Delete a saved view by name (case-insensitive). */
+  deleteFilterView: (name: string) => void;
+  /**
+   * Move a saved view one position up or down in display order (array index
+   * order IS display order — no separate "position" field). A no-op if the
+   * view isn't found, or is already at the boundary in that direction.
+   */
+  moveFilterView: (name: string, direction: "up" | "down") => void;
+}
+
+const MAX_VIEWS = 50;
+
+/**
+ * Build an independent, `localStorage`-backed saved-views store scoped to
+ * `storageKey`. One call site per Operations sub-tab — each gets its own key
+ * and its own "Saved views" menu, mirroring the Cases list's
+ * `savedFilterViews.ts` (which this deliberately does not touch: that file
+ * keeps working exactly as today, on its own `csm.savedFilters.v1` key).
+ */
+export function createSavedFilterViewsStore(storageKey: string): SavedFilterViewsStore {
+  const storageEvent = `csm:saved-filters-changed:${storageKey}`;
+
+  function readStorage(): SavedFilterView[] {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return [];
+      const parsed: unknown = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter(
+        (v): v is SavedFilterView =>
+          typeof v === "object" &&
+          v !== null &&
+          typeof (v as SavedFilterView).name === "string" &&
+          typeof (v as SavedFilterView).qs === "string",
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  function writeStorage(views: SavedFilterView[]): void {
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(views.slice(0, MAX_VIEWS)));
+      // In-tab listeners (the storage event only fires cross-tab).
+      window.dispatchEvent(new CustomEvent(storageEvent));
+    } catch {
+      // ignore quota / serialization errors
+    }
+  }
+
+  function useSavedFilterViews(): SavedFilterView[] {
+    const [views, setViews] = useState<SavedFilterView[]>(() => readStorage());
+    useEffect(() => {
+      const sync = () => setViews(readStorage());
+      window.addEventListener(storageEvent, sync);
+      window.addEventListener("storage", sync);
+      return () => {
+        window.removeEventListener(storageEvent, sync);
+        window.removeEventListener("storage", sync);
+      };
+    }, []);
+    return views;
+  }
+
+  function saveFilterView(name: string, qs: string): string {
+    const trimmed = name.trim();
+    if (!trimmed) return "";
+    const current = readStorage().filter(
+      (v) => v.name.toLowerCase() !== trimmed.toLowerCase(),
+    );
+    writeStorage([{ name: trimmed, qs }, ...current]);
+    return trimmed;
+  }
+
+  function deleteFilterView(name: string): void {
+    writeStorage(
+      readStorage().filter((v) => v.name.toLowerCase() !== name.trim().toLowerCase()),
+    );
+  }
+
+  function moveFilterView(name: string, direction: "up" | "down"): void {
+    const current = readStorage();
+    const index = current.findIndex(
+      (v) => v.name.toLowerCase() === name.trim().toLowerCase(),
+    );
+    if (index === -1) return;
+    const target = direction === "up" ? index - 1 : index + 1;
+    if (target < 0 || target >= current.length) return;
+    const reordered = [...current];
+    [reordered[index], reordered[target]] = [reordered[target], reordered[index]];
+    writeStorage(reordered);
+  }
+
+  return { useSavedFilterViews, saveFilterView, deleteFilterView, moveFilterView };
+}

--- a/apps/csm-portal/webapp/src/features/help/content/operations.md
+++ b/apps/csm-portal/webapp/src/features/help/content/operations.md
@@ -24,6 +24,12 @@ The Change requests tab lists change requests with server-side search,
 pagination, and filters for state, impact, and closed-date range, plus a
 CSV export of the filtered results. Each row links to a detail page.
 
+**Saved views**: save the current search/filter combination under a name for
+one-click reuse later, from the same "Saved views" button as the Support
+section's case list. Saved views here are scoped to this tab only (they
+don't show up on Incidents, Problem management, or the case list, and vice
+versa) and stay on this device/browser.
+
 The detail page shows:
 
 - An **overview** card: project, type, linked case, deployment, deployed
@@ -61,6 +67,10 @@ From the detail page a CS engineer can:
 The Incidents tab lists incidents with server-side search, pagination, and
 filters for priority, SLA-violated status, created-date range, and product,
 plus a CSV export of the filtered results. Each row links to a detail page.
+
+Like Change requests, this tab has its own **Saved views** button for
+naming and reapplying a filter combination — scoped to this tab, on this
+device/browser.
 
 The detail page shows:
 
@@ -100,6 +110,10 @@ instead of an error.
 The Problem management tab lists problems with server-side search,
 pagination, free-text search, and a state filter. Each row links to a
 detail page.
+
+Like Change requests and Incidents, this tab has its own **Saved views**
+button for naming and reapplying a filter combination — scoped to this tab,
+on this device/browser.
 
 The detail page shows an overview (priority, category, subcategory, assigned
 to, opened/closed dates), any linked records (origin record, primary


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The Operations page's Change Requests, Incidents, and Problems tabs had no way to save a filter combination for reuse — engineers re-picked the same filters every visit. The Cases page already solved this with a "Saved views" feature; these three tabs didn't have it.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Add the same save/apply/delete/reorder "Saved views" capability to Change Requests, Incidents, and Problems, each with its own independent, localStorage-backed list of named filter sets.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- Extracted the Cases page's saved-view storage logic into a generic `createSavedFilterViewsStore(storageKey)` factory, then created three thin per-tab stores (`changeRequestsSavedViews.ts`, `incidentsSavedViews.ts`, `problemsSavedViews.ts`) on distinct localStorage keys — no cross-tab sharing, matching how Cases already scopes its own store.
- A new shared `SavedViewsMenu.tsx` component replicates the Cases page's Saved-views button/menu/save-dialog UI and is wired into `ChangeRequestsFilterBar`, `IncidentsFilterBar`, and `ProblemsFilterBar`.
- Problems had no URL-synced filter state before this change (Change Requests and Incidents already did). Added `problemsFiltersUrl.ts` and moved `ProblemsTab` to `useSearchParams`, matching the existing Incidents pattern, so saved views (and shareable/bookmarkable filter URLs) work the same way across all three tabs.
- The Cases page's own Saved-views implementation is untouched.
- Service Requests already gets this feature via the shared Cases view and needed no change.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, I can save my current Change Request / Incident / Problem filter combination under a name, and re-apply it later without re-entering each filter by hand.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Added "Saved views" (save, apply, reorder, delete named filter sets) to the Operations page's Change Requests, Incidents, and Problems tabs.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

Updated the in-app `/help` topic (`features/help/content/operations.md`) with a short "Saved views" note under each of the three tabs.

## Training
N/A — no training content for this repo.

## Certification
N/A — no impact on certification exams.

## Marketing
N/A — internal CS engineer tooling, not customer-facing.

## Automation tests
 - Unit tests
   > New colocated tests: `SavedViewsMenu.test.tsx` (save/apply/delete/reorder/active-view highlighting), `problemsFiltersUrl.test.ts` (URL codec round-trip), `ProblemsTab.test.tsx` (URL-synced filter state). Full `csm-operations` suite re-run: 38 files / 412 tests passing.
 - Integration tests
   > None added; no backend/API surface changed.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, no Java code
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — client-side localStorage only, no server-side data migration.

## Test environment
Verified with `pnpm run lint`, `pnpm run build` (`tsc -b && vite build`), and `npx vitest run` in `apps/csm-portal/webapp`, on this branch, all passing.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Saved views to Change Requests, Incidents, and Problems.
  * Save, apply, rename, reorder, and delete filter views for quick reuse.
  * Filter selections persist in the URL and can be restored when sharing or revisiting pages.
  * Saved views remain separate for each Operations tab and persist in the current browser.

* **Documentation**
  * Added help content explaining Saved views and tab-specific storage.

* **Bug Fixes**
  * Improved handling of invalid or incomplete filter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->