### PR TITLE
[Customer Portal] Guard case feedback submission against non-closed cases

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/case_enum_mapping.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_enum_mapping.go
@@ -211,6 +211,32 @@ func caseStateLookupKey(label string) string {
 	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(label)), "_", " ")
 }
 
+// caseStateClosed is entity-service's domain enum for a closed case — the key
+// caseStateIDs, caseStateLabelWords, and caseStateDisplayLabels all agree on.
+const caseStateClosed = "closed"
+
+// IsCaseStateClosed reports whether a case state means "closed", accepting
+// every representation this one field travels as: entity-service's domain enum
+// ("closed"), ServiceNow's display text ("Closed"), and the numeric SN
+// choice-list id the frontend still speaks ("3"). Handlers pass
+// entity.CaseView.State, which carries one of the first two depending on the
+// active data source (see SearchCaseView's doc comment); the id form is
+// accepted so a caller holding a portal-facing status id resolves the same way.
+//
+// Exported because the case write guards live in internal/handler but
+// the state vocabulary they need lives here, alongside the tables it is keyed
+// on — a handler must never re-hardcode "closed"/"3" itself.
+func IsCaseStateClosed(state string) bool {
+	trimmed := strings.TrimSpace(state)
+	if trimmed == "" {
+		return false
+	}
+	if caseStateLabelWords[caseStateLookupKey(trimmed)] == caseStateClosed {
+		return true
+	}
+	return caseStateIDToEnum[trimmed] == caseStateClosed
+}
+
 func caseStatusRef(label string) *IDLabelRef {
 	if label == "" {
 		return nil

--- a/apps/customer-portal/backend-v2/internal/dto/case_state_closed_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_state_closed_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "testing"
+
+func TestIsCaseStateClosed(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		// Closed representations
+		{name: "domain enum closed", input: "closed", expected: true},
+		{name: "display label Closed", input: "Closed", expected: true},
+		{name: "uppercase CLOSED", input: "CLOSED", expected: true},
+		{name: "choice list id 3", input: "3", expected: true},
+		{name: "padded closed", input: "  closed  ", expected: true},
+		{name: "padded id 3", input: " 3 ", expected: true},
+
+		// Non-closed representations (domain enum, display label, and numeric id)
+		{name: "domain enum open", input: "open", expected: false},
+		{name: "display label Open", input: "Open", expected: false},
+		{name: "choice list id 1 (open)", input: "1", expected: false},
+		{name: "domain enum work_in_progress", input: "work_in_progress", expected: false},
+		{name: "display label Work In Progress", input: "Work In Progress", expected: false},
+		{name: "choice list id 2 (wip)", input: "2", expected: false},
+		{name: "domain enum waiting_on_wso2", input: "waiting_on_wso2", expected: false},
+		{name: "choice list id 10 (waiting on wso2)", input: "10", expected: false},
+		{name: "domain enum awaiting_info", input: "awaiting_info", expected: false},
+		{name: "choice list id 11 (awaiting info)", input: "11", expected: false},
+		{name: "domain enum solution_proposed", input: "solution_proposed", expected: false},
+		{name: "display label Solution Proposed", input: "Solution Proposed", expected: false},
+		{name: "choice list id 6 (solution proposed)", input: "6", expected: false},
+		{name: "domain enum reopened", input: "reopened", expected: false},
+		{name: "choice list id 13 (reopened)", input: "13", expected: false},
+
+		// Edge cases
+		{name: "empty string", input: "", expected: false},
+		{name: "whitespace only", input: "   ", expected: false},
+		{name: "unknown string", input: "foobar", expected: false},
+		{name: "unknown id", input: "999", expected: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsCaseStateClosed(tc.input)
+			if got != tc.expected {
+				t.Fatalf("IsCaseStateClosed(%q) = %v, want %v", tc.input, got, tc.expected)
+			}
+		})
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/cases.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases.go
@@ -374,7 +374,8 @@ func (h *CaseHandler) GetCaseFeedback(w http.ResponseWriter, r *http.Request) {
 	writeJSONValue(w, http.StatusOK, dto.MapCaseFeedback(result))
 }
 
-// SubmitCaseFeedback handles POST /cases/{id}/feedback.
+// SubmitCaseFeedback handles POST /cases/{id}/feedback. Rejected with 400
+// when the case is not in the closed state.
 func (h *CaseHandler) SubmitCaseFeedback(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -396,6 +397,12 @@ func (h *CaseHandler) SubmitCaseFeedback(w http.ResponseWriter, r *http.Request)
 	var req dto.SubmitCaseFeedbackRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	if caseView, err := h.entity.GetCase(r.Context(), id); err == nil && !dto.IsCaseStateClosed(caseView.State) {
+		slog.WarnContext(r.Context(), "rejected feedback submission on a non-closed case", "userID", user.UserID, "caseID", id, "state", caseView.State)
+		writeError(w, http.StatusBadRequest, ErrMsgCaseNotClosedForFeedback)
 		return
 	}
 

--- a/apps/customer-portal/backend-v2/internal/handler/closed_case_feedback_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/closed_case_feedback_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+type fakeFeedbackCaseClient struct {
+	entityCaseClient
+	caseState      string
+	getCaseErr     error
+	submitFeedback bool
+}
+
+func (f *fakeFeedbackCaseClient) GetCase(ctx context.Context, id string) (entity.CaseView, error) {
+	if f.getCaseErr != nil {
+		return entity.CaseView{}, f.getCaseErr
+	}
+	return entity.CaseView{ID: id, State: f.caseState}, nil
+}
+
+func (f *fakeFeedbackCaseClient) SubmitCaseFeedback(ctx context.Context, caseID string, req entity.SubmitCaseFeedbackRequest) (entity.SubmitCaseFeedbackResponse, error) {
+	f.submitFeedback = true
+	return entity.SubmitCaseFeedbackResponse{
+		Message: "Feedback submitted successfully.",
+		Feedback: entity.CaseFeedbackResult{
+			ID:           "fb-1",
+			AssessmentID: "as-1",
+			CaseID:       caseID,
+			CreatedBy:    "customer@example.com",
+		},
+	}, nil
+}
+
+func decodeFeedbackMessage(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return body.Message
+}
+
+func TestSubmitCaseFeedback_NonClosedCases(t *testing.T) {
+	const validBody = `{"emojiId":"11111111-1111-1111-1111-111111111111","chipIds":["22222222-2222-2222-2222-222222222222"]}`
+	nonClosedStates := []string{
+		"open",
+		"Open",
+		"work_in_progress",
+		"Work In Progress",
+		"waiting_on_wso2",
+		"awaiting_info",
+		"solution_proposed",
+		"Solution Proposed",
+		"reopened",
+	}
+
+	for _, state := range nonClosedStates {
+		t.Run("state_"+state, func(t *testing.T) {
+			fake := &fakeFeedbackCaseClient{caseState: state}
+			h := NewCaseHandler(fake)
+			mux := http.NewServeMux()
+			mux.HandleFunc("POST /cases/{id}/feedback", h.SubmitCaseFeedback)
+
+			req := authedRequest(http.MethodPost, "/cases/"+testCaseID+"/feedback", validBody)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			if got := decodeFeedbackMessage(t, rec); got != ErrMsgCaseNotClosedForFeedback {
+				t.Fatalf("message = %q, want %q", got, ErrMsgCaseNotClosedForFeedback)
+			}
+			if fake.submitFeedback {
+				t.Fatal("SubmitCaseFeedback reached entity-service on a non-closed case")
+			}
+		})
+	}
+}
+
+func TestSubmitCaseFeedback_ClosedCases(t *testing.T) {
+	const validBody = `{"emojiId":"11111111-1111-1111-1111-111111111111","chipIds":["22222222-2222-2222-2222-222222222222"]}`
+	closedStates := []string{"closed", "Closed", "CLOSED", "3"}
+
+	for _, state := range closedStates {
+		t.Run("state_"+state, func(t *testing.T) {
+			fake := &fakeFeedbackCaseClient{caseState: state}
+			h := NewCaseHandler(fake)
+			mux := http.NewServeMux()
+			mux.HandleFunc("POST /cases/{id}/feedback", h.SubmitCaseFeedback)
+
+			req := authedRequest(http.MethodPost, "/cases/"+testCaseID+"/feedback", validBody)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusCreated {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusCreated, rec.Body.String())
+			}
+			if !fake.submitFeedback {
+				t.Fatal("SubmitCaseFeedback was not reached for a closed case")
+			}
+		})
+	}
+}
+
+func TestSubmitCaseFeedback_LookupFailureFailsOpen(t *testing.T) {
+	const validBody = `{"emojiId":"11111111-1111-1111-1111-111111111111","chipIds":["22222222-2222-2222-2222-222222222222"]}`
+
+	fake := &fakeFeedbackCaseClient{
+		getCaseErr: errors.New("upstream timeout"),
+	}
+	h := NewCaseHandler(fake)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cases/{id}/feedback", h.SubmitCaseFeedback)
+
+	req := authedRequest(http.MethodPost, "/cases/"+testCaseID+"/feedback", validBody)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if !fake.submitFeedback {
+		t.Fatal("expected SubmitCaseFeedback to proceed when GetCase fails")
+	}
+}
+
+func TestSubmitCaseFeedback_Unauthenticated(t *testing.T) {
+	h := NewCaseHandler(&fakeFeedbackCaseClient{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cases/{id}/feedback", h.SubmitCaseFeedback)
+
+	req := httptest.NewRequest(http.MethodPost, "/cases/"+testCaseID+"/feedback", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestSubmitCaseFeedback_InvalidUUID(t *testing.T) {
+	h := NewCaseHandler(&fakeFeedbackCaseClient{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cases/{id}/feedback", h.SubmitCaseFeedback)
+
+	req := authedRequest(http.MethodPost, "/cases/not-a-uuid/feedback", `{}`)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	if got := decodeFeedbackMessage(t, rec); got != ErrMsgInvalidUUID {
+		t.Fatalf("message = %q, want %q", got, ErrMsgInvalidUUID)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/response.go
+++ b/apps/customer-portal/backend-v2/internal/handler/response.go
@@ -73,6 +73,11 @@ const (
 	ErrMsgInternal     = "An internal server error occurred. Please try again later."
 	ErrMsgInvalidUUID  = "Invalid UUID format."
 	errMsgReadBody     = "Failed to read request body."
+
+	// Closed-case feedback guard. Matches the Ballerina backend's
+	// ERR_MSG_CASE_NOT_CLOSED_FOR_FEEDBACK constant so both backends reject
+	// non-closed cases with the same message.
+	ErrMsgCaseNotClosedForFeedback = "Cannot submit feedback for a case that is not closed."
 )
 
 // errorBody is the JSON error payload format matching the customer-portal pattern.

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -3928,6 +3928,9 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
     post:
       summary: Submit feedback for a case.
+      description: >
+        Rejected with 400 when the case is not closed: feedback can only be
+        submitted for closed cases.
       operationId: postCasesIdFeedback
       parameters:
         - name: id

--- a/apps/customer-portal/backend/constants.bal
+++ b/apps/customer-portal/backend/constants.bal
@@ -40,6 +40,7 @@ const ERR_MSG_ESCALATION_REASON_REQUIRED = "Reason is required when escalating a
 const ERR_MSG_ESCALATION_INVALID_ACTION = "Invalid action. Allowed values are ESCALATE or DEESCALATE.";
 const ERR_MSG_CASE_NOT_FOUND_FOR_ESCALATION = "The case for which you're trying to create an escalation does not exist.";
 const ERR_MSG_CASE_CLOSED_FOR_ESCALATION = "Cannot create an escalation for a closed case.";
+const ERR_MSG_CASE_NOT_CLOSED_FOR_FEEDBACK = "Cannot submit feedback for a case that is not closed.";
 
 // Default Pagination Values
 public const int DEFAULT_OFFSET = 0;

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -2456,6 +2456,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # Submit feedback for a specific case.
     #
     # + id - ID of the case
+    # + payload - Submitted feedback payload
     # + return - Submitted feedback response or error response
     resource function post cases/[entity:IdString id]/feedback(http:RequestContext ctx,
             types:CaseFeedbackPayload payload)
@@ -2466,6 +2467,16 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             return <http:InternalServerError>{
                 body: {
                     message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        entity:CaseResponse|error caseResponse = entity:getCase(userInfo.idToken, id);
+        if caseResponse is entity:CaseResponse && !isCaseClosed(caseResponse) {
+            log:printWarn(string `User: ${userInfo.userId} attempted to submit feedback for non-closed case: ${id}`);
+            return <http:BadRequest>{
+                body: {
+                    message: ERR_MSG_CASE_NOT_CLOSED_FOR_FEEDBACK
                 }
             };
         }

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1484,3 +1484,19 @@ public isolated function mapDeployedProductMetricsUsageCounts(
         chartData
     };
 }
+
+# Check whether a case is closed.
+#
+# + caseResponse - Case response record from entity service
+# + return - True if the case is closed, false otherwise
+public isolated function isCaseClosed(entity:CaseResponse caseResponse) returns boolean {
+    entity:ChoiceListItem? state = caseResponse.state;
+    if state !is () {
+        string label = state.label.toLowerAscii().trim();
+        string id = state.id.toString().toLowerAscii().trim();
+        if label == "closed" || id == "closed" || id == "3" {
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
## Purpose
In the Customer Portal, case feedback is intended to be submitted only when a case is resolved and closed (prompted when a user accepts a solution or closes a case, and only rendered on closed cases). However, the backend endpoints did not enforce case state validation. Direct API invocations allowed submitting feedback for cases in any state (e.g. Open, Work in Progress, Waiting on WSO2), bypassing the intended lifecycle.

## Goals
- Restrict feedback submission to closed cases across both the Ballerina backend and Go backend-v2 (`POST /cases/{id}/feedback`).
- Return HTTP `400 Bad Request` with a clear, consistent error message (`"Cannot submit feedback for a case that is not closed."`) when feedback submission is attempted on a non-closed case.
- Ensure fail-open resiliency so transient `GetCase` lookup failures do not block legitimate submissions.

## Approach
1. **Ballerina Backend (`apps/customer-portal/backend`)**:
   - Added `isCaseClosed(entity:CaseResponse caseResponse) returns boolean` helper function in `utils.bal` checking state label and ID (`"closed"` or `"3"`).
   - Added error constant in `constants.bal`:
     - `ERR_MSG_CASE_NOT_CLOSED_FOR_FEEDBACK` ("Cannot submit feedback for a case that is not closed.")
   - In `service.bal`:
     - Guarded `POST /cases/[entity:IdString id]/feedback` by fetching the case via `entity:getCase` and rejecting with HTTP 400 if the case is not closed.

2. **Go Backend-v2 (`apps/customer-portal/backend-v2`)**:
   - Added `IsCaseStateClosed(state string) bool` in `internal/dto/case_enum_mapping.go` handling domain enum (`"closed"`), ServiceNow label (`"Closed"`), and numeric ID (`"3"`).
   - Added error constant `ErrMsgCaseNotClosedForFeedback` in `internal/handler/response.go`.
   - In `internal/handler/cases.go`:
     - Guarded `SubmitCaseFeedback` (`POST /cases/{id}/feedback`) by fetching the case via `h.entity.GetCase` and rejecting with HTTP 400 if the case is not closed.
   - Documented the 400 rejection in `openapi.yaml`.
   - Added unit tests in `internal/dto/case_state_closed_test.go` and `internal/handler/closed_case_feedback_test.go`.

## User stories
N/A

## Release note
- [Customer Portal] Enforce backend-level validation to restrict case feedback submission to closed cases.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests:
  - `apps/customer-portal/backend-v2/internal/dto/case_state_closed_test.go`: covers domain enum, ServiceNow label, uppercase, and numeric ID permutations.
  - `apps/customer-portal/backend-v2/internal/handler/closed_case_feedback_test.go`: covers `SubmitCaseFeedback` for non-closed cases, closed cases, lookup failures, unauthenticated requests, and invalid UUIDs.
- All Go tests passing with `go test -race ./...`.
- Verified Ballerina compilation with `bal pack`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
- macOS, Go 1.22+, Ballerina 2201.12.10

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feedback can now be submitted only for cases in the closed state.
  * Closed-state detection supports standard labels, numeric status values, capitalization differences, and extra spaces.
* **Bug Fixes**
  * Attempts to submit feedback for non-closed cases now return a clear 400 error message.
  * Existing authentication and invalid-case validation behavior remains supported.
* **Documentation**
  * API documentation now explains that feedback is restricted to closed cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->