### PR TITLE
Add "is not one of" for project, and account filtering, to case advanced filters

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -930,6 +930,7 @@ export type BeCaseFieldFilterField =
   | "workState"
   | "tag"
   | "projectId"
+  | "accountId"
   | "deploymentId"
   | "assignedUserId"
   | "createdBy"

--- a/apps/csm-portal/webapp/src/features/csm-accounts/api/useSearchAccounts.ts
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/api/useSearchAccounts.ts
@@ -14,11 +14,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useQuery,
+} from "@tanstack/react-query";
+import { useMemo } from "react";
 import { useAuthApiClient } from "@hooks/useAuthApiClient";
 import { apiConfig } from "@config/apiConfig";
 import { ApiError, parseApiResponseMessage } from "@utils/ApiError";
 import type {
+  Account,
   SearchAccountsRequest,
   SearchAccountsResponse,
 } from "@features/csm-accounts/types/csmAccounts";
@@ -46,4 +52,94 @@ export function useSearchAccounts(request: SearchAccountsRequest) {
     placeholderData: keepPreviousData,
     staleTime: 30_000,
   });
+}
+
+/** Page size for the lazy-loaded (scroll-to-load-more) account filter — same
+ * default as {@link PROJECT_PAGE_SIZE} in `useProjectSearch.ts`, the picker
+ * this hook mirrors. */
+export const ACCOUNT_PAGE_SIZE = 10;
+
+/** Flattened, paginated result for the lazy-loaded account filter — same
+ * shape as `useProjectSearch.ts`'s `InfiniteProjectSearch`. */
+export interface InfiniteAccountSearch {
+  /** All accounts loaded so far, across every fetched page. */
+  accounts: Account[];
+  isFetching: boolean;
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean;
+  isError: boolean;
+  /** Fetch the next page (wired to the dropdown's scroll). */
+  fetchNextPage: () => void;
+}
+
+/**
+ * Paginated account search for the cases "Account" advanced filter, backed
+ * by the same `POST /accounts/search` endpoint {@link useSearchAccounts}
+ * already calls for the Accounts list page. Loads the first
+ * {@link ACCOUNT_PAGE_SIZE} accounts as soon as it is enabled (the dropdown
+ * opens) — no typing required — and pages through the rest on demand via
+ * {@link InfiniteAccountSearch.fetchNextPage} (wired to the listbox scroll).
+ * Mirrors {@link useInfiniteProjectSearch} in `useProjectSearch.ts`, the
+ * reference shape for this "type-to-search, scroll-to-page" picker pattern.
+ */
+export function useInfiniteAccountSearch(
+  query: string,
+  enabled: boolean,
+): InfiniteAccountSearch {
+  const authFetch = useAuthApiClient();
+  const q = query.trim();
+
+  const result = useInfiniteQuery<SearchAccountsResponse, Error>({
+    queryKey: ["csm-accounts-search-paged", q],
+    queryFn: async ({ pageParam }) => {
+      const request: SearchAccountsRequest = {
+        pagination: { offset: pageParam as number, limit: ACCOUNT_PAGE_SIZE },
+        ...(q.length > 0 ? { filters: { searchQuery: q } } : {}),
+      };
+      const res = await authFetch(`${apiConfig.backendUrl}/accounts/search`, {
+        method: "POST",
+        body: JSON.stringify(request),
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new ApiError(
+          res.status,
+          res.statusText,
+          parseApiResponseMessage(body, res.status, res.statusText),
+        );
+      }
+      return (await res.json()) as SearchAccountsResponse;
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage.hasMore) return undefined;
+      // Stop if the last page came back empty: the offset wouldn't advance, so
+      // scroll-fetching would otherwise loop on the same page forever.
+      if ((lastPage.accounts?.length ?? 0) === 0) return undefined;
+      // Next offset = rows already loaded; robust even if the backend does not
+      // echo back the offset we sent.
+      return allPages.reduce((n, p) => n + (p.accounts?.length ?? 0), 0);
+    },
+    enabled,
+    // Keep prior pages on screen while a new query's first page loads, so the
+    // dropdown doesn't flash empty between searches.
+    placeholderData: keepPreviousData,
+    staleTime: 60_000,
+  });
+
+  const accounts = useMemo(
+    () => (result.data?.pages ?? []).flatMap((p) => p.accounts ?? []),
+    [result.data],
+  );
+
+  return {
+    accounts,
+    isFetching: result.isFetching,
+    isFetchingNextPage: result.isFetchingNextPage,
+    hasNextPage: result.hasNextPage,
+    isError: result.isError,
+    fetchNextPage: () => {
+      void result.fetchNextPage();
+    },
+  };
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AdvancedFiltersBuilder.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AdvancedFiltersBuilder.tsx
@@ -33,6 +33,7 @@ import MultiSelectField from "@components/MultiSelectField";
 import AsyncCreatedByMultiSelect from "@features/csm-cases/components/AsyncCreatedByMultiSelect";
 import AsyncAssigneeMultiSelect from "@features/csm-cases/components/AsyncAssigneeMultiSelect";
 import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
+import AsyncAccountMultiSelect from "@features/csm-cases/components/AsyncAccountMultiSelect";
 import ProductNameMultiSelect from "@features/csm-cases/components/ProductNameMultiSelect";
 import AsyncTagMultiSelect from "@features/csm-cases/components/AsyncTagMultiSelect";
 import {
@@ -69,6 +70,11 @@ interface AdvancedFiltersBuilderProps {
    * (`AsyncProjectMultiSelect`) — same seed the Simple grid's own "Project"
    * control uses. */
   projectNameSeed?: Map<string, string>;
+  /** Known id → name pairs for the `accountId` row's value input
+   * (`AsyncAccountMultiSelect`) — same shape as `projectNameSeed`, but
+   * `accountId` has no Simple-grid control of its own to seed it from, so
+   * this is currently always empty in practice; kept for parity/future use. */
+  accountNameSeed?: Map<string, string>;
 }
 
 /** "YYYY-MM-DD" to a local-midnight Date (avoids the UTC-parse day-shift
@@ -232,6 +238,7 @@ export default function AdvancedFiltersBuilder({
   sreTeamOptions,
   assigneeNameSeed,
   projectNameSeed,
+  accountNameSeed,
 }: AdvancedFiltersBuilderProps): JSX.Element {
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -350,6 +357,15 @@ export default function AdvancedFiltersBuilder({
                   values={row.values}
                   onChange={(next) => onUpdateRow(row, { ...asRow(row), values: next })}
                   nameSeed={projectNameSeed}
+                />
+              )}
+              {opMeta?.valueKind === "asyncAccountMultiSelect" && (
+                <AsyncAccountMultiSelect
+                  id={`advanced-filter-value-${index}`}
+                  label="Value(s)"
+                  values={row.values}
+                  onChange={(next) => onUpdateRow(row, { ...asRow(row), values: next })}
+                  nameSeed={accountNameSeed}
                 />
               )}
               {opMeta?.valueKind === "asyncProductMultiSelect" && (

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAccountMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAccountMultiSelect.tsx
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Autocomplete,
+  Box,
+  Checkbox,
+  ListItemText,
+  TextField,
+  Tooltip,
+} from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import type * as React from "react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useInfiniteAccountSearch } from "@features/csm-accounts/api/useSearchAccounts";
+
+interface AccountOption {
+  id: string;
+  name: string;
+}
+
+interface AsyncAccountMultiSelectProps {
+  id?: string;
+  label?: string;
+  /** Selected account ids. */
+  values: string[];
+  onChange: (next: string[]) => void;
+  /**
+   * Known id → name pairs (e.g. from the cases currently on screen) used to
+   * label already-selected accounts before any search has run.
+   */
+  nameSeed?: Map<string, string>;
+}
+
+/**
+ * Account filter that searches the backend as the user types instead of
+ * loading the whole account catalogue up front. Selected account names are
+ * remembered (captured at selection time, plus any seed) so the chips stay
+ * labelled even after the search results change. Mirrors
+ * `AsyncProjectMultiSelect` (the `projectId` row's own value input) — same
+ * debounce/search/paginate shape, pointed at `POST /accounts/search` instead.
+ */
+export default function AsyncAccountMultiSelect({
+  id = "cases-filter-account",
+  label = "Account",
+  values,
+  onChange,
+  nameSeed,
+}: AsyncAccountMultiSelectProps): JSX.Element {
+  const [input, setInput] = useState("");
+  const [open, setOpen] = useState(false);
+  const debounced = useDebouncedValue(input, 300);
+  const query = debounced.trim();
+
+  // Enabled while the dropdown is open, so it loads the first page of accounts
+  // on open (no typing needed) and re-pages as the user types. Closed → the
+  // query idles (cached pages stay for an instant re-open).
+  const {
+    accounts,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    isError,
+    fetchNextPage,
+  } = useInfiniteAccountSearch(query, open);
+
+  // Lazy-load the next page when the listbox is scrolled near its end.
+  const handleListboxScroll = (event: React.UIEvent<HTMLElement>): void => {
+    const el = event.currentTarget;
+    if (
+      hasNextPage &&
+      !isFetchingNextPage &&
+      el.scrollHeight - el.scrollTop - el.clientHeight < 80
+    ) {
+      fetchNextPage();
+    }
+  };
+
+  // Names captured when the user picks an account, so a chip keeps its label
+  // even once the search moves on to a different term.
+  const [pickedNames, setPickedNames] = useState<Map<string, string>>(
+    () => new Map(),
+  );
+
+  const nameById = useMemo(() => {
+    const m = new Map<string, string>(nameSeed);
+    accounts.forEach((a) => {
+      if (a.name) m.set(a.id, a.name);
+    });
+    pickedNames.forEach((name, aid) => m.set(aid, name));
+    return m;
+  }, [nameSeed, accounts, pickedNames]);
+
+  const selectedOptions: AccountOption[] = useMemo(
+    () => values.map((v) => ({ id: v, name: nameById.get(v) ?? v })),
+    [values, nameById],
+  );
+
+  // Pool = current selection (so the field can render its chips) + the search
+  // results, de-duplicated by id.
+  const options: AccountOption[] = useMemo(() => {
+    const results = accounts.map((a) => ({ id: a.id, name: a.name || a.id }));
+    const seen = new Set(values);
+    return [...selectedOptions, ...results.filter((o) => !seen.has(o.id))];
+  }, [accounts, values, selectedOptions]);
+
+  return (
+    <Autocomplete<AccountOption, true>
+      multiple
+      size="small"
+      id={id}
+      options={options}
+      value={selectedOptions}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      // Spinner only while the first page loads; later pages append on scroll.
+      loading={isFetching && accounts.length === 0}
+      disableCloseOnSelect
+      sx={{
+        "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap", minHeight: 40 },
+      }}
+      // The backend already filtered by the typed term; don't re-filter locally.
+      filterOptions={(opts) => opts}
+      getOptionLabel={(opt) => opt.name}
+      isOptionEqualToValue={(opt, val) => opt.id === val.id}
+      slotProps={{ listbox: { onScroll: handleListboxScroll } }}
+      onChange={(_event, next) => {
+        setPickedNames((prev) => {
+          const m = new Map(prev);
+          next.forEach((o) => m.set(o.id, o.name));
+          return m;
+        });
+        onChange(next.map((o) => o.id));
+      }}
+      inputValue={input}
+      onInputChange={(_event, value, reason) => {
+        // Keep the typed term after a selection (reason "reset") so the user can
+        // pick several from one search; clear only on explicit input/clear.
+        if (reason === "input" || reason === "clear") setInput(value);
+      }}
+      noOptionsText={
+        isError
+          ? "Couldn't load accounts. Try again."
+          : isFetching
+            ? "Loading accounts…"
+            : "No accounts found"
+      }
+      renderTags={(value) => {
+        const displayText = value.map((o) => o.name).join(", ");
+        const content = (
+          <Box
+            component="span"
+            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", pl: 1 }}
+          >
+            {displayText}
+          </Box>
+        );
+        return value.length === 1 ? content : (
+          <Tooltip title={displayText} placement="top">{content}</Tooltip>
+        );
+      }}
+      renderOption={(props, option, { selected }) => {
+        const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
+          key: string;
+        };
+        return (
+          <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
+            <Checkbox size="small" checked={selected} sx={{ mr: 1, p: 0.25 }} />
+            {/* An account name can run long with no space near the end --
+                without `overflowWrap`, it only breaks at a space/hyphen,
+                then overflows and gets clipped by the popup's own
+                overflow instead of wrapping onto a further line. */}
+            <ListItemText
+              primary={option.name}
+              slotProps={{
+                primary: { style: { fontSize: 13, overflowWrap: "anywhere" } },
+              }}
+            />
+          </li>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          placeholder={values.length ? undefined : "Type an account…"}
+        />
+      )}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAccountMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAccountMultiSelect.tsx
@@ -141,7 +141,14 @@ export default function AsyncAccountMultiSelect({
       onChange={(_event, next) => {
         setPickedNames((prev) => {
           const m = new Map(prev);
-          next.forEach((o) => m.set(o.id, o.name));
+          // A preselected id absent from both nameSeed and the current search
+          // results falls back to using its own id as `name` (see
+          // selectedOptions above) -- never cache that fallback here, or a
+          // later real name for the same id (from a fresh search) would be
+          // shadowed by the stale id-as-name value forever.
+          next.forEach((o) => {
+            if (o.name !== o.id) m.set(o.id, o.name);
+          });
           return m;
         });
         onChange(next.map((o) => o.id));

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.test.ts
@@ -71,6 +71,32 @@ describe("ADVANCED_FILTER_FIELDS — full unification", () => {
   it("`state` offers both `in` and `notIn`, same as the Simple grid's tri-state control", () => {
     expect(getAdvancedFilterFieldMeta("state")?.ops.map((o) => o.op)).toEqual(["in", "notIn"]);
   });
+
+  it("`projectId` offers both `in` and `notIn`, both backed by the async project picker", () => {
+    expect(getAdvancedFilterFieldMeta("projectId")?.ops.map((o) => o.op)).toEqual([
+      "in",
+      "notIn",
+    ]);
+    expect(getAdvancedFilterOpMeta("projectId", "in")?.valueKind).toBe(
+      "asyncProjectMultiSelect",
+    );
+    expect(getAdvancedFilterOpMeta("projectId", "notIn")?.valueKind).toBe(
+      "asyncProjectMultiSelect",
+    );
+  });
+
+  it("`accountId` is a real field offering both `in` and `notIn`, backed by the async account picker", () => {
+    expect(getAdvancedFilterFieldMeta("accountId")?.ops.map((o) => o.op)).toEqual([
+      "in",
+      "notIn",
+    ]);
+    expect(getAdvancedFilterOpMeta("accountId", "in")?.valueKind).toBe(
+      "asyncAccountMultiSelect",
+    );
+    expect(getAdvancedFilterOpMeta("accountId", "notIn")?.valueKind).toBe(
+      "asyncAccountMultiSelect",
+    );
+  });
 });
 
 describe("ADVANCED_FILTER_FIELDS — real suggestions instead of hand-typed values", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
@@ -40,11 +40,13 @@ import { ALL_CASE_TYPES, CASE_TYPE_LABEL } from "@features/csm-cases/utils/caseT
  * comment on that enum, which mirrors the entity-service's
  * `caseFilterFieldSet` exactly.
  *
- * Deliberately excludes two fields a hand-off brief once listed
- * (`accountId`, `resolvedOn`): neither appears in `BeCaseFieldFilterField`,
- * so the backend would reject them — widening that enum is a backend
- * contract change, out of scope for this FE-only builder. Flagged in
- * `PROGRESS.md`, not silently worked around.
+ * Deliberately excludes `resolvedOn`, one of two fields a hand-off brief
+ * once listed as candidates (the other, `accountId`, is now included below
+ * — it's a real, backend-accepted field with both `in` and `notIn` support,
+ * mirroring `projectId`). `resolvedOn` still doesn't appear in
+ * `BeCaseFieldFilterField`, so the backend would reject it — widening that
+ * enum is a backend contract change, out of scope for this FE-only builder.
+ * Flagged in `PROGRESS.md`, not silently worked around.
  *
  * `tag`, `projectOnboardingStatus`, and `creTeam` were briefly excluded here
  * (2026-08-31) on the theory that a field with its own dedicated Simple-grid
@@ -63,6 +65,7 @@ export type AdvancedFilterField =
   | "type"
   | "assignedUserId"
   | "projectId"
+  | "accountId"
   | "product"
   | "creTeam"
   | "tag"
@@ -122,6 +125,11 @@ export type AdvancedFilterValueKind =
    * same type-to-search project picker the Simple grid's own "Project"
    * control uses. */
   | "asyncProjectMultiSelect"
+  /** {@link AsyncAccountMultiSelect} — the `accountId` row's value input
+   * (both `in` and `notIn` ops), a type-to-search account picker backed by
+   * `POST /accounts/search` (the same endpoint `CsmAccountsPage`'s account
+   * list already searches via `useSearchAccounts`). */
+  | "asyncAccountMultiSelect"
   /** {@link ProductNameMultiSelect} — the `product` row's value input, same
    * type-to-search product-name picker the Simple grid's own "Product"
    * control uses. */
@@ -224,7 +232,18 @@ export const ADVANCED_FILTER_FIELDS: AdvancedFilterFieldMeta[] = [
   {
     field: "projectId",
     label: "Project",
-    ops: [{ op: "in", label: "is one of", valueKind: "asyncProjectMultiSelect" }],
+    ops: [
+      { op: "in", label: "is one of", valueKind: "asyncProjectMultiSelect" },
+      { op: "notIn", label: "is not one of", valueKind: "asyncProjectMultiSelect" },
+    ],
+  },
+  {
+    field: "accountId",
+    label: "Account",
+    ops: [
+      { op: "in", label: "is one of", valueKind: "asyncAccountMultiSelect" },
+      { op: "notIn", label: "is not one of", valueKind: "asyncAccountMultiSelect" },
+    ],
   },
   {
     field: "product",

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -236,6 +236,40 @@ describe("advanced filters (`af` param)", () => {
     expect(round.advancedFilters).toEqual(advancedFilters);
   });
 
+  // `projectId`/`notIn` has no typed `CasesFilters` slot of its own (only
+  // `projectId`/`in` does, via `filters.projects`) -- it stays in the untyped
+  // `advancedFilters` array mechanism, same as any other field with no typed
+  // adapter, and still round-trips losslessly through the URL.
+  it("round-trips a `projectId`/`notIn` row through the URL", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "projectId", op: "notIn", values: ["proj-1", "proj-2"] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.advancedFilters).toEqual(advancedFilters);
+  });
+
+  // `accountId` is a brand-new field with no typed `CasesFilters` slot at
+  // all -- both its `in` and `notIn` ops go through the same untyped
+  // `advancedFilters` array mechanism.
+  it("round-trips an `accountId`/`in` row through the URL", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "accountId", op: "in", values: ["acct-1", "acct-2"] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.advancedFilters).toEqual(advancedFilters);
+  });
+
+  it("round-trips an `accountId`/`notIn` row through the URL", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "accountId", op: "notIn", values: ["acct-3"] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.advancedFilters).toEqual(advancedFilters);
+  });
+
   // `escalation` now has a typed `CasesFilters` slot (`hasEscalation`, see
   // `filterFieldAdapters.ts`'s typed-adapter registry) — an `af` row
   // targeting it is folded (`normalizeCasesFilters`) into that real property

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1582,6 +1582,10 @@ type ParsedCaseFilters struct {
 	Types             []string
 	ProjectIDs        []string
 	DeploymentIDs     []string
+	// ExcludeProjectIDs filters to cases whose project is NOT one of these
+	// project UUIDs (optional). Inverse of ProjectIDs, and the two are
+	// independent: a request may carry either, both, or neither.
+	ExcludeProjectIDs []string
 	States            []CaseState
 	Severities        []CaseSeverity
 	IssueTypes        []CaseIssueType
@@ -1654,6 +1658,10 @@ type ParsedCaseFilters struct {
 	SreTeamIDs []string
 	// AccountIDs filters to cases belonging to one of these customer_account UUIDs (optional).
 	AccountIDs []string
+	// ExcludeAccountIDs filters to cases whose parent account is NOT one of
+	// these customer_account UUIDs (optional). Inverse of AccountIDs, and the
+	// two are independent: a request may carry either, both, or neither.
+	ExcludeAccountIDs []string
 	// Unassigned, when true, filters to cases with no assigned engineer. false and
 	// omitted are treated identically (optional).
 	Unassigned bool

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -603,6 +603,12 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
+	if len(req.Parsed.ExcludeProjectIDs) > 0 {
+		where += fmt.Sprintf(" AND c.project_id != ALL($%d::uuid[])", argIdx)
+		filterArgs = append(filterArgs, req.Parsed.ExcludeProjectIDs)
+		argIdx++
+	}
+
 	if len(req.Parsed.DeploymentIDs) > 0 {
 		where += fmt.Sprintf(" AND c.deployment_id = ANY($%d::uuid[])", argIdx)
 		filterArgs = append(filterArgs, req.Parsed.DeploymentIDs)

--- a/entity-service/internal/service/case_filters.go
+++ b/entity-service/internal/service/case_filters.go
@@ -350,9 +350,15 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 				if err := requireCaseFilterValues(f); err != nil {
 					return domain.ParsedCaseFilters{}, err
 				}
+				if err := validateUUIDs("filters: projectId", f.Values); err != nil {
+					return domain.ParsedCaseFilters{}, err
+				}
 				p.ProjectIDs = append(p.ProjectIDs, f.Values...)
 			case "notIn":
 				if err := requireCaseFilterValues(f); err != nil {
+					return domain.ParsedCaseFilters{}, err
+				}
+				if err := validateUUIDs("filters: projectId", f.Values); err != nil {
 					return domain.ParsedCaseFilters{}, err
 				}
 				p.ExcludeProjectIDs = append(p.ExcludeProjectIDs, f.Values...)

--- a/entity-service/internal/service/case_filters.go
+++ b/entity-service/internal/service/case_filters.go
@@ -345,13 +345,20 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 			}
 
 		case "projectId":
-			if f.Op != "in" {
+			switch f.Op {
+			case "in":
+				if err := requireCaseFilterValues(f); err != nil {
+					return domain.ParsedCaseFilters{}, err
+				}
+				p.ProjectIDs = append(p.ProjectIDs, f.Values...)
+			case "notIn":
+				if err := requireCaseFilterValues(f); err != nil {
+					return domain.ParsedCaseFilters{}, err
+				}
+				p.ExcludeProjectIDs = append(p.ExcludeProjectIDs, f.Values...)
+			default:
 				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
 			}
-			if err := requireCaseFilterValues(f); err != nil {
-				return domain.ParsedCaseFilters{}, err
-			}
-			p.ProjectIDs = append(p.ProjectIDs, f.Values...)
 
 		case "deploymentId":
 			if f.Op != "in" {
@@ -523,16 +530,26 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 			p.SreTeamIDs = append(p.SreTeamIDs, f.Values...)
 
 		case "accountId":
-			if f.Op != "in" {
+			switch f.Op {
+			case "in":
+				if err := requireCaseFilterValues(f); err != nil {
+					return domain.ParsedCaseFilters{}, err
+				}
+				if err := validateUUIDs("filters: accountId", f.Values); err != nil {
+					return domain.ParsedCaseFilters{}, err
+				}
+				p.AccountIDs = append(p.AccountIDs, f.Values...)
+			case "notIn":
+				if err := requireCaseFilterValues(f); err != nil {
+					return domain.ParsedCaseFilters{}, err
+				}
+				if err := validateUUIDs("filters: accountId", f.Values); err != nil {
+					return domain.ParsedCaseFilters{}, err
+				}
+				p.ExcludeAccountIDs = append(p.ExcludeAccountIDs, f.Values...)
+			default:
 				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
 			}
-			if err := requireCaseFilterValues(f); err != nil {
-				return domain.ParsedCaseFilters{}, err
-			}
-			if err := validateUUIDs("filters: accountId", f.Values); err != nil {
-				return domain.ParsedCaseFilters{}, err
-			}
-			p.AccountIDs = append(p.AccountIDs, f.Values...)
 
 		case "resolutionNotes":
 			// isNotEmpty has no prior equivalent: false and omitted were
@@ -783,6 +800,10 @@ func rejectUnsupportedOrGroupFields(parsed domain.ParsedCaseFilters) error {
 		return &apierror.ValidationError{Msg: "anyOf: field \"sreTeam\" is not supported inside an OR group"}
 	case len(parsed.AccountIDs) > 0:
 		return &apierror.ValidationError{Msg: "anyOf: field \"accountId\" is not supported inside an OR group"}
+	case len(parsed.ExcludeProjectIDs) > 0:
+		return &apierror.ValidationError{Msg: "anyOf: field \"projectId\" (notIn) is not supported inside an OR group"}
+	case len(parsed.ExcludeAccountIDs) > 0:
+		return &apierror.ValidationError{Msg: "anyOf: field \"accountId\" (notIn) is not supported inside an OR group"}
 	case len(parsed.ExcludeStates) > 0:
 		// state+in is supported inside a branch (CaseFilterGroup.States);
 		// state+notIn is not modeled there.

--- a/entity-service/internal/service/case_filters_test.go
+++ b/entity-service/internal/service/case_filters_test.go
@@ -366,6 +366,8 @@ func TestParseCaseFieldFilters_Rejections(t *testing.T) {
 		{name: "accountId notIn malformed UUID", in: []domain.CaseFieldFilter{{Field: "accountId", Op: "notIn", Values: []string{"not-a-uuid"}}}},
 		{name: "accountId unsupported op", in: []domain.CaseFieldFilter{{Field: "accountId", Op: "eq", Values: []string{"00000000-0000-0000-0000-000000000000"}}}},
 		{name: "projectId unsupported op", in: []domain.CaseFieldFilter{{Field: "projectId", Op: "eq", Values: []string{"00000000-0000-0000-0000-000000000000"}}}},
+		{name: "projectId malformed UUID", in: []domain.CaseFieldFilter{{Field: "projectId", Op: "in", Values: []string{"not-a-uuid"}}}},
+		{name: "projectId notIn malformed UUID", in: []domain.CaseFieldFilter{{Field: "projectId", Op: "notIn", Values: []string{"not-a-uuid"}}}},
 		{name: "slaBreached with unsupported op", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "in", Values: []string{"true"}}}},
 		{name: "slaBreached with non-boolean value", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"yes"}}}},
 		{name: "slaBreached with more than one value", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"true", "false"}}}},

--- a/entity-service/internal/service/case_filters_test.go
+++ b/entity-service/internal/service/case_filters_test.go
@@ -86,6 +86,45 @@ func TestParseCaseFieldFilters_NamedFieldTranslations(t *testing.T) {
 			},
 		},
 		{
+			name: "accountId notIn maps to ExcludeAccountIDs",
+			in: []domain.CaseFieldFilter{{
+				Field:  "accountId",
+				Op:     "notIn",
+				Values: []string{"00000000-0000-0000-0000-000000000000"},
+			}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if len(p.ExcludeAccountIDs) != 1 || p.ExcludeAccountIDs[0] != "00000000-0000-0000-0000-000000000000" {
+					t.Fatalf("ExcludeAccountIDs = %v", p.ExcludeAccountIDs)
+				}
+				// notIn must never be folded into the positive allowlist: that
+				// would silently invert the predicate's meaning.
+				if len(p.AccountIDs) != 0 {
+					t.Fatalf("AccountIDs = %v, want empty: notIn must not populate the in list", p.AccountIDs)
+				}
+			},
+		},
+		{
+			name: "projectId in maps to ProjectIDs",
+			in:   []domain.CaseFieldFilter{{Field: "projectId", Op: "in", Values: []string{"00000000-0000-0000-0000-000000000000"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if len(p.ProjectIDs) != 1 || p.ProjectIDs[0] != "00000000-0000-0000-0000-000000000000" {
+					t.Fatalf("ProjectIDs = %v", p.ProjectIDs)
+				}
+			},
+		},
+		{
+			name: "projectId notIn maps to ExcludeProjectIDs",
+			in:   []domain.CaseFieldFilter{{Field: "projectId", Op: "notIn", Values: []string{"11111111-1111-1111-1111-111111111111"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if len(p.ExcludeProjectIDs) != 1 || p.ExcludeProjectIDs[0] != "11111111-1111-1111-1111-111111111111" {
+					t.Fatalf("ExcludeProjectIDs = %v", p.ExcludeProjectIDs)
+				}
+				if len(p.ProjectIDs) != 0 {
+					t.Fatalf("ProjectIDs = %v, want empty: notIn must not populate the in list", p.ProjectIDs)
+				}
+			},
+		},
+		{
 			name: "tag in maps to Tags",
 			in:   []domain.CaseFieldFilter{{Field: "tag", Op: "in", Values: []string{"patch"}}},
 			check: func(t *testing.T, p domain.ParsedCaseFilters) {
@@ -324,6 +363,9 @@ func TestParseCaseFieldFilters_Rejections(t *testing.T) {
 		{name: "internalId in unsupported", in: []domain.CaseFieldFilter{{Field: "internalId", Op: "in", Values: []string{"12345"}}}},
 		{name: "projectOnboardingStatus eq unsupported", in: []domain.CaseFieldFilter{{Field: "projectOnboardingStatus", Op: "eq", Values: []string{"Completed"}}}},
 		{name: "accountId malformed UUID", in: []domain.CaseFieldFilter{{Field: "accountId", Op: "in", Values: []string{"not-a-uuid"}}}},
+		{name: "accountId notIn malformed UUID", in: []domain.CaseFieldFilter{{Field: "accountId", Op: "notIn", Values: []string{"not-a-uuid"}}}},
+		{name: "accountId unsupported op", in: []domain.CaseFieldFilter{{Field: "accountId", Op: "eq", Values: []string{"00000000-0000-0000-0000-000000000000"}}}},
+		{name: "projectId unsupported op", in: []domain.CaseFieldFilter{{Field: "projectId", Op: "eq", Values: []string{"00000000-0000-0000-0000-000000000000"}}}},
 		{name: "slaBreached with unsupported op", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "in", Values: []string{"true"}}}},
 		{name: "slaBreached with non-boolean value", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"yes"}}}},
 		{name: "slaBreached with more than one value", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"true", "false"}}}},
@@ -563,6 +605,42 @@ func TestParseCaseFieldFilterGroups_RejectsStateNotIn(t *testing.T) {
 	const want = `anyOf: field "state" (notIn) is not supported inside an OR group`
 	if ve.Msg != want {
 		t.Errorf("Msg = %q, want %q", ve.Msg, want)
+	}
+}
+
+// projectId+in and accountId+in are supported inside an OR branch (via
+// CaseFilterGroup.ProjectIDs, and accountId+in is separately rejected
+// elsewhere), but neither's notIn side is modeled there -- accepting it would
+// drop the exclusion and widen the branch's result set, same reasoning as
+// state+notIn above.
+func TestParseCaseFieldFilterGroups_RejectsProjectIdAndAccountIdNotIn(t *testing.T) {
+	cases := []struct {
+		name   string
+		branch domain.CaseFilterBranch
+		want   string
+	}{
+		{
+			name:   "projectId notIn",
+			branch: domain.CaseFilterBranch{Filters: []domain.CaseFieldFilter{{Field: "projectId", Op: "notIn", Values: []string{"00000000-0000-0000-0000-000000000000"}}}},
+			want:   `anyOf: field "projectId" (notIn) is not supported inside an OR group`,
+		},
+		{
+			name:   "accountId notIn",
+			branch: domain.CaseFilterBranch{Filters: []domain.CaseFieldFilter{{Field: "accountId", Op: "notIn", Values: []string{"00000000-0000-0000-0000-000000000000"}}}},
+			want:   `anyOf: field "accountId" (notIn) is not supported inside an OR group`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseCaseFieldFilterGroups([]domain.CaseFilterBranch{tc.branch})
+			var ve *apierror.ValidationError
+			if !errors.As(err, &ve) {
+				t.Fatalf("err = %v (%T), want *apierror.ValidationError", err, err)
+			}
+			if ve.Msg != tc.want {
+				t.Errorf("Msg = %q, want %q", ve.Msg, tc.want)
+			}
+		})
 	}
 }
 

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -436,6 +436,9 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 	if err := validateUUIDs("projectId", parsed.ProjectIDs); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
+	if err := validateUUIDs("projectId", parsed.ExcludeProjectIDs); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
 	if err := validateUUIDs("deploymentId", parsed.DeploymentIDs); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
@@ -531,6 +534,13 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 	}
 	if len(parsed.SreTeamIDs) > 0 {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "sreTeam" is not supported by this data source`}
+	}
+	// accountId+in has no repository query support today either (see
+	// domain.ParsedCaseFilters.AccountIDs); accountId+notIn is rejected the
+	// same way rather than silently dropping the exclusion and widening the
+	// result set.
+	if len(parsed.ExcludeAccountIDs) > 0 {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "accountId" (notIn) is not supported by this data source`}
 	}
 	if parsed.Unassigned {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "assignedUserId" (isEmpty) is not supported by this data source`}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -520,6 +520,9 @@ type snCaseFilters struct {
 	CaseTypes          []string `json:"caseTypes"`
 	SearchQuery        string   `json:"searchQuery,omitempty"`
 	ProjectIDs         []string `json:"projectIds,omitempty"`
+	// ExcludeProjectIDs is the inverse of ProjectIDs: cases whose project is
+	// none of these. See domain.ParsedCaseFilters.ExcludeProjectIDs.
+	ExcludeProjectIDs  []string `json:"excludeProjectIds,omitempty"`
 	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
 	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
 	StateKeys          []int    `json:"stateKeys,omitempty"`
@@ -590,7 +593,10 @@ type snCaseFilters struct {
 	CreTeamIDs []string `json:"integrationCsTeamIds,omitempty"`
 	SreTeamIDs []string `json:"sreTeamIds,omitempty"`
 	// AccountIDs: see domain.ParsedCaseFilters.AccountIDs doc comment.
-	AccountIDs           []string `json:"accountIds,omitempty"`
+	AccountIDs []string `json:"accountIds,omitempty"`
+	// ExcludeAccountIDs is the inverse of AccountIDs: cases whose parent
+	// account is none of these. See domain.ParsedCaseFilters.ExcludeAccountIDs.
+	ExcludeAccountIDs    []string `json:"excludeAccountIds,omitempty"`
 	Unassigned           bool     `json:"unassigned,omitempty"`
 	ResolutionNotesEmpty bool     `json:"resolutionNotesEmpty,omitempty"`
 	// TaskSLAFilter: SN-side join on Task SLA table, filtering by businessElapsedPercent
@@ -3472,6 +3478,7 @@ func buildSNCaseFilters(parsed domain.ParsedCaseFilters, searchQuery string) snC
 		CaseTypes:                        snCaseTypes,
 		SearchQuery:                      searchQuery,
 		ProjectIDs:                       uuidsToSysids(parsed.ProjectIDs),
+		ExcludeProjectIDs:                uuidsToSysids(parsed.ExcludeProjectIDs),
 		DeploymentIDs:                    uuidsToSysids(parsed.DeploymentIDs),
 		StateKeys:                        domainStatesToSNIDs(parsed.States),
 		ExcludeStates:                    domainStatesToSNIDs(parsed.ExcludeStates),
@@ -3502,6 +3509,7 @@ func buildSNCaseFilters(parsed domain.ParsedCaseFilters, searchQuery string) snC
 		CreTeamIDs:                       uuidsToSysids(parsed.CreTeamIDs),
 		SreTeamIDs:                       uuidsToSysids(parsed.SreTeamIDs),
 		AccountIDs:                       uuidsToSysids(parsed.AccountIDs),
+		ExcludeAccountIDs:                uuidsToSysids(parsed.ExcludeAccountIDs),
 		Unassigned:                       parsed.Unassigned,
 		ResolutionNotesEmpty:             parsed.ResolutionNotesEmpty,
 		TaskSLAFilter:                    buildSNTaskSLAFilter(parsed.TaskSLAFilter),
@@ -3575,6 +3583,9 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 		return domain.SearchCasesResponse{}, err
 	}
 	if err := validateUUIDs("accountId", req.Parsed.AccountIDs); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+	if err := validateUUIDs("accountId", req.Parsed.ExcludeAccountIDs); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
 
@@ -3896,6 +3907,9 @@ func (s *snCaseService) AggregateCases(ctx context.Context, req domain.Aggregate
 		return domain.AggregateResponse{}, err
 	}
 	if err := validateUUIDs("accountId", parsed.AccountIDs); err != nil {
+		return domain.AggregateResponse{}, err
+	}
+	if err := validateUUIDs("accountId", parsed.ExcludeAccountIDs); err != nil {
 		return domain.AggregateResponse{}, err
 	}
 	for _, t := range parsed.Types {

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -7610,7 +7610,10 @@ components:
         - **tag** (in / notIn): free-text case tag labels. in matches cases
           carrying any of the given tags; notIn excludes cases carrying any of
           them.
-        - **projectId** (in): project UUIDs.
+        - **projectId** (in / notIn): project UUIDs. in matches cases whose
+          project is any of the given UUIDs; notIn matches cases whose
+          project is none of them. The two are independent and may be
+          combined. notIn is not supported inside an anyOf branch.
         - **deploymentId** (in): deployment UUIDs.
         - **assignedUserId** (in / isEmpty): in matches assigned-engineer user
           UUIDs; isEmpty (values ignored) matches cases with no assigned
@@ -7644,8 +7647,13 @@ components:
           Expansion) team, as team UUIDs.
         - **sreTeam** (in): the parent account's SRE (Site Reliability
           Engineering) team, as team UUIDs.
-        - **accountId** (in): the case's parent customer account, as account
-          UUIDs.
+        - **accountId** (in / notIn): the case's parent customer account, as
+          account UUIDs. in matches cases whose account is any of the given
+          UUIDs; notIn matches cases whose account is none of them. The two
+          are independent and may be combined. notIn is not supported inside
+          an anyOf branch, and not supported by the relational data source
+          (accountId+in has no relational-data-source query support today
+          either).
         - **resolutionNotes** (isEmpty): values ignored; matches cases with
           empty resolution notes. isNotEmpty is not supported: false and
           omitted were always treated identically for this filter, so there


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The case advanced filters builder supported "is one of" for Project but had no exclusion form, and had no Account filter at all — even though the entity-service already accepted `accountId`+`in`.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Add `notIn` ("is not one of") to the existing Project row.
- Add a new Account field to the advanced filters builder, supporting both `in` and `notIn`.
- Widen the entity-service's case-search filter DSL (`projectId`/`accountId`) to accept `notIn`, for both the Postgres repository and the ServiceNow-backed service.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- `entity-service`: new `ExcludeProjectIDs`/`ExcludeAccountIDs` on `ParsedCaseFilters`; `case_filters.go` accepts `notIn` for both fields (mirroring the existing `state`/`tag` pattern); Postgres repo gained the `projectId` exclusion clause; the ServiceNow-backed service forwards the two new filter keys.
- Webapp: `advancedFilters.ts` gained `notIn` on the `projectId` row and a new `accountId` field entry; a new `AsyncAccountMultiSelect` component (mirroring the existing `AsyncProjectMultiSelect`) backed by a new `useInfiniteAccountSearch` hook against the existing `POST /accounts/search` endpoint.
- Both new field/op combinations round-trip through the existing untyped advanced-filters URL mechanism (no `CasesFilters` schema change needed), the same way `deploymentId`/`number` already do.

Note: `accountId` filtering has no Postgres repository implementation yet (pre-existing gap, not introduced by this PR) — tracked separately.

## User stories
> Summary of user stories addressed by this change>

As a CS engineer, I can exclude cases belonging to specific projects or accounts (not just include them) when building an advanced case filter, and I can filter by account at all in the advanced builder.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Advanced case filters now support "is not one of" for Project, and a new Account filter (is one of / is not one of).

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A — the in-app `/help` advanced-filters topic already describes the builder generically (field/op/value shape); no specific field list is documented there to update.

## Training
N/A — no training-content impact.

## Certification
N/A — no certification-exam impact.

## Marketing
N/A — internal CS-tooling change, no customer-facing marketing surface.

## Automation tests
 - Unit tests
   > New/updated: `entity-service/internal/service/case_filters_test.go` (projectId/accountId notIn translation + rejection cases, OR-group rejection); `advancedFilters.test.ts` (catalogue coverage for both new op/field combos); `casesFiltersUrl.test.ts` (URL round-trip). Full webapp suite: 2611/2611 passing (8 pre-existing, unrelated failing suites confirmed present on `main` too — missing local `CSM_PORTAL_BACKEND_BASE_URL` config).
 - Integration tests
   > None added; existing `go test ./...` passes for entity-service.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (not a Java component)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
> List any other related PRs

A corresponding Ballerina entity-service change (adding the two new filter keys to the shared case-search filter contract), tracked separately.

## Migrations (if applicable)
N/A

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Local: Go (entity-service module toolchain), Node/pnpm (webapp), macOS.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Followed this repo's existing `state`/`tag` `in`/`notIn` precedent in `case_filters.go` and the existing `AsyncProjectMultiSelect` component shape for the new async account picker.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added account ID filtering to case searches with selectable accounts and paginated search results.
  - Added `notIn` filtering for project IDs and account IDs.
  - Project and account filters can be combined with their corresponding inclusion filters.

- **Bug Fixes**
  - Preserved advanced filter selections when sharing or reloading search URLs.

- **Documentation**
  - Documented filter compatibility, including limitations for OR groups and certain data sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->