### PR TITLE
[CSM Portal] Time cards: approvals state filter + all-tab approver search

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdSingleSelect.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdSingleSelect.test.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import AsyncUserIdSingleSelect from "@features/csm-cases/components/AsyncUserIdSingleSelect";
+import { useInfiniteUserSearch } from "@features/csm-cases/api/useUserSearch";
+
+vi.mock("@features/csm-cases/api/useUserSearch", () => ({
+  useInfiniteUserSearch: vi.fn(),
+}));
+
+const mockedUseInfiniteUserSearch = vi.mocked(useInfiniteUserSearch);
+
+afterEach(() => {
+  mockedUseInfiniteUserSearch.mockReset();
+});
+
+const NO_RESULTS = {
+  users: [],
+  isFetching: false,
+  isFetchingNextPage: false,
+  hasNextPage: false,
+  isError: false,
+  fetchNextPage: vi.fn(),
+};
+
+describe("AsyncUserIdSingleSelect — selection rendering", () => {
+  it("renders nothing selected when value is empty", () => {
+    mockedUseInfiniteUserSearch.mockReturnValue(NO_RESULTS);
+
+    render(<AsyncUserIdSingleSelect value="" onChange={vi.fn()} label="Approver" />);
+
+    expect(screen.getByLabelText("Approver")).toHaveValue("");
+  });
+
+  it("falls back to the raw UUID when the value has no nameSeed and no search result", () => {
+    mockedUseInfiniteUserSearch.mockReturnValue(NO_RESULTS);
+
+    render(
+      <AsyncUserIdSingleSelect
+        value="22222222-2222-2222-2222-222222222222"
+        onChange={vi.fn()}
+        label="Approver"
+      />,
+    );
+
+    expect(screen.getByDisplayValue("22222222-2222-2222-2222-222222222222")).toBeInTheDocument();
+  });
+
+  it("prefers a nameSeed label over the raw UUID", () => {
+    mockedUseInfiniteUserSearch.mockReturnValue(NO_RESULTS);
+
+    render(
+      <AsyncUserIdSingleSelect
+        value="22222222-2222-2222-2222-222222222222"
+        onChange={vi.fn()}
+        nameSeed={new Map([["22222222-2222-2222-2222-222222222222", "Jane Doe"]])}
+        label="Approver"
+      />,
+    );
+
+    expect(screen.getByDisplayValue("Jane Doe")).toBeInTheDocument();
+  });
+});
+
+describe("AsyncUserIdSingleSelect — server-side role scoping", () => {
+  it("forwards roleIds/active straight through to useInfiniteUserSearch's scope", () => {
+    mockedUseInfiniteUserSearch.mockReturnValue(NO_RESULTS);
+
+    render(
+      <AsyncUserIdSingleSelect
+        value=""
+        onChange={vi.fn()}
+        roleIds={["timecard_approver"]}
+        active
+        label="Approver"
+      />,
+    );
+
+    expect(mockedUseInfiniteUserSearch).toHaveBeenCalledWith("", false, {
+      roleIds: ["timecard_approver"],
+      active: true,
+    });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdSingleSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdSingleSelect.tsx
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Autocomplete, TextField } from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import type * as React from "react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useInfiniteUserSearch } from "@features/csm-cases/api/useUserSearch";
+
+interface UserIdOption {
+  id: string;
+  name: string;
+}
+
+interface AsyncUserIdSingleSelectProps {
+  id?: string;
+  label?: string;
+  /** Selected value: a platform user UUID, or `""` for "no selection" —
+   * matches the singular, single-value `approverId` search filter this
+   * feeds (unlike {@link AsyncUserIdMultiSelect}'s `userIds`, a genuinely
+   * plural filter). */
+  value: string;
+  onChange: (next: string) => void;
+  /** Known id -> name pairs so an already-selected user stays labelled
+   * before any search has run (e.g. after switching tabs — see
+   * `engineerNameCache` in `CsmTimeCardsPage`, which this mirrors). */
+  nameSeed?: Map<string, string>;
+  /** Server-side role scoping passed straight through to
+   * {@link useInfiniteUserSearch}'s {@link UserSearchScope} — e.g. restrict
+   * the directory search to accounts holding the timecard-approver role, so
+   * this never offers someone who could never actually be picked as an
+   * approver. */
+  roleIds?: string[];
+  /** See {@link roleIds}; restrict to active accounts only. */
+  active?: boolean;
+  /** Called whenever this instance resolves an id -> name pair (a directory
+   * search result, or an existing selection) — lets a caller that persists
+   * its own id -> name cache across this component's unmount (a tab switch)
+   * learn names this instance discovered. Mirrors
+   * `AsyncUserIdMultiSelect`'s own `onNamesResolved`. */
+  onNameResolved?: (id: string, name: string) => void;
+  placeholder?: string;
+}
+
+/**
+ * Single-select twin of {@link AsyncUserIdMultiSelect}: the same
+ * backend-search Autocomplete (`useInfiniteUserSearch`, the shared
+ * user-directory search every assignee/approver-style picker in this app
+ * already uses) but stores at most one platform id, matching a singular
+ * search filter (e.g. `approverId`) rather than a plural one.
+ */
+export default function AsyncUserIdSingleSelect({
+  id = "user-id-single-select",
+  label = "User",
+  value,
+  onChange,
+  nameSeed,
+  roleIds,
+  active,
+  onNameResolved,
+  placeholder,
+}: AsyncUserIdSingleSelectProps): JSX.Element {
+  const [input, setInput] = useState("");
+  const [open, setOpen] = useState(false);
+  const debounced = useDebouncedValue(input, 300);
+  const query = debounced.trim();
+
+  const { users: searchResults, isFetching, isFetchingNextPage, hasNextPage, isError, fetchNextPage } =
+    useInfiniteUserSearch(query, open, { roleIds, active });
+  // `id` is optional on `UserSearchOption` (`POST /users/search` doesn't
+  // guarantee it) — this picker filters on the id, so a row without one is
+  // unusable here and dropped.
+  const users = useMemo(
+    () => searchResults.filter((u): u is typeof u & { id: string } => Boolean(u.id)),
+    [searchResults],
+  );
+
+  const handleListboxScroll = (event: React.UIEvent<HTMLElement>): void => {
+    const el = event.currentTarget;
+    if (
+      hasNextPage &&
+      !isFetchingNextPage &&
+      el.scrollHeight - el.scrollTop - el.clientHeight < 80
+    ) {
+      fetchNextPage();
+    }
+  };
+
+  const [pickedName, setPickedName] = useState<[string, string] | undefined>(undefined);
+
+  const nameById = useMemo(() => {
+    const m = new Map<string, string>(nameSeed);
+    users.forEach((u) => m.set(u.id, u.name));
+    if (pickedName) m.set(pickedName[0], pickedName[1]);
+    return m;
+  }, [nameSeed, users, pickedName]);
+
+  const selectedOption: UserIdOption | null = useMemo(
+    () => (value ? { id: value, name: nameById.get(value) ?? value } : null),
+    [value, nameById],
+  );
+
+  // Pool = current selection (so the field renders its value even before a
+  // search has run) + the search results, de-duplicated by id.
+  const options: UserIdOption[] = useMemo(() => {
+    const results = users.filter((u) => u.id !== value).map((u) => ({ id: u.id, name: u.name }));
+    return selectedOption ? [selectedOption, ...results] : results;
+  }, [users, value, selectedOption]);
+
+  return (
+    <Autocomplete<UserIdOption, false>
+      size="small"
+      id={id}
+      options={options}
+      value={selectedOption}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      loading={isFetching && users.length === 0}
+      filterOptions={(opts) => opts}
+      getOptionLabel={(opt) => opt.name}
+      isOptionEqualToValue={(opt, val) => opt.id === val.id}
+      slotProps={{ listbox: { onScroll: handleListboxScroll } }}
+      onChange={(_event, next) => {
+        if (next) {
+          setPickedName([next.id, next.name]);
+          onNameResolved?.(next.id, next.name);
+        }
+        onChange(next?.id ?? "");
+      }}
+      inputValue={input}
+      onInputChange={(_event, val, reason) => {
+        // "reset" fires when Autocomplete syncs the visible text to the
+        // current `value` (on selection, or on mount/re-render with an
+        // already-set `value`) — needed here since `inputValue` is
+        // controlled; without it, a preset/selected value would never
+        // actually show its label in the text field.
+        if (reason === "input" || reason === "clear" || reason === "reset") setInput(val);
+      }}
+      noOptionsText={
+        isError
+          ? "Couldn't load approvers. Try again."
+          : isFetching
+            ? "Loading approvers…"
+            : "No approvers found"
+      }
+      renderInput={(params) => (
+        <TextField {...params} label={label} placeholder={value ? undefined : placeholder} />
+      )}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.test.tsx
@@ -23,6 +23,7 @@ import {
   invalidateTimecards,
   mapTimeCard,
   searchTimeCards,
+  useApprovalQueue,
   useBulkApproveCards,
   useRecentApprovers,
 } from "@features/csm-timecards/api/useTimeSheets";
@@ -229,6 +230,56 @@ function wrapper({ children }: { children: ReactNode }) {
   });
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }
+
+describe("useApprovalQueue — states default/override", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue(bePage([], 0, 0, 20));
+  });
+
+  it("defaults to states: ['submitted'] when the caller passes no states filter", async () => {
+    const { result } = renderHook(
+      () => useApprovalQueue(true, undefined, { page: 0, rowsPerPage: 20 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+    const body = postMock.mock.calls[0][1] as BeSearchTimeCardsPayload;
+    expect(body.filters?.approverId).toBe("eng-1");
+    expect(body.filters?.states).toEqual(["submitted"]);
+  });
+
+  it("respects the caller's own states instead of silently overriding them (the Approvals State filter)", async () => {
+    const { result } = renderHook(
+      () => useApprovalQueue(true, { states: ["approved"] }, { page: 0, rowsPerPage: 20 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const body = postMock.mock.calls[0][1] as BeSearchTimeCardsPayload;
+    expect(body.filters?.states).toEqual(["approved"]);
+  });
+
+  it("still respects the caller's own states when it's every reachable state (the 'All states' pick)", async () => {
+    const { result } = renderHook(
+      () =>
+        useApprovalQueue(
+          true,
+          { states: ["submitted", "approved", "rejected"] },
+          { page: 0, rowsPerPage: 20 },
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const body = postMock.mock.calls[0][1] as BeSearchTimeCardsPayload;
+    expect(body.filters?.states).toEqual(["submitted", "approved", "rejected"]);
+  });
+});
 
 describe("useBulkApproveCards", () => {
   beforeEach(() => {

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -294,6 +294,12 @@ export function useMyTimeCards(
  * {@link useMyTimeCards}, no project scope is required (the search runs
  * unscoped when no project filter is picked), and `enabled` should be gated on
  * this tab actually being active (see the note on {@link useMyTimeCards}).
+ *
+ * `filters.states` defaults to `["submitted"]` — the queue's original,
+ * still-default behavior — but a caller that supplies its own `states` (the
+ * Approvals tab's own State filter, defaulting to "Submitted" but user
+ * changeable to Approved/Rejected/"All states") now has that respected
+ * instead of silently overridden.
  */
 export function useApprovalQueue(
   enabled: boolean,
@@ -306,7 +312,11 @@ export function useApprovalQueue(
     queryKey: [ApiQueryKeys.TIME_CARD_APPROVAL_QUEUE, me.id, filters, pagination],
     queryFn: async (): Promise<TimeCardSearchResult> => {
       if (!me.id) return { cards: [], total: 0 };
-      return searchTimeCards(api, { ...filters, approverId: me.id, states: ["submitted"] }, pagination);
+      return searchTimeCards(
+        api,
+        { ...filters, approverId: me.id, states: filters?.states?.length ? filters.states : ["submitted"] },
+        pagination,
+      );
     },
     enabled: enabled && !!me.id,
     staleTime: 5_000,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -315,19 +315,24 @@ export default function CsmTimeCardsPage(): JSX.Element {
   );
   const decideCard = useDecideCard();
 
-  const anyFilterActive =
-    filterProject.length > 0 ||
-    filterWorkItem.length > 0 ||
-    !!filterState ||
-    filterEngineer.length > 0 ||
-    !!filterApprover ||
-    !!filterFrom ||
-    !!filterTo;
-  // Approvals' own State filter isn't part of the shared `anyFilterActive`
-  // above (that would make Mine/All's "no cards match filters" messaging
-  // react to an Approvals-only pick) — "submitted" is this filter's default,
+  // Per-tab "is any filter narrowing this tab's own query" predicates —
+  // deliberately not one shared flag. Mine, All, and Approvals each apply a
+  // different subset of these filters (see baseFilters/filtersForAll/
+  // filtersForApprovals above), so a single shared predicate would make a
+  // tab's empty-state message react to a filter it never actually sends —
+  // e.g. picking an All-only Approver would make Mine/Approvals show "No time
+  // cards match the current filters." despite querying exactly as before.
+  const sharedFiltersActive =
+    filterProject.length > 0 || filterWorkItem.length > 0 || !!filterFrom || !!filterTo;
+  const mineFilterActive = sharedFiltersActive || !!filterState;
+  const allFilterActive =
+    sharedFiltersActive || !!filterState || filterEngineer.length > 0 || !!filterApprover;
+  // Approvals' own State filter isn't folded into this predicate the same way
+  // as filterState is for Mine/All — "submitted" is this filter's default,
   // matching its previous hardcoded behavior, so only a change away from it
-  // counts as the viewer actively narrowing the queue.
+  // counts as the viewer actively narrowing the queue (see approvalsStateActive
+  // below, OR'd in separately at the Approvals empty-state check).
+  const approvalsFilterActive = sharedFiltersActive || filterEngineer.length > 0;
   const approvalsStateActive = filterApprovalsState !== "submitted";
 
   // A filter change re-scopes the search for every tab, so every tab's page
@@ -682,7 +687,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
                 roleFor={mineRole}
                 onCardAction={handleCardAction}
                 emptyText={
-                  anyFilterActive
+                  mineFilterActive
                     ? "No time cards match the current filters."
                     : "No time logged yet. Open a case and use its Time tracking tab to log time."
                 }
@@ -784,7 +789,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
                 showEngineerColumn
                 roleFor={allRoleFor}
                 onCardAction={handleCardAction}
-                emptyText={anyFilterActive ? "No time cards match the current filters." : "No time logged yet."}
+                emptyText={allFilterActive ? "No time cards match the current filters." : "No time logged yet."}
               />
               <TablePagination
                 component="div"
@@ -889,7 +894,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
                 onToggleSelect={toggleSelectCard}
                 onToggleSelectAll={toggleSelectAllCards}
                 emptyText={
-                  anyFilterActive || approvalsStateActive
+                  approvalsFilterActive || approvalsStateActive
                     ? "No time cards match the current filters."
                     : "Nothing awaiting approval."
                 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -82,7 +82,9 @@ import BulkApproveDialog from "@features/csm-timecards/components/BulkApproveDia
 import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
 import SearchableMultiSelect from "@components/SearchableMultiSelect";
 import AsyncUserIdMultiSelect from "@features/csm-cases/components/AsyncUserIdMultiSelect";
+import AsyncUserIdSingleSelect from "@features/csm-cases/components/AsyncUserIdSingleSelect";
 import { INTERNAL_USER_ROLES } from "@features/csm-users/types/csmUsers";
+import { TIMECARD_APPROVER_GROUP } from "@features/csm-timecards/constants/timeCardConstants";
 import { exportTimeCardsCsv } from "@features/csm-timecards/utils/timeCardCsvExport";
 import { cardActions, type TimecardAction, type TimecardRoleCtx } from "@features/csm-timecards/utils/timeSheetState";
 import type { TimeCardGroupBy } from "@features/csm-timecards/utils/timeCardGrouping";
@@ -220,6 +222,22 @@ export default function CsmTimeCardsPage(): JSX.Element {
   const [filterWorkItem, setFilterWorkItem] = useState<string[]>([]);
   const [filterState, setFilterState] = useState<TimeCardState | "">("");
   const [filterEngineer, setFilterEngineer] = useState<string[]>([]);
+  // The All tab's own Approver filter — a single-select search over the
+  // timecard-approver directory (see filtersForAll below), wired to the
+  // backend's singular `approverId` search field. Distinct from Engineer
+  // (a real multi-select `userIds` filter): the backend has no plural
+  // `approverIds` search field, only this singular one, so this stays
+  // single-select rather than mirroring Engineer's shape.
+  const [filterApprover, setFilterApprover] = useState("");
+  // The Approvals tab's own State filter — independent of the shared
+  // `filterState` above (used by Mine/All), same isolation pattern as
+  // `filterEngineer`/`filtersWithEngineer`: a value picked here must never
+  // leak into Mine/All's queries, or vice versa. Defaults to "submitted",
+  // matching this tab's previous hardcoded behavior; "" here means "All
+  // states" (see approvalsStates below), not "unset".
+  const [filterApprovalsState, setFilterApprovalsState] = useState<TimeCardState | "">(
+    "submitted",
+  );
   // Date range (YYYY-MM-DD, inclusive) — `from`/`to` are already real
   // server-side filters (see TimeCardSearchFilters), just never had a UI
   // control wired to them until now.
@@ -248,6 +266,35 @@ export default function CsmTimeCardsPage(): JSX.Element {
     ? { ...baseFilters, userIds: filterEngineer }
     : baseFilters;
 
+  // All tab only: its own Approver filter, folded on top of
+  // filtersWithEngineer (not baseFilters directly) so All keeps stacking
+  // with Engineer the same way it already did. Kept out of baseFilters/
+  // filtersWithEngineer themselves so a value picked here can never leak
+  // into Mine's or Approvals' own queries.
+  const filtersForAll: TimeCardSearchFilters = filterApprover
+    ? { ...filtersWithEngineer, approverId: filterApprover }
+    : filtersWithEngineer;
+
+  // Approvals tab only: its own State filter (filterApprovalsState) replaces
+  // whatever `states` baseFilters/filtersWithEngineer would have carried from
+  // the shared `filterState` — Approvals never reads that shared value at
+  // all now that it has its own control. "" (All states) is sent as every
+  // reachable state explicitly, rather than omitted, so useApprovalQueue's
+  // "no states supplied" fallback (submitted-only) doesn't also swallow an
+  // explicit "show me everything" pick.
+  const approvalsStates: TimeCardState[] = filterApprovalsState
+    ? [filterApprovalsState]
+    : [...FILTER_STATES];
+  const approvalsBaseFilters: TimeCardSearchFilters = {
+    ...(scopeProjectIds.length && { projectIds: scopeProjectIds }),
+    ...(filterFrom && { from: filterFrom }),
+    ...(filterTo && { to: filterTo }),
+    states: approvalsStates,
+  };
+  const filtersForApprovals: TimeCardSearchFilters = filterEngineer.length
+    ? { ...approvalsBaseFilters, userIds: filterEngineer }
+    : approvalsBaseFilters;
+
   // Each tab pages independently — was previously fetching its *entire*
   // scope (up to 1,000 cards, sequential page-by-page requests) before
   // showing anything, confirmed live to take 30-60+ seconds and, with all
@@ -260,10 +307,10 @@ export default function CsmTimeCardsPage(): JSX.Element {
   const approvalsPagination = usePagination();
 
   const myCards = useMyTimeCards(activeTab === "mine", baseFilters, minePagination.pagination);
-  const allCards = useAllTimeCards(activeTab === "all", filtersWithEngineer, allPagination.pagination);
+  const allCards = useAllTimeCards(activeTab === "all", filtersForAll, allPagination.pagination);
   const queue = useApprovalQueue(
     activeTab === "approvals" && role.isApprover,
-    filtersWithEngineer,
+    filtersForApprovals,
     approvalsPagination.pagination,
   );
   const decideCard = useDecideCard();
@@ -273,8 +320,15 @@ export default function CsmTimeCardsPage(): JSX.Element {
     filterWorkItem.length > 0 ||
     !!filterState ||
     filterEngineer.length > 0 ||
+    !!filterApprover ||
     !!filterFrom ||
     !!filterTo;
+  // Approvals' own State filter isn't part of the shared `anyFilterActive`
+  // above (that would make Mine/All's "no cards match filters" messaging
+  // react to an Approvals-only pick) — "submitted" is this filter's default,
+  // matching its previous hardcoded behavior, so only a change away from it
+  // counts as the viewer actively narrowing the queue.
+  const approvalsStateActive = filterApprovalsState !== "submitted";
 
   // A filter change re-scopes the search for every tab, so every tab's page
   // position needs to reset too — otherwise "page 3" of a narrower result
@@ -307,6 +361,14 @@ export default function CsmTimeCardsPage(): JSX.Element {
     setFilterEngineer(v);
     resetAllPages();
   };
+  const handleFilterApproverChange = (v: string): void => {
+    setFilterApprover(v);
+    resetAllPages();
+  };
+  const handleFilterApprovalsStateChange = (v: TimeCardState | ""): void => {
+    setFilterApprovalsState(v);
+    resetAllPages();
+  };
   const handleFilterFromChange = (v: string): void => {
     setFilterFrom(v);
     // min/max on the date inputs only guide the picker UI — typing a date
@@ -324,6 +386,8 @@ export default function CsmTimeCardsPage(): JSX.Element {
     setFilterWorkItem([]);
     setFilterState("");
     setFilterEngineer([]);
+    setFilterApprover("");
+    setFilterApprovalsState("submitted");
     setFilterFrom("");
     setFilterTo("");
     resetAllPages();
@@ -399,7 +463,10 @@ export default function CsmTimeCardsPage(): JSX.Element {
   // showing a raw id until the dropdown is reopened and re-searched. (The
   // Engineer filter's own search always finds the name eventually, since it
   // now queries the real users directory rather than only the current page —
-  // this cache just avoids a raw-UUID flash in the meantime.)
+  // this cache just avoids a raw-UUID flash in the meantime.) The Approver
+  // filter (All tab only) shares this same userId -> userName cache — it's
+  // just as generic a "known user names" lookup, and Approver is also
+  // directory-search-backed rather than derived from loaded cards.
   //
   // Reconciled during render (React's "adjusting state when data changes"
   // pattern: https://react.dev/reference/react/useState#storing-information-from-previous-renders)
@@ -468,6 +535,13 @@ export default function CsmTimeCardsPage(): JSX.Element {
     }
     if (next) setEngineerNameCache(next);
   };
+
+  /** Single-pair adapter over {@link handleEngineerNamesResolved} for
+   * `AsyncUserIdSingleSelect`'s `onNameResolved` (one id/name pair at a
+   * time), which shares the same underlying cache — see the comment above
+   * `engineerNameCache`. */
+  const handleApproverNameResolved = (id: string, name: string): void =>
+    handleEngineerNamesResolved([[id, name]]);
 
   // Filtered cards per tab, computed once and shared between the FilterBar's
   // export action and the table rendering below — rather than recomputing
@@ -666,6 +740,20 @@ export default function CsmTimeCardsPage(): JSX.Element {
               />
             }
             engineerActive={filterEngineer.length > 0}
+            approverSlot={
+              <AsyncUserIdSingleSelect
+                id="timecards-filter-approver-all"
+                label="Approver"
+                placeholder="Search approvers…"
+                value={filterApprover}
+                onChange={handleFilterApproverChange}
+                nameSeed={engineerNameCache}
+                onNameResolved={handleApproverNameResolved}
+                roleIds={[TIMECARD_APPROVER_GROUP]}
+                active
+              />
+            }
+            approverActive={!!filterApprover}
           />
 
           <GroupByToggle value={groupBy} onChange={setGroupBy} />
@@ -724,14 +812,14 @@ export default function CsmTimeCardsPage(): JSX.Element {
             filterWorkItem={filterWorkItem}
             setFilterWorkItem={handleFilterWorkItemChange}
             workItemOptions={approvalsWorkItemOptions}
-            filterState={filterState}
-            setFilterState={handleFilterStateChange}
+            filterState={filterApprovalsState}
+            setFilterState={handleFilterApprovalsStateChange}
+            stateActive={approvalsStateActive}
             filterFrom={filterFrom}
             setFilterFrom={handleFilterFromChange}
             filterTo={filterTo}
             setFilterTo={handleFilterToChange}
             onClear={clearFilters}
-            hideStateFilter
             engineerSlot={
               <AsyncUserIdMultiSelect
                 id="timecards-filter-engineer-approvals"
@@ -800,7 +888,11 @@ export default function CsmTimeCardsPage(): JSX.Element {
                 selectedIds={selectedApprovalCardIds}
                 onToggleSelect={toggleSelectCard}
                 onToggleSelectAll={toggleSelectAllCards}
-                emptyText={anyFilterActive ? "No time cards match the current filters." : "Nothing awaiting approval."}
+                emptyText={
+                  anyFilterActive || approvalsStateActive
+                    ? "No time cards match the current filters."
+                    : "Nothing awaiting approval."
+                }
               />
               <TablePagination
                 component="div"
@@ -1007,7 +1099,9 @@ function FilterBar({
   onClear,
   engineerSlot,
   engineerActive,
-  hideStateFilter,
+  approverSlot,
+  approverActive,
+  stateActive,
 }: {
   /** `projectId -> projectName` lookup for already-selected chips — the
    * page-level, cross-tab accumulating cache (see `projectNameCache` in
@@ -1022,6 +1116,12 @@ function FilterBar({
   /** Case numbers to offer in the work-item picker — scoped to whatever the
    * calling tab currently has loaded (see `workItemOptionsFrom`). */
   workItemOptions: string[];
+  /** The State control's own value for whichever tab renders this instance —
+   * Mine/All pass the shared `filterState` (default "", meaning unset); the
+   * Approvals tab passes its own `filterApprovalsState` (default
+   * "submitted") instead, since a value picked there must never leak into
+   * Mine/All's queries or vice versa (see `filterApprovalsState` in
+   * `CsmTimeCardsPage`). */
   filterState: TimeCardState | "";
   setFilterState: (v: TimeCardState | "") => void;
   /** Inclusive date range (YYYY-MM-DD), matched against a card's work date. */
@@ -1034,21 +1134,30 @@ function FilterBar({
   /** Whether the Engineer filter (only on the All/Approvals tabs) is active —
    * counted alongside the other fields for the toggle button's badge. */
   engineerActive?: boolean;
-  /** Approvals always forces `states: ["submitted"]` server-side (see
-   * `useApprovalQueue`), so the State control can't actually narrow anything
-   * there — hide it instead of showing a filter that silently does nothing. */
-  hideStateFilter?: boolean;
+  /** The Approver filter (All tab only) — a single-select search field, not
+   * a fixed shape like Engineer/State, so it's a caller-supplied slot the
+   * same way `engineerSlot` is. */
+  approverSlot?: JSX.Element;
+  /** Whether the Approver filter is active — counted alongside the other
+   * fields for the toggle button's badge, same role as `engineerActive`. */
+  approverActive?: boolean;
+  /** Whether `filterState` should count as an active filter for this tab's
+   * badge/"N filters active" caption. Left unset, defaults to `!!filterState`
+   * (Mine/All's own rule: "" is never active). The Approvals tab passes this
+   * explicitly instead, since its own default is "submitted", not "" — only
+   * a change *away from* that default should count as the viewer actively
+   * narrowing the queue (see `approvalsStateActive` in `CsmTimeCardsPage`). */
+  stateActive?: boolean;
 }): JSX.Element {
   const [isFiltersOpen, setIsFiltersOpen] = useState(true);
 
-  // filterState counts here even when this tab hides its own State control
-  // (hideStateFilter) — it's shared across tabs, so a value set elsewhere
-  // must still be clearable from this one, not just invisible and stuck.
+  const isStateActive = stateActive ?? !!filterState;
   const activeCount =
     (filterProject.length > 0 ? 1 : 0) +
     (filterWorkItem.length > 0 ? 1 : 0) +
     (engineerActive ? 1 : 0) +
-    (filterState ? 1 : 0) +
+    (approverActive ? 1 : 0) +
+    (isStateActive ? 1 : 0) +
     (filterFrom || filterTo ? 1 : 0);
   const hasActive = activeCount > 0;
 
@@ -1105,37 +1214,36 @@ function FilterBar({
               />
             </Box>
             {engineerSlot && <Box sx={{ flex: "1 1 0", minWidth: 160 }}>{engineerSlot}</Box>}
-            {!hideStateFilter && (
-              <Box sx={{ flex: "1 1 0", minWidth: 160 }}>
-                <TextField
-                  select
-                  fullWidth
-                  size="small"
-                  label="State"
-                  value={filterState}
-                  onChange={(e) => setFilterState(e.target.value as TimeCardState | "")}
-                  slotProps={{
-                    // oxygen-ui's own theme shifts an unshrunk label up by
-                    // `top: -7px` for any Select-backed field (see
-                    // `MultiSelectField.tsx`'s doc comment) -- tie `shrink`
-                    // to whether a state is actually picked, rather than
-                    // MUI's focus-driven default.
-                    inputLabel: {
-                      shrink: filterState !== "",
-                      sx: { top: "0px !important" },
-                    },
-                    select: { notched: filterState !== "" },
-                  }}
-                >
-                  <MenuItem value="">All states</MenuItem>
-                  {FILTER_STATES.map((s) => (
-                    <MenuItem key={s} value={s}>
-                      {TIME_CARD_STATE_META[s].label}
-                    </MenuItem>
-                  ))}
-                </TextField>
-              </Box>
-            )}
+            {approverSlot && <Box sx={{ flex: "1 1 0", minWidth: 160 }}>{approverSlot}</Box>}
+            <Box sx={{ flex: "1 1 0", minWidth: 160 }}>
+              <TextField
+                select
+                fullWidth
+                size="small"
+                label="State"
+                value={filterState}
+                onChange={(e) => setFilterState(e.target.value as TimeCardState | "")}
+                slotProps={{
+                  // oxygen-ui's own theme shifts an unshrunk label up by
+                  // `top: -7px` for any Select-backed field (see
+                  // `MultiSelectField.tsx`'s doc comment) -- tie `shrink`
+                  // to whether a state is actually picked, rather than
+                  // MUI's focus-driven default.
+                  inputLabel: {
+                    shrink: filterState !== "",
+                    sx: { top: "0px !important" },
+                  },
+                  select: { notched: filterState !== "" },
+                }}
+              >
+                <MenuItem value="">All states</MenuItem>
+                {FILTER_STATES.map((s) => (
+                  <MenuItem key={s} value={s}>
+                    {TIME_CARD_STATE_META[s].label}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </Box>
           </Box>
 
           {/* Row 2: the work-date range, its own full-width row — each


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The Approvals tab hardcoded the time-card state filter to "submitted" server-side and hid the State control entirely, so an approver couldn't look back at what they'd already approved/rejected without leaving the tab. The All time cards tab had no way to search/filter by approver.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Approvals tab: expose the State filter as a normal, user-changeable control, defaulting to "submitted" (today's behavior) but selectable to Approved, Rejected, or All states.
- All tab: add a single-select Approver filter, backed by the same real approver-directory search `LogTimeCardDialog`'s own approver picker already uses.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- `useApprovalQueue` no longer unconditionally forces `states: ["submitted"]`; it honors any `states` filter the caller passes and only defaults to `["submitted"]` when none is given.
- `CsmTimeCardsPage.tsx` gives the Approvals tab its own `filterApprovalsState` (default `"submitted"`), isolated from the shared `filterState` used by Mine/All, so a value picked on one tab can't leak into another (same pattern already used for the Engineer filter).
- `FilterBar`'s `hideStateFilter` prop is removed; State is always shown, with a separate `stateActive` flag so Approvals' "submitted is the default, not an active filter" semantics don't affect Mine/All's badge counting.
- All tab gets a new `filterApprover` (single value) wired to the backend's existing singular `approverId` search field, via a new `AsyncUserIdSingleSelect` component (single-select twin of the existing `AsyncUserIdMultiSelect`) sourced from the `timecard_approver`-scoped user directory search.
- No backend/entity-service changes: `approverId` was already a fully supported search filter end-to-end, just never exposed as a general-purpose UI filter outside the approvals queue's hardcoded self-scope.

## User stories
> Summary of user stories addressed by this change

As a CS approver, I can filter the Approvals tab by state so I can review cards I've already approved or rejected, not just what's pending.
As a CS engineer/approver, I can search the All time cards tab by approver.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Time Cards: the Approvals tab's state filter is now user-selectable (defaults to Submitted), and the All time cards tab supports filtering by approver.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A — existing filter UX extended to a control already documented elsewhere on the same page; no new flow/nav item.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal filter UX change, not user-facing marketing material.

## Automation tests
 - Unit tests
   > `useTimeSheets.test.tsx`: 3 new cases for `useApprovalQueue` (default-to-submitted, caller-states honored, "all states" honored). `AsyncUserIdSingleSelect.test.tsx`: 4 new cases (selection rendering, nameSeed precedence, role-scope passthrough). `npx vitest run` on the touched feature dirs: 466 passed.
 - Integration tests
   > None added; no backend/API contract change.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend only
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
`tsc -b --noEmit` clean, `npm run lint` clean (0 new warnings), `vitest run` on `csm-timecards`/`csm-cases/components` — 466 passed. Live click-through against the local stack pending.

## Learning
Reused the existing `TIMECARD_APPROVER_GROUP` role-scoped directory search already used by `LogTimeCardDialog`'s approver picker, rather than deriving approver options from whatever cards happen to be loaded on the current page — a stronger source since it searches the real approver directory instead of being limited to the currently visible page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Approver filter to the All timecards view with searchable user selection.
  * Added a dedicated State filter to the Approvals view, defaulting to “Submitted.”
  * Filter counts, badges, and empty-state messages now reflect the selected Approver and State filters.

* **Bug Fixes**
  * Custom approval state selections are now preserved instead of being replaced by the default filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->