### PR TITLE
[CSM Portal] fix: rename Account Owner label to Account Manager

### DIFF
--- a/apps/csm-portal/microapp/src/pages/AccountDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/AccountDetailPage.tsx
@@ -92,7 +92,7 @@ export default function AccountDetailPage() {
             />
           </MetaRow>
           <Divider />
-          <MetaRow label="Account owner">
+          <MetaRow label="Account manager">
             <MetaValue>{a.ownerName || a.ownerId || "—"}</MetaValue>
           </MetaRow>
           <Divider />

--- a/apps/customer-portal/webapp/src/components/access-control/ProjectSuspendedNoticePage.tsx
+++ b/apps/customer-portal/webapp/src/components/access-control/ProjectSuspendedNoticePage.tsx
@@ -120,7 +120,7 @@ export default function ProjectSuspendedNoticePage({
             <InfoRow label="Project Name:" value={project.name} />
             <InfoRow label="Project Key:" value={project.key} />
             <InfoRow label="Project Type:" value={projectType} />
-            <InfoRow label="Account Owner:" value={accountOwner} />
+            <InfoRow label="Account Manager:" value={accountOwner} />
             <InfoRow label="Subscription Start Date:" value={startDateLabel} />
           </Stack>
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

"Account Owner" and "Account Manager" were both used in the UI to refer to the same person/role, which is confusing for users switching between screens.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Standardize on "Account Manager" everywhere in the CP and CSM portals. The main CSM webapp already used "Account Manager" consistently; only two other screens still said "Account Owner".

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Pure copy fix, two files:
- `apps/csm-portal/microapp/src/pages/AccountDetailPage.tsx`: `"Account owner"` → `"Account manager"`
- `apps/customer-portal/webapp/src/components/access-control/ProjectSuspendedNoticePage.tsx`: `"Account Owner:"` → `"Account Manager:"`

No data model, DTO, type, or variable renames — only the displayed label text changed. "Technical Owner" labels (a distinct role) are untouched.

## User stories
> Summary of user stories addressed by this change

N/A — terminology consistency fix, not a new feature.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed inconsistent "Account Owner" / "Account Manager" labeling across the customer and CSM portals; both now consistently say "Account Manager".

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — label-only text change, no behavior or workflow change to document.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A — no training content references this label.

## Certification
> Type "Sent" when you have provided new/updated certification questions...

N/A — no certification content affected.

## Marketing
> Link to drafts of marketing content...

N/A — internal UI copy fix only.

## Automation tests
 - Unit tests
   > Code coverage information

N/A — no logic changed, only static label strings.
 - Integration tests
   > Details about the test cases and coverage

N/A — no logic changed, only static label strings.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no code logic changed
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

N/A

## Related PRs
> List any other related PRs

None

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A — no migration needed.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Not run in a live browser for this change; verified via code review of the diff only (no local node_modules in the working worktree to run a build/typecheck).

## Learning
> Describe the research phase...

Grepped the codebase for "Account Owner"/"Account Manager" usage across csm-portal webapp, csm-portal microapp, and customer-portal webapp before changing anything, to confirm this was a stray-copy issue and not a case of two genuinely different roles sharing similar names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
