### PR TITLE
[Customer Portal] Allow email watch lists longer than 50 on case PATCH

### DIFF
--- a/entity-service/internal/service/sn_watch_list.go
+++ b/entity-service/internal/service/sn_watch_list.go
@@ -117,9 +117,11 @@ func resolveWatchListIdentities(
 
 // watchListEmails returns the email addresses the backing service's case
 // create, case update, and incident create payloads declare. Incoming emails
-// (Customer Portal) are forwarded in the caller's order with no lookup.
+// (Customer Portal) are forwarded in the caller's order with no lookup and
+// no length cap (Ballerina; existing SN cases often exceed 50 watchers).
 // Incoming platform UUIDs (CSM) are resolved to emails first — forwarding
-// ids verbatim is silently accepted upstream and drops every watcher.
+// ids verbatim is silently accepted upstream and drops every watcher — and
+// are capped at maxUserLimit because resolution is one /users/search page.
 // A mixed list, or a value that is neither an email nor a UUID, is a
 // validation error. The returned slice is non-nil and in the caller's order.
 func watchListEmails(
@@ -127,11 +129,6 @@ func watchListEmails(
 ) ([]string, error) {
 	if len(values) == 0 {
 		return []string{}, nil
-	}
-	if len(values) > maxUserLimit {
-		return nil, &apierror.ValidationError{
-			Msg: fmt.Sprintf("%s cannot contain more than %d values", field, maxUserLimit),
-		}
 	}
 
 	allEmail := true
@@ -152,6 +149,10 @@ func watchListEmails(
 	}
 
 	if allEmail {
+		// Emails are forwarded as-is (Ballerina / Customer Portal). The 50-item
+		// cap below exists only because UUID resolution is a single
+		// /users/search page; it must not reject an existing SN watch list that
+		// is already larger than that page size.
 		out := make([]string, len(values))
 		copy(out, values)
 		return out, nil
@@ -164,6 +165,12 @@ func watchListEmails(
 		}
 		return nil, &apierror.ValidationError{
 			Msg: fmt.Sprintf("%s items must all be email addresses or all be user identifiers", field),
+		}
+	}
+
+	if len(values) > maxUserLimit {
+		return nil, &apierror.ValidationError{
+			Msg: fmt.Sprintf("%s cannot contain more than %d values", field, maxUserLimit),
 		}
 	}
 

--- a/entity-service/internal/service/sn_watch_list_test.go
+++ b/entity-service/internal/service/sn_watch_list_test.go
@@ -19,6 +19,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -144,6 +145,24 @@ func TestWatchListEmails_ForwardsEmailsWithoutLookup(t *testing.T) {
 		if got[i] != w {
 			t.Fatalf("got[%d] = %q, want %q", i, got[i], w)
 		}
+	}
+}
+
+// TestWatchListEmails_ForwardsMoreThan50Emails pins that the /users/search
+// page cap must not reject a portal email list. Existing SN cases routinely
+// carry more than 50 watchers; PATCH replaces the whole list, so a 50 cap
+// made every save of those cases fail.
+func TestWatchListEmails_ForwardsMoreThan50Emails(t *testing.T) {
+	in := make([]string, maxUserLimit+1)
+	for i := range in {
+		in[i] = fmt.Sprintf("watcher%03d@example.com", i)
+	}
+	got, err := watchListEmails(context.Background(), nil, "token", "watchList", in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(in) {
+		t.Fatalf("got %d emails, want %d", len(got), len(in))
 	}
 }
 


### PR DESCRIPTION
## Purpose

Follow-up to https://github.com/wso2-open-operations/cs-tools/pull/1692. PATCH /cases/{id} with a Watch List of emails succeeded past the UUID check, then failed with `watchList cannot contain more than 50 values` on existing ServiceNow cases whose watch list is already larger than 50.

## Goals

- Customer Portal can save a Watch List of more than 50 emails (the full existing list plus edits).
- CSM UUID watch lists stay capped at 50, because those still resolve through a single /users/search page.

## Approach

watchListEmails forwards an all-email list as-is with no length cap (same as Ballerina). The 50-item check runs only on the all-UUID path before resolveWatchListIdentities.

## User stories

As a Customer Portal user, I can edit the Watch List on a case that already has more than 50 watchers and the save succeeds.

## Release note

Go entity-service no longer rejects Customer Portal email watch lists longer than 50. UUID watch lists remain capped at 50.

## Documentation

N/A — behaviour is described in code comments; OpenAPI already allows an unbounded email array.

## Training

N/A — no training content impact.

## Certification

N/A — no certification exam impact.

## Marketing

N/A

## Automation tests

- Unit tests
  - TestWatchListEmails_ForwardsMoreThan50Emails
  - Existing WatchList tests still pass (`go test ./internal/service/ -count=1 -run WatchList`)

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

https://github.com/wso2-open-operations/cs-tools/pull/1692

## Migrations (if applicable)

N/A

## Test environment

- Go 1.26 locally
- Unit tests against mocked ServiceNow integration client
- Local PATCH on a case with more than 50 existing watchers

## Learning

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Watch lists containing email addresses can now include more than the previous 50-entry limit.
  - Email-based watch lists are forwarded without unnecessary identity lookups or validation errors.
  - Watch lists based on user IDs remain subject to the existing limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->