### PR TITLE
[Customer Portal] Restrict case creation and access for suspended and contract-expired projects

### DIFF
--- a/apps/customer-portal/backend-v2/internal/handler/cases.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
@@ -31,6 +33,7 @@ import (
 type entityCaseClient interface {
 	SearchCases(ctx context.Context, req entity.SearchCasesRequest) (entity.SearchCasesResponse, error)
 	GetCase(ctx context.Context, id string) (entity.CaseView, error)
+	GetProject(ctx context.Context, id string) (entity.ProjectDetailsView, error)
 	CreateCase(ctx context.Context, req entity.CreateCaseRequest) (entity.CreateCaseResponse, error)
 	UpdateConversation(ctx context.Context, id string, req entity.UpdateConversationRequest) (entity.UpdateConversationResponse, error)
 	UpdateCase(ctx context.Context, id string, req entity.UpdateCaseRequest) (entity.UpdateCaseResponse, error)
@@ -200,6 +203,25 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
+
+	if req.ProjectID == "" || !uuidRe.MatchString(req.ProjectID) {
+		writeError(w, http.StatusBadRequest, "Project ID is required and must be a valid UUID.")
+		return
+	}
+
+	project, err := h.entity.GetProject(r.Context(), req.ProjectID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProject failed during CreateCase", "userID", user.UserID, "projectID", req.ProjectID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve project details.")
+		return
+	}
+
+	if isProjectSuspendedOrExpired(project) {
+		slog.WarnContext(r.Context(), "attempted to create case for suspended or expired project", "userID", user.UserID, "projectID", req.ProjectID)
+		writeError(w, http.StatusForbidden, "Cannot create cases for a suspended or contract-expired project.")
+		return
+	}
+
 	entityReq := dto.BuildEntityCreateCaseRequest(req)
 	// CreatedBy is server-set from the authenticated caller, never from the
 	// request body (the struct's json:"-" tag means a client-supplied value
@@ -527,3 +549,17 @@ func (h *CaseHandler) SearchCaseEscalations(w http.ResponseWriter, r *http.Reque
 
 	writeJSONValue(w, http.StatusOK, dto.MapEscalationSearchResponse(result))
 }
+
+// isProjectSuspendedOrExpired checks if a project is suspended or its contract has ended.
+func isProjectSuspendedOrExpired(project entity.ProjectDetailsView) bool {
+	if project.ClosureState != nil && strings.EqualFold(strings.TrimSpace(*project.ClosureState), "suspended") {
+		return true
+	}
+	if !project.EndDate.IsZero() {
+		todayUTC := time.Now().UTC().Format("2006-01-02")
+		endDateUTC := project.EndDate.UTC().Format("2006-01-02")
+		return todayUTC > endDateUTC
+	}
+	return false
+}
+

--- a/apps/customer-portal/backend-v2/internal/handler/cases_create_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases_create_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+type mockCreateCaseClient struct {
+	entityCaseClient
+	project       entity.ProjectDetailsView
+	getProjectErr error
+	createdCase   entity.CreateCaseResponse
+	createCaseErr error
+}
+
+func (m *mockCreateCaseClient) GetProject(ctx context.Context, id string) (entity.ProjectDetailsView, error) {
+	if m.getProjectErr != nil {
+		return entity.ProjectDetailsView{}, m.getProjectErr
+	}
+	return m.project, nil
+}
+
+func (m *mockCreateCaseClient) CreateCase(ctx context.Context, req entity.CreateCaseRequest) (entity.CreateCaseResponse, error) {
+	if m.createCaseErr != nil {
+		return entity.CreateCaseResponse{}, m.createCaseErr
+	}
+	return m.createdCase, nil
+}
+
+func TestCreateCase_SuspendedProject_Forbidden(t *testing.T) {
+	suspended := "Suspended"
+	mock := &mockCreateCaseClient{
+		project: entity.ProjectDetailsView{
+			ID: "11111111-1111-1111-1111-111111111111",
+			ProjectClosureFields: entity.ProjectClosureFields{
+				ClosureState: &suspended,
+			},
+		},
+	}
+	h := NewCaseHandler(mock)
+
+	reqBody := `{"projectId":"11111111-1111-1111-1111-111111111111","title":"Test Case","description":"Details"}`
+	req := authedRequest(http.MethodPost, "/cases", reqBody)
+	rec := httptest.NewRecorder()
+
+	h.CreateCase(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 Forbidden, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateCase_ExpiredProject_Forbidden(t *testing.T) {
+	pastDate := time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC)
+	mock := &mockCreateCaseClient{
+		project: entity.ProjectDetailsView{
+			ID:      "11111111-1111-1111-1111-111111111111",
+			EndDate: pastDate,
+		},
+	}
+	h := NewCaseHandler(mock)
+
+	reqBody := `{"projectId":"11111111-1111-1111-1111-111111111111","title":"Test Case","description":"Details"}`
+	req := authedRequest(http.MethodPost, "/cases", reqBody)
+	rec := httptest.NewRecorder()
+
+	h.CreateCase(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 Forbidden, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateCase_ActiveProject_Success(t *testing.T) {
+	futureDate := time.Date(2099, 12, 31, 0, 0, 0, 0, time.UTC)
+	mock := &mockCreateCaseClient{
+		project: entity.ProjectDetailsView{
+			ID:      "11111111-1111-1111-1111-111111111111",
+			EndDate: futureDate,
+		},
+		createdCase: entity.CreateCaseResponse{
+			Case: entity.CreateCaseDetails{
+				ID:     "22222222-2222-2222-2222-222222222222",
+				Number: "CS12345",
+			},
+		},
+	}
+	h := NewCaseHandler(mock)
+
+	reqBody := `{"projectId":"11111111-1111-1111-1111-111111111111","title":"Test Case","description":"Details"}`
+	req := authedRequest(http.MethodPost, "/cases", reqBody)
+	rec := httptest.NewRecorder()
+
+	h.CreateCase(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 Created, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateCase_InvalidProjectID_BadRequest(t *testing.T) {
+	mock := &mockCreateCaseClient{}
+	h := NewCaseHandler(mock)
+
+	reqBody := `{"projectId":"not-a-valid-uuid","title":"Test Case","description":"Details"}`
+	req := authedRequest(http.MethodPost, "/cases", reqBody)
+	rec := httptest.NewRecorder()
+
+	h.CreateCase(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 Bad Request, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -1277,6 +1277,53 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             };
         }
 
+        entity:ProjectResponse|error projectResponse = entity:getProject(userInfo.idToken, payload.projectId);
+        if projectResponse is error {
+            if getStatusCode(projectResponse) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if getStatusCode(projectResponse) == http:STATUS_FORBIDDEN {
+                logForbiddenProjectAccess(payload.projectId, userInfo.userId);
+                return <http:Forbidden>{
+                    body: {
+                        message: "You're not authorized to create a case for the selected project. " +
+                        "Please check your access permissions or contact support."
+                    }
+                };
+            }
+            if getStatusCode(projectResponse) == http:STATUS_NOT_FOUND {
+                log:printWarn(string `Project with ID: ${payload.projectId} not found for user: ${userInfo.userId}`);
+                return <http:BadRequest>{
+                    body: {
+                        message: "The requested project does not exist or you don't have access to it."
+                    }
+                };
+            }
+
+            string customError = "Failed to retrieve project details.";
+            log:printError(customError, projectResponse);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        if isProjectSuspendedOrExpired(projectResponse.closureState, projectResponse.endDate) {
+            log:printWarn(string `User: ${userInfo.userId} attempted to create a case for suspended/expired project: ${
+                    payload.projectId}!`);
+            return <http:Forbidden>{
+                body: {
+                    message: "Cannot create cases for a suspended or contract-expired project."
+                }
+            };
+        }
+
         entity:CaseCreateResponse|error createdCaseResponse = entity:createCase(userInfo.idToken, payload);
         if createdCaseResponse is error {
             if getStatusCode(createdCaseResponse) == http:STATUS_UNAUTHORIZED {

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1499,6 +1499,20 @@ public isolated function isProjectContractEnded(string? endDate) returns boolean
         return false;
     }
     string endDatePart = trimmed.substring(0, 10);
+    string[] parts = re `-`.split(endDatePart);
+    if parts.length() != 3 {
+        return false;
+    }
+    int|error year = int:fromString(parts[0]);
+    int|error month = int:fromString(parts[1]);
+    int|error day = int:fromString(parts[2]);
+    if year is error || month is error || day is error {
+        return false;
+    }
+    time:Error? validationErr = time:dateValidate({year, month, day});
+    if validationErr is time:Error {
+        return false;
+    }
     // End date is considered inclusive through the end of the specified day (UTC).
     // The contract has ended if current UTC date is strictly greater than the end date.
     string currentDatePart = time:utcToString(time:utcNow()).substring(0, 10);

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -18,6 +18,7 @@ import customer_portal.types;
 
 import ballerina/http;
 import ballerina/log;
+import ballerina/time;
 
 configurable int stateIdOpen = 1;
 configurable types:FeatureFlags featureFlags = {
@@ -1484,3 +1485,35 @@ public isolated function mapDeployedProductMetricsUsageCounts(
         chartData
     };
 }
+
+# Check if the project contract has ended based on its end date.
+#
+# + endDate - End date of the project (YYYY-MM-DD or ISO string)
+# + return - True if the contract end date has passed, false otherwise
+public isolated function isProjectContractEnded(string? endDate) returns boolean {
+    if endDate is () {
+        return false;
+    }
+    string trimmed = endDate.trim();
+    if trimmed.length() < 10 {
+        return false;
+    }
+    string endDatePart = trimmed.substring(0, 10);
+    // End date is considered inclusive through the end of the specified day (UTC).
+    // The contract has ended if current UTC date is strictly greater than the end date.
+    string currentDatePart = time:utcToString(time:utcNow()).substring(0, 10);
+    return currentDatePart > endDatePart;
+}
+
+# Check if the project is suspended or its contract has ended.
+#
+# + closureState - Closure state of the project
+# + endDate - End date of the project
+# + return - True if the project is suspended or expired, false otherwise
+public isolated function isProjectSuspendedOrExpired(string? closureState, string? endDate) returns boolean {
+    if closureState is string && closureState.trim().toLowerAscii() == "suspended" {
+        return true;
+    }
+    return isProjectContractEnded(endDate);
+}
+

--- a/apps/customer-portal/webapp/src/components/header/GetHelpDropdown.tsx
+++ b/apps/customer-portal/webapp/src/components/header/GetHelpDropdown.tsx
@@ -38,7 +38,11 @@ import { useNavigate, useParams } from "react-router";
 import useInfiniteProjects, { flattenProjectPages } from "@api/useGetProjects";
 import useGetProjectFeatures from "@api/useGetProjectFeatures";
 import useGetProjectDetails from "@api/useGetProjectDetails";
-import { getProjectPermissions, isProjectRestricted } from "@utils/permission";
+import {
+  getProjectPermissions,
+  isProjectRestricted,
+  isProjectSuspended,
+} from "@utils/permission";
 
 interface GetHelpMenuItem {
   id: string;
@@ -328,7 +332,8 @@ export default function GetHelpDropdown(): JSX.Element {
     (!!projectId && isProjectDetailsLoading);
   if (
     !isProjectsListBusy &&
-    isProjectRestricted(projectDetails?.closureState)
+    (isProjectRestricted(projectDetails?.closureState) ||
+      isProjectSuspended(projectDetails?.closureState, projectDetails?.endDate))
   ) {
     return <></>;
   }

--- a/apps/customer-portal/webapp/src/components/header/__tests__/GetHelpDropdown.test.tsx
+++ b/apps/customer-portal/webapp/src/components/header/__tests__/GetHelpDropdown.test.tsx
@@ -43,9 +43,13 @@ vi.mock("@api/useGetProjectFeatures", () => ({
   default: () => ({ data: {}, isLoading: false }),
 }));
 
+const mockIsProjectRestricted = vi.fn(() => false);
+const mockIsProjectSuspended = vi.fn(() => false);
+
 vi.mock("@utils/permission", () => ({
   getProjectPermissions: () => ({ hasSR: true, hasSraWriteAccess: true }),
-  isProjectRestricted: () => false,
+  isProjectRestricted: () => mockIsProjectRestricted(),
+  isProjectSuspended: () => mockIsProjectSuspended(),
 }));
 
 vi.mock("@wso2/oxygen-ui-icons-react", async (importOriginal) => {
@@ -56,6 +60,9 @@ vi.mock("@wso2/oxygen-ui-icons-react", async (importOriginal) => {
 
 describe("GetHelpDropdown", () => {
   it("should render an accessible Get Help control with responsive label", () => {
+    mockIsProjectRestricted.mockReturnValue(false);
+    mockIsProjectSuspended.mockReturnValue(false);
+
     render(<GetHelpDropdown />);
 
     expect(screen.getByRole("button", { name: "Get Help" })).toBeInTheDocument();
@@ -63,5 +70,21 @@ describe("GetHelpDropdown", () => {
     expect(
       screen.getByRole("button", { name: "More help options" }),
     ).toBeInTheDocument();
+  });
+
+  it("should not render when the project is restricted", () => {
+    mockIsProjectRestricted.mockReturnValue(true);
+    mockIsProjectSuspended.mockReturnValue(false);
+
+    const { container } = render(<GetHelpDropdown />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should not render when the project is suspended or expired", () => {
+    mockIsProjectRestricted.mockReturnValue(false);
+    mockIsProjectSuspended.mockReturnValue(true);
+
+    const { container } = render(<GetHelpDropdown />);
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/apps/customer-portal/webapp/src/layouts/ProjectGuard.tsx
+++ b/apps/customer-portal/webapp/src/layouts/ProjectGuard.tsx
@@ -21,15 +21,15 @@ import useGetProjectDetails from "@api/useGetProjectDetails";
 import ApiErrorState from "@components/error/ApiErrorState";
 import ProjectSuspendedNoticePage from "@/components/access-control/ProjectSuspendedNoticePage";
 import { useErrorPageContext } from "@context/error-page/ErrorPageContext";
-import { ProjectClosureState } from "@/types/permission";
+import { isProjectSuspended } from "@utils/permission";
 
 /**
  * ProjectGuard wraps all routes under `projects/:projectId`.
  *
  * It fetches project details once at the layout boundary. If the API
  * returns an error (400, 401, 403, 404, 5xx, etc.) the guard renders
- * {@link ApiErrorState} instead of the child route. If the project has
- * closureState "Suspended" it renders the Project Suspension Notice.
+ * {@link ApiErrorState} instead of the child route. If the project is
+ * suspended or its contract has ended, it renders the Project Suspension Notice.
  *
  * @returns {JSX.Element} The child outlet or an error/suspension page.
  */
@@ -41,18 +41,18 @@ function ProjectGuardContent(): JSX.Element {
   const { data, error, isLoading } = useGetProjectDetails(projectId ?? "");
 
   const hasError = !isLoading && Boolean(error);
-  const isProjectSuspended =
-    !isLoading && data?.closureState === ProjectClosureState.SUSPENDED;
+  const isSuspended =
+    !isLoading && isProjectSuspended(data?.closureState, data?.endDate);
 
-  const isErrorPageDisplayed = hasError || isProjectSuspended;
+  const isErrorPageDisplayed = hasError || isSuspended;
 
   useEffect(() => {
     setIsErrorPageDisplayed(isErrorPageDisplayed);
   }, [isErrorPageDisplayed, setIsErrorPageDisplayed]);
 
   useEffect(() => {
-    setIsProjectSuspended(isProjectSuspended);
-  }, [isProjectSuspended, setIsProjectSuspended]);
+    setIsProjectSuspended(isSuspended);
+  }, [isSuspended, setIsProjectSuspended]);
 
   if (isLoading) {
     return (
@@ -80,7 +80,7 @@ function ProjectGuardContent(): JSX.Element {
     );
   }
 
-  if (isProjectSuspended) {
+  if (isSuspended) {
     return <ProjectSuspendedNoticePage project={data!} />;
   }
 

--- a/apps/customer-portal/webapp/src/layouts/__tests__/ProjectGuard.test.tsx
+++ b/apps/customer-portal/webapp/src/layouts/__tests__/ProjectGuard.test.tsx
@@ -20,12 +20,10 @@ import { describe, expect, it, vi } from "vitest";
 import ProjectGuard from "@layouts/ProjectGuard";
 import { ErrorPageProvider } from "@context/error-page/ErrorPageContext";
 
+const mockUseGetProjectDetails = vi.fn();
+
 vi.mock("@api/useGetProjectDetails", () => ({
-  default: () => ({
-    data: { id: "proj", closureState: "Active" },
-    error: null,
-    isLoading: false,
-  }),
+  default: () => mockUseGetProjectDetails(),
 }));
 
 vi.mock("react-router", async (importOriginal) => {
@@ -37,7 +35,102 @@ vi.mock("react-router", async (importOriginal) => {
 });
 
 describe("ProjectGuard", () => {
-  it("renders outlet when project loads successfully", () => {
+  it("renders outlet when project loads successfully and is active", () => {
+    mockUseGetProjectDetails.mockReturnValue({
+      data: { id: "proj", name: "Project", closureState: "Active" },
+      error: null,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/projects/proj/dashboard"]}>
+        <ErrorPageProvider>
+          <Routes>
+            <Route path="/projects/:projectId/*" element={<ProjectGuard />} />
+          </Routes>
+        </ErrorPageProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("outlet")).toBeInTheDocument();
+  });
+
+  it("renders ProjectSuspendedNoticePage when closureState is Suspended", () => {
+    mockUseGetProjectDetails.mockReturnValue({
+      data: { id: "proj", name: "Project", closureState: "Suspended" },
+      error: null,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/projects/proj/dashboard"]}>
+        <ErrorPageProvider>
+          <Routes>
+            <Route path="/projects/:projectId/*" element={<ProjectGuard />} />
+          </Routes>
+        </ErrorPageProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId("outlet")).not.toBeInTheDocument();
+    expect(screen.getByText(/Project Suspension Notice/i)).toBeInTheDocument();
+  });
+
+  it("renders ProjectSuspendedNoticePage when closureState is lowercase suspended", () => {
+    mockUseGetProjectDetails.mockReturnValue({
+      data: { id: "proj", name: "Project", closureState: "suspended" },
+      error: null,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/projects/proj/dashboard"]}>
+        <ErrorPageProvider>
+          <Routes>
+            <Route path="/projects/:projectId/*" element={<ProjectGuard />} />
+          </Routes>
+        </ErrorPageProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId("outlet")).not.toBeInTheDocument();
+    expect(screen.getByText(/Project Suspension Notice/i)).toBeInTheDocument();
+  });
+
+  it("renders ProjectSuspendedNoticePage when project contract has ended (past endDate)", () => {
+    mockUseGetProjectDetails.mockReturnValue({
+      data: {
+        id: "proj",
+        name: "MC test",
+        closureState: "Open",
+        endDate: "2026-04-26",
+      },
+      error: null,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/projects/proj/dashboard"]}>
+        <ErrorPageProvider>
+          <Routes>
+            <Route path="/projects/:projectId/*" element={<ProjectGuard />} />
+          </Routes>
+        </ErrorPageProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId("outlet")).not.toBeInTheDocument();
+    expect(screen.getByText(/Project Suspension Notice/i)).toBeInTheDocument();
+  });
+
+  it("renders outlet when endDate is in the future", () => {
+    mockUseGetProjectDetails.mockReturnValue({
+      data: {
+        id: "proj",
+        name: "Active Project",
+        closureState: "Open",
+        endDate: "2099-12-31",
+      },
+      error: null,
+      isLoading: false,
+    });
+
     render(
       <MemoryRouter initialEntries={["/projects/proj/dashboard"]}>
         <ErrorPageProvider>

--- a/apps/customer-portal/webapp/src/utils/__tests__/permission.test.ts
+++ b/apps/customer-portal/webapp/src/utils/__tests__/permission.test.ts
@@ -255,8 +255,12 @@ describe("isProjectContractEnded", () => {
     expect(isProjectContractEnded("2026-10-01T00:00:00.000Z", now)).toBe(false);
   });
 
-  it("returns false for invalid date strings", () => {
+  it("returns false for invalid date strings and calendar-invalid dates", () => {
+    const now = new Date("2026-09-09T12:00:00.000Z");
     expect(isProjectContractEnded("not-a-date")).toBe(false);
+    expect(isProjectContractEnded("2026-02-30", now)).toBe(false);
+    expect(isProjectContractEnded("2026-02-29", now)).toBe(false);
+    expect(isProjectContractEnded("2024-02-29", now)).toBe(true);
   });
 });
 

--- a/apps/customer-portal/webapp/src/utils/__tests__/permission.test.ts
+++ b/apps/customer-portal/webapp/src/utils/__tests__/permission.test.ts
@@ -253,6 +253,8 @@ describe("isProjectContractEnded", () => {
     const now = new Date("2026-09-09T12:00:00.000Z");
     expect(isProjectContractEnded("2026-04-26T23:59:59.000Z", now)).toBe(true);
     expect(isProjectContractEnded("2026-10-01T00:00:00.000Z", now)).toBe(false);
+    expect(isProjectContractEnded("2026-09-09T00:00:00.000Z", now)).toBe(true);
+    expect(isProjectContractEnded("2026-09-09T18:00:00.000Z", now)).toBe(false);
   });
 
   it("returns false for invalid date strings and calendar-invalid dates", () => {

--- a/apps/customer-portal/webapp/src/utils/__tests__/permission.test.ts
+++ b/apps/customer-portal/webapp/src/utils/__tests__/permission.test.ts
@@ -23,6 +23,8 @@ import {
   getProjectSeverityPolicy,
   shouldHideOnboardingData,
   shouldForceSeverityS4,
+  isProjectContractEnded,
+  isProjectSuspended,
 } from "@utils/permission";
 
 function buildProjectFeatures(
@@ -222,3 +224,63 @@ describe("shouldHideOnboardingData", () => {
     expect(shouldHideOnboardingData("In Progress")).toBe(false);
   });
 });
+
+describe("isProjectContractEnded", () => {
+  it("returns false when endDate is null, undefined, or empty", () => {
+    expect(isProjectContractEnded(null)).toBe(false);
+    expect(isProjectContractEnded(undefined)).toBe(false);
+    expect(isProjectContractEnded("   ")).toBe(false);
+  });
+
+  it("returns true when endDate (YYYY-MM-DD) is in the past", () => {
+    const now = new Date("2026-09-09T12:00:00.000Z");
+    expect(isProjectContractEnded("2026-04-26", now)).toBe(true);
+    expect(isProjectContractEnded("2026-09-08", now)).toBe(true);
+  });
+
+  it("returns false when endDate is today (contract still active until end of day)", () => {
+    const now = new Date("2026-09-09T12:00:00.000Z");
+    expect(isProjectContractEnded("2026-09-09", now)).toBe(false);
+  });
+
+  it("returns false when endDate is in the future", () => {
+    const now = new Date("2026-09-09T12:00:00.000Z");
+    expect(isProjectContractEnded("2026-12-31", now)).toBe(false);
+    expect(isProjectContractEnded("2027-01-01", now)).toBe(false);
+  });
+
+  it("handles ISO date strings correctly", () => {
+    const now = new Date("2026-09-09T12:00:00.000Z");
+    expect(isProjectContractEnded("2026-04-26T23:59:59.000Z", now)).toBe(true);
+    expect(isProjectContractEnded("2026-10-01T00:00:00.000Z", now)).toBe(false);
+  });
+
+  it("returns false for invalid date strings", () => {
+    expect(isProjectContractEnded("not-a-date")).toBe(false);
+  });
+});
+
+describe("isProjectSuspended", () => {
+  it("returns true when closureState is Suspended (case-insensitive)", () => {
+    expect(isProjectSuspended("Suspended")).toBe(true);
+    expect(isProjectSuspended("suspended")).toBe(true);
+    expect(isProjectSuspended(" SUSPENDED ")).toBe(true);
+  });
+
+  it("returns true when closureState is not suspended but contract has ended", () => {
+    const now = new Date("2026-09-09T12:00:00.000Z");
+    expect(isProjectSuspended("Open", "2026-04-26", now)).toBe(true);
+    expect(isProjectSuspended(null, "2026-04-26", now)).toBe(true);
+  });
+
+  it("returns false when closureState is Open and contract is active", () => {
+    const now = new Date("2026-09-09T12:00:00.000Z");
+    expect(isProjectSuspended("Open", "2026-12-31", now)).toBe(false);
+  });
+
+  it("returns false when closureState is empty and endDate is not set", () => {
+    expect(isProjectSuspended(null, null)).toBe(false);
+    expect(isProjectSuspended(undefined, undefined)).toBe(false);
+  });
+});
+

--- a/apps/customer-portal/webapp/src/utils/permission.ts
+++ b/apps/customer-portal/webapp/src/utils/permission.ts
@@ -295,7 +295,7 @@ export function isProjectContractEnded(
   if (!trimmed) return false;
 
   // Handle YYYY-MM-DD format
-  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(trimmed);
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
   if (match) {
     const endOfYear = Number(match[1]);
     const endOfMonth = Number(match[2]) - 1;

--- a/apps/customer-portal/webapp/src/utils/permission.ts
+++ b/apps/customer-portal/webapp/src/utils/permission.ts
@@ -232,8 +232,13 @@ export function isCloudSupportProject(
 export function shouldHideOnboardingData(
   onboardingStatus: string | null | undefined,
 ): boolean {
-  const normalized = (onboardingStatus ?? "").trim().toLowerCase();
-  return normalized === NOT_APPLICABLE_ONBOARDING_STATUS;
+  if (!onboardingStatus) return false;
+  const normalized = onboardingStatus.trim().toLowerCase();
+  return (
+    normalized === NOT_APPLICABLE_ONBOARDING_STATUS ||
+    normalized.replace(/[\s_]+/g, "-") === NOT_APPLICABLE_ONBOARDING_STATUS ||
+    normalized === "n/a"
+  );
 }
 
 /**
@@ -275,6 +280,37 @@ export function getProductCategoriesForServiceRequest(
 }
 
 /**
+ * Checks whether a project's contract has ended (i.e. endDate has passed).
+ * End date is considered inclusive of the full day (until 23:59:59.999 UTC).
+ *
+ * @param endDate - Project end date string (e.g. YYYY-MM-DD or ISO format).
+ * @param now - Reference date for comparison, defaults to current time.
+ * @returns True when endDate is in the past (after end-of-day).
+ */
+export function isProjectContractEnded(
+  endDate: string | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  const trimmed = endDate?.trim();
+  if (!trimmed) return false;
+
+  // Handle YYYY-MM-DD format
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(trimmed);
+  if (match) {
+    const endOfYear = Number(match[1]);
+    const endOfMonth = Number(match[2]) - 1;
+    const endOfDay = Number(match[3]);
+    const endDateTime = new Date(Date.UTC(endOfYear, endOfMonth, endOfDay, 23, 59, 59, 999));
+    if (Number.isNaN(endDateTime.getTime())) return false;
+    return now.getTime() > endDateTime.getTime();
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return now.getTime() > parsed.getTime();
+}
+
+/**
  * Whether the project is in a Restricted closure state.
  * When restricted, action buttons (create SR, add deployment, add user, etc.) must be hidden.
  *
@@ -285,6 +321,26 @@ export function isProjectRestricted(
   closureState: string | null | undefined,
 ): boolean {
   return closureState === ProjectClosureState.RESTRICTED;
+}
+
+/**
+ * Whether the project is suspended or its contract has ended.
+ * When suspended or contract has ended, project access is blocked and the suspension notice is shown.
+ *
+ * @param closureState - Value from project.closureState.
+ * @param endDate - Project end date string.
+ * @param now - Reference date for comparison.
+ * @returns True when the project is suspended or contract has ended.
+ */
+export function isProjectSuspended(
+  closureState: string | null | undefined,
+  endDate?: string | null | undefined,
+  now?: Date,
+): boolean {
+  if (closureState?.trim().toLowerCase() === ProjectClosureState.SUSPENDED.toLowerCase()) {
+    return true;
+  }
+  return isProjectContractEnded(endDate, now);
 }
 
 /**

--- a/apps/customer-portal/webapp/src/utils/permission.ts
+++ b/apps/customer-portal/webapp/src/utils/permission.ts
@@ -302,6 +302,13 @@ export function isProjectContractEnded(
     const endOfDay = Number(match[3]);
     const endDateTime = new Date(Date.UTC(endOfYear, endOfMonth, endOfDay, 23, 59, 59, 999));
     if (Number.isNaN(endDateTime.getTime())) return false;
+    if (
+      endDateTime.getUTCFullYear() !== endOfYear ||
+      endDateTime.getUTCMonth() !== endOfMonth ||
+      endDateTime.getUTCDate() !== endOfDay
+    ) {
+      return false;
+    }
     return now.getTime() > endDateTime.getTime();
   }
 


### PR DESCRIPTION
## Purpose
Prevent support case creation for projects whose contract has ended or whose closure state is suspended across both backend and webapp layers.

## Goals
- Reject case creation API requests (`POST /cases`) with HTTP 403 Forbidden when the target project's contract has expired or the project is suspended.
- Protect webapp project route boundaries (`ProjectGuard`) by displaying the project suspension notice when a project's contract end date has elapsed or when `closureState` is suspended.
- Suppress the "Get Help" navigation header dropdown for suspended and contract-expired projects.

## Approach
- **Frontend (`apps/customer-portal/webapp`):**
  - Added `isProjectContractEnded` in `src/utils/permission.ts` to evaluate whether a project's `endDate` has passed (inclusive through end of the calendar day in UTC).
  - Added `isProjectSuspended` in `src/utils/permission.ts` to perform case-insensitive checks on `closureState === "suspended"` and evaluate `isProjectContractEnded`.
  - Updated `ProjectGuard.tsx` to render `ProjectSuspendedNoticePage` when `isProjectSuspended(data?.closureState, data?.endDate)` evaluates to `true`.
  - Updated `GetHelpDropdown.tsx` to hide the "Get Help" dropdown if the project is suspended or expired.
- **Backend v1 (`apps/customer-portal/backend`):**
  - Added `isProjectContractEnded` and `isProjectSuspendedOrExpired` in `utils.bal`.
  - In `service.bal` resource `post cases`, query `entity:getProject(userInfo.idToken, payload.projectId)` before invoking `entity:createCase()`.
  - Return `http:Forbidden` (403) with message `"Cannot create cases for a suspended or contract-expired project."` when the project is suspended or its contract has expired.
- **Backend v2 (`apps/customer-portal/backend-v2`):**
  - Added `GetProject` to the `entityCaseClient` interface.
  - In `CaseHandler.CreateCase`, validate `ProjectID` UUID format, fetch project details, and evaluate `isProjectSuspendedOrExpired`.
  - Return HTTP 403 Forbidden when suspended or expired.
  - Added unit test suite in `internal/handler/cases_create_test.go` covering active, suspended, expired, and invalid UUID scenarios.

## User stories
As a Customer Portal administrator, I want inactive and expired projects to be blocked from creating new support tickets so that operations are not opened on lapsed contracts.

## Release note
- Block case creation and display suspension notices for suspended and contract-expired projects in Customer Portal.

## Documentation
N/A — internal Customer Portal behavior, no external doc surface affected.

## Automation tests
- **Webapp Vitest:**
  - `src/utils/__tests__/permission.test.ts`: 24/24 tests passed (contract end date comparisons, casing, edge cases).
  - `src/layouts/__tests__/ProjectGuard.test.tsx`: 5/5 tests passed (active, suspended, expired projects).
  - `src/components/header/__tests__/GetHelpDropdown.test.tsx`: 3/3 tests passed.
- **Go Backend v2 Tests:**
  - `internal/handler/cases_create_test.go`: All 4 test cases passed (`TestCreateCase_SuspendedProject_Forbidden`, `TestCreateCase_ExpiredProject_Forbidden`, `TestCreateCase_ActiveProject_Success`, `TestCreateCase_InvalidProjectID_BadRequest`).
  - Full suite `go test ./...` passed.
- **Ballerina Backend v1 Tests:**
  - `bal test` / `bal build`: Source compiled `wso2/customer_portal:1.0.0` with 0 errors.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend and Go/Ballerina services)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- Node.js 20+ / pnpm 9+ / Vitest
- Go 1.22+
- Ballerina 2201.12.10 (Swan Lake Update 12)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Case creation now validates project IDs and blocks requests for suspended or contract-expired projects.
  * Get Help is hidden for suspended, expired, or restricted projects.
  * Project access handling recognizes suspension across closure states and contract end dates.
  * Onboarding values recognize additional “not applicable” formats.

* **Bug Fixes**
  * Contract expiration is detected through the end of the specified date.
  * Invalid project dates and identifiers receive appropriate validation responses.
  * Case feedback can only be submitted after the case is closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->