### PR TITLE
[Customer Portal v2] Accept both id shapes on every path parameter

### DIFF
--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -703,8 +703,29 @@ struct actually carries it), and a stray extra check on `PATCH` would just be de
 - **Auth**: always check `middleware.UserInfoFromContext(r.Context()) == nil` first → 401.
 - **Body size**: use the shared `readJSONBody(w, r)` helper (`internal/handler/response.go`) — caps
   at `maxRequestBodyBytes` (1 MiB) and validates the body is well-formed JSON.
-- **Path params**: guard against empty string after `r.PathValue("id")`; validate UUID-shaped IDs
-  with the package-level `uuidRe` and return 400 on mismatch before calling entity-service.
+- **Path params**: normalize an id-shaped path param with `toDashedID(r.PathValue("id"))`, then
+  validate it with `isEntityID` and return 400 on mismatch before calling entity-service. Do **not**
+  validate with `uuidRe` directly — an id reaches this API in two shapes (the dashed UUID
+  entity-service returns, and the bare 32-hex ServiceNow sysid the same value has upstream), and
+  `uuidRe` alone rejected every dashless one with `Invalid UUID format.` before it ever left this
+  backend. That was reported from staging as `GET /projects/<32-hex sysid>` → 400, from a URL
+  carrying the dashless form; the customer-portal webapp, unlike the CSM portal's
+  `useNormalizedIdParam`, does not repair such a URL itself.
+  - **Normalize to the dashed form, never to a sysid.** It is the only shape both entity-service
+    data sources accept: the ServiceNow path strips the hyphens itself (`uuidToSysid`, which
+    passes a non-canonical value through unchanged), but the Postgres path runs `validateUUIDs`
+    and rejects a dashless id outright. `internal/dto`'s `toSysID` (call requests, deployed
+    products) goes the other way on purpose — both of those endpoints are ServiceNow-only, so
+    the Postgres constraint doesn't apply there; don't copy that direction onto a route that
+    exists on both data sources.
+  - **Request-body id fields stay strict `uuidRe`** (`dto.CommentCreateRequest.ReferenceID`,
+    `CreateCaseRequest.ConversationID`, and the WebSocket message's own `conversationId`), and
+    `openapi.yaml` keeps `format: uuid` on exactly those — the app builds them from an
+    entity-service response, which is always dashed, so there is no dashless source to
+    accommodate. Every *path* parameter in the spec declares the two-shape `pattern` instead.
+  - `isAttachmentID` is the same predicate as `isEntityID` under a route-specific name; the
+    attachment routes deliberately forward the id verbatim without normalizing (fetched straight
+    from ServiceNow by sysid, no Postgres path to satisfy).
 - **Upstream errors**: always use `mapUpstreamError(w, err, "<fallback message>")` — never write
   custom status mappings inline. For a 400, this now returns entity-service's own message
   (`apiErr.Body`) verbatim to the caller instead of a generic string — entity-service's validation

--- a/apps/customer-portal/backend-v2/internal/handler/accounts.go
+++ b/apps/customer-portal/backend-v2/internal/handler/accounts.go
@@ -80,8 +80,8 @@ func (h *AccountHandler) GetAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/ai_chat.go
+++ b/apps/customer-portal/backend-v2/internal/handler/ai_chat.go
@@ -152,8 +152,8 @@ func (h *AIChatHandler) SearchConversations(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -189,8 +189,8 @@ func (h *AIChatHandler) GetConversationMessages(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	conversationID := r.PathValue("id")
-	if conversationID == "" || !uuidRe.MatchString(conversationID) {
+	conversationID := toDashedID(r.PathValue("id"))
+	if conversationID == "" || !isEntityID(conversationID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -237,8 +237,8 @@ func (h *AIChatHandler) CreateConversation(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -347,9 +347,9 @@ func (h *AIChatHandler) SendConversationMessage(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	projectID := r.PathValue("projectId")
-	conversationID := r.PathValue("conversationId")
-	if !uuidRe.MatchString(projectID) || !uuidRe.MatchString(conversationID) {
+	projectID := toDashedID(r.PathValue("projectId"))
+	conversationID := toDashedID(r.PathValue("conversationId"))
+	if !isEntityID(projectID) || !isEntityID(conversationID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -430,8 +430,8 @@ func (h *AIChatHandler) GetConversation(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -455,8 +455,8 @@ func (h *AIChatHandler) UpdateConversation(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -495,9 +495,9 @@ func (h *AIChatHandler) GetConversationSummary(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	projectID := r.PathValue("id")
-	conversationID := r.PathValue("conversationId")
-	if !uuidRe.MatchString(projectID) || !uuidRe.MatchString(conversationID) {
+	projectID := toDashedID(r.PathValue("id"))
+	conversationID := toDashedID(r.PathValue("conversationId"))
+	if !isEntityID(projectID) || !isEntityID(conversationID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/call_requests.go
+++ b/apps/customer-portal/backend-v2/internal/handler/call_requests.go
@@ -56,8 +56,8 @@ func (h *CallRequestHandler) CreateCallRequest(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	caseID := r.PathValue("caseId")
-	if caseID == "" || !uuidRe.MatchString(caseID) {
+	caseID := toDashedID(r.PathValue("caseId"))
+	if caseID == "" || !isEntityID(caseID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -99,8 +99,8 @@ func (h *CallRequestHandler) SearchCallRequests(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	caseID := r.PathValue("caseId")
-	if caseID == "" || !uuidRe.MatchString(caseID) {
+	caseID := toDashedID(r.PathValue("caseId"))
+	if caseID == "" || !isEntityID(caseID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -137,8 +137,8 @@ func (h *CallRequestHandler) PatchCallRequest(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/cases.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases.go
@@ -63,8 +63,8 @@ func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -98,8 +98,8 @@ func (h *CaseHandler) SearchCaseAttachments(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -131,8 +131,8 @@ func (h *CaseHandler) CreateCaseAttachment(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -166,8 +166,8 @@ func (h *CaseHandler) GetCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -237,8 +237,8 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -284,8 +284,8 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -323,8 +323,8 @@ func (h *CaseHandler) SearchCaseActivities(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -358,8 +358,8 @@ func (h *CaseHandler) GetCaseFeedback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -382,8 +382,8 @@ func (h *CaseHandler) SubmitCaseFeedback(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -421,9 +421,9 @@ func (h *CaseHandler) PatchCaseAttachment(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	caseID := r.PathValue("caseId")
-	attachmentID := r.PathValue("attachmentId")
-	if !uuidRe.MatchString(caseID) || !uuidRe.MatchString(attachmentID) {
+	caseID := toDashedID(r.PathValue("caseId"))
+	attachmentID := toDashedID(r.PathValue("attachmentId"))
+	if !isEntityID(caseID) || !isEntityID(attachmentID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -459,8 +459,8 @@ func (h *CaseHandler) CreateCaseEscalation(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	caseID := r.PathValue("caseId")
-	if !uuidRe.MatchString(caseID) {
+	caseID := toDashedID(r.PathValue("caseId"))
+	if !isEntityID(caseID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -501,8 +501,8 @@ func (h *CaseHandler) SearchCaseEscalations(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	caseID := r.PathValue("caseId")
-	if !uuidRe.MatchString(caseID) {
+	caseID := toDashedID(r.PathValue("caseId"))
+	if !isEntityID(caseID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/catalogs.go
+++ b/apps/customer-portal/backend-v2/internal/handler/catalogs.go
@@ -52,8 +52,8 @@ func (h *CatalogHandler) SearchCatalogs(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	deployedProductID := r.PathValue("deployedProductId")
-	if !uuidRe.MatchString(deployedProductID) {
+	deployedProductID := toDashedID(r.PathValue("deployedProductId"))
+	if !isEntityID(deployedProductID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -87,9 +87,9 @@ func (h *CatalogHandler) GetCatalogItemVariables(w http.ResponseWriter, r *http.
 		return
 	}
 
-	catalogID := r.PathValue("catalogId")
-	catalogItemID := r.PathValue("itemId")
-	if !uuidRe.MatchString(catalogID) || !uuidRe.MatchString(catalogItemID) {
+	catalogID := toDashedID(r.PathValue("catalogId"))
+	catalogItemID := toDashedID(r.PathValue("itemId"))
+	if !isEntityID(catalogID) || !isEntityID(catalogItemID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/change_requests.go
+++ b/apps/customer-portal/backend-v2/internal/handler/change_requests.go
@@ -92,8 +92,8 @@ func (h *ChangeRequestHandler) SearchChangeRequests(w http.ResponseWriter, r *ht
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -127,8 +127,8 @@ func (h *ChangeRequestHandler) GetChangeRequest(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -151,8 +151,8 @@ func (h *ChangeRequestHandler) PatchChangeRequest(w http.ResponseWriter, r *http
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -190,8 +190,8 @@ func (h *ChangeRequestHandler) GetChangeRequestApprovals(w http.ResponseWriter, 
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -214,8 +214,8 @@ func (h *ChangeRequestHandler) DecideChangeRequestApproval(w http.ResponseWriter
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/contacts.go
+++ b/apps/customer-portal/backend-v2/internal/handler/contacts.go
@@ -67,8 +67,8 @@ func (h *ContactHandler) GetProjectContacts(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -99,8 +99,8 @@ func (h *ContactHandler) CreateProjectContact(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -144,9 +144,9 @@ func (h *ContactHandler) RemoveProjectContact(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	projectID := r.PathValue("id")
+	projectID := toDashedID(r.PathValue("id"))
 	email := r.PathValue("email")
-	if projectID == "" || !uuidRe.MatchString(projectID) || email == "" {
+	if projectID == "" || !isEntityID(projectID) || email == "" {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
@@ -177,9 +177,9 @@ func (h *ContactHandler) UpdateProjectContactRole(w http.ResponseWriter, r *http
 		return
 	}
 
-	projectID := r.PathValue("id")
+	projectID := toDashedID(r.PathValue("id"))
 	email := r.PathValue("email")
-	if projectID == "" || !uuidRe.MatchString(projectID) || email == "" {
+	if projectID == "" || !isEntityID(projectID) || email == "" {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
@@ -219,8 +219,8 @@ func (h *ContactHandler) ValidateProjectContact(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/deployed_products.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployed_products.go
@@ -56,8 +56,8 @@ func (h *DeployedProductHandler) SearchDeployedProducts(w http.ResponseWriter, r
 		return
 	}
 
-	deploymentID := r.PathValue("deploymentId")
-	if deploymentID == "" || !uuidRe.MatchString(deploymentID) {
+	deploymentID := toDashedID(r.PathValue("deploymentId"))
+	if deploymentID == "" || !isEntityID(deploymentID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -94,8 +94,8 @@ func (h *DeployedProductHandler) CreateDeployedProduct(w http.ResponseWriter, r 
 		return
 	}
 
-	deploymentID := r.PathValue("deploymentId")
-	if deploymentID == "" || !uuidRe.MatchString(deploymentID) {
+	deploymentID := toDashedID(r.PathValue("deploymentId"))
+	if deploymentID == "" || !isEntityID(deploymentID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -136,9 +136,9 @@ func (h *DeployedProductHandler) PatchDeployedProduct(w http.ResponseWriter, r *
 		return
 	}
 
-	deploymentID := r.PathValue("deploymentId")
-	id := r.PathValue("id")
-	if deploymentID == "" || !uuidRe.MatchString(deploymentID) || id == "" || !uuidRe.MatchString(id) {
+	deploymentID := toDashedID(r.PathValue("deploymentId"))
+	id := toDashedID(r.PathValue("id"))
+	if deploymentID == "" || !isEntityID(deploymentID) || id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -205,9 +205,9 @@ func (h *DeployedProductHandler) SearchDeployedProductMetrics(w http.ResponseWri
 		return
 	}
 
-	deploymentID := r.PathValue("deploymentId")
-	productID := r.PathValue("productId")
-	if !uuidRe.MatchString(deploymentID) || !uuidRe.MatchString(productID) {
+	deploymentID := toDashedID(r.PathValue("deploymentId"))
+	productID := toDashedID(r.PathValue("productId"))
+	if !isEntityID(deploymentID) || !isEntityID(productID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -246,9 +246,9 @@ func (h *DeployedProductHandler) SearchDeployedProductUsageCounts(w http.Respons
 		return
 	}
 
-	deploymentID := r.PathValue("deploymentId")
-	productID := r.PathValue("productId")
-	if !uuidRe.MatchString(deploymentID) || !uuidRe.MatchString(productID) {
+	deploymentID := toDashedID(r.PathValue("deploymentId"))
+	productID := toDashedID(r.PathValue("productId"))
+	if !isEntityID(deploymentID) || !isEntityID(productID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/deployments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployments.go
@@ -56,8 +56,8 @@ func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -100,8 +100,8 @@ func (h *DeploymentHandler) CreateDeployment(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -139,8 +139,8 @@ func (h *DeploymentHandler) PatchDeployment(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -190,9 +190,9 @@ func (h *DeploymentHandler) PatchDeploymentAttachment(w http.ResponseWriter, r *
 		return
 	}
 
-	deploymentID := r.PathValue("deploymentId")
-	attachmentID := r.PathValue("attachmentId")
-	if !uuidRe.MatchString(deploymentID) || !uuidRe.MatchString(attachmentID) {
+	deploymentID := toDashedID(r.PathValue("deploymentId"))
+	attachmentID := toDashedID(r.PathValue("attachmentId"))
+	if !isEntityID(deploymentID) || !isEntityID(attachmentID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -232,8 +232,8 @@ func (h *DeploymentHandler) SearchDeploymentAttachments(w http.ResponseWriter, r
 		return
 	}
 
-	deploymentID := r.PathValue("deploymentId")
-	if deploymentID == "" || !uuidRe.MatchString(deploymentID) {
+	deploymentID := toDashedID(r.PathValue("deploymentId"))
+	if deploymentID == "" || !isEntityID(deploymentID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -265,8 +265,8 @@ func (h *DeploymentHandler) CreateDeploymentAttachment(w http.ResponseWriter, r 
 		return
 	}
 
-	deploymentID := r.PathValue("deploymentId")
-	if deploymentID == "" || !uuidRe.MatchString(deploymentID) {
+	deploymentID := toDashedID(r.PathValue("deploymentId"))
+	if deploymentID == "" || !isEntityID(deploymentID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/entity_id_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/entity_id_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// The same synthetic identifier in both shapes it reaches this API as. A
+// dashless id like this one, on a real detail route, used to answer
+// {"message":"Invalid UUID format."} — the handler required the dashed form,
+// so entity-service never saw the request at all.
+const (
+	testDashlessID = "a1b2c3d4e5f60718293a4b5c6d7e8f90"
+	testDashedID   = "a1b2c3d4-e5f6-0718-293a-4b5c6d7e8f90"
+)
+
+// TestToDashedID pins the normalization every id path parameter now runs
+// through. The dashed form is what gets forwarded upstream because it is the
+// only shape both entity-service data sources accept — ServiceNow strips the
+// hyphens itself, Postgres validates them.
+func TestToDashedID(t *testing.T) {
+	tests := map[string]struct {
+		in   string
+		want string
+	}{
+		"bare sysid gains hyphens":      {in: testDashlessID, want: testDashedID},
+		"uppercase sysid keeps case":    {in: "A1B2C3D4E5F60718293A4B5C6D7E8F90", want: "A1B2C3D4-E5F6-0718-293A-4B5C6D7E8F90"},
+		"dashed uuid is untouched":      {in: testDashedID, want: testDashedID},
+		"empty is untouched":            {in: "", want: ""},
+		"31 hex is untouched":           {in: "a1b2c3d4e5f60718293a4b5c6d7e8f9", want: "a1b2c3d4e5f60718293a4b5c6d7e8f9"},
+		"33 hex is untouched":           {in: "a1b2c3d4e5f60718293a4b5c6d7e8f900", want: "a1b2c3d4e5f60718293a4b5c6d7e8f900"},
+		"non-hex is untouched":          {in: "a1b2c3d4e5f60718293a4b5c6d7e8fzz", want: "a1b2c3d4e5f60718293a4b5c6d7e8fzz"},
+		"path traversal is untouched":   {in: "../../secrets", want: "../../secrets"},
+		"already-dashed junk untouched": {in: "not-an-id", want: "not-an-id"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := toDashedID(tc.in); got != tc.want {
+				t.Fatalf("toDashedID(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsEntityID covers the widened predicate: both id shapes are accepted,
+// and anything that is neither is still refused so it can never reach an
+// upstream URL path.
+func TestIsEntityID(t *testing.T) {
+	valid := []string{
+		testDashedID,
+		testDashlessID,
+		"A1B2C3D4-E5F6-0718-293A-4B5C6D7E8F90",
+		"A1B2C3D4E5F60718293A4B5C6D7E8F90",
+	}
+	for _, id := range valid {
+		if !isEntityID(id) {
+			t.Errorf("isEntityID(%q) = false, want true", id)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"   ",
+		"a1b2c3d4",
+		"a1b2c3d4e5f60718293a4b5c6d7e8f9",   // 31 hex
+		"a1b2c3d4e5f60718293a4b5c6d7e8f900", // 33 hex
+		"a1b2c3d4e5f60718293a4b5c6d7e8fzz",  // non-hex
+		"a1b2c3d4-e5f6-0718-4b5c6d7e8f90",   // missing a group
+		"../../secrets",
+		testDashedID + "/../other",
+		testDashedID + "?x=1",
+	}
+	for _, id := range invalid {
+		if isEntityID(id) {
+			t.Errorf("isEntityID(%q) = true, want false", id)
+		}
+	}
+}
+
+// fakeEntityProjectClient records the id GetProject was called with.
+// entityProjectClient is embedded (nil) so only the method under test needs
+// implementing.
+type fakeEntityProjectClient struct {
+	entityProjectClient
+	gotID  string
+	called bool
+}
+
+func (f *fakeEntityProjectClient) GetProject(ctx context.Context, id string) (entity.ProjectDetailsView, error) {
+	f.gotID = id
+	f.called = true
+	return entity.ProjectDetailsView{ID: id}, nil
+}
+
+// TestGetProject_AcceptsDashlessID is the regression test for the reported
+// staging 400. It goes through a real http.ServeMux registered with the exact
+// pattern main.go uses, and asserts both halves of the fix: the dashless id is
+// no longer rejected, and what reaches entity-service is the dashed form (a
+// dashless id forwarded verbatim would work on a ServiceNow deployment and 400
+// on a Postgres one, whose GetProjectByID runs validateUUIDs).
+func TestGetProject_AcceptsDashlessID(t *testing.T) {
+	tests := map[string]struct {
+		id         string
+		wantStatus int
+		wantSentID string
+	}{
+		"dashless sysid": {id: testDashlessID, wantStatus: http.StatusOK, wantSentID: testDashedID},
+		"dashed uuid":    {id: testDashedID, wantStatus: http.StatusOK, wantSentID: testDashedID},
+		"neither shape":  {id: "a1b2c3d4", wantStatus: http.StatusBadRequest},
+		"path traversal": {id: "..%2F..%2Fsecrets", wantStatus: http.StatusBadRequest},
+		"trailing junk":  {id: testDashlessID + "x", wantStatus: http.StatusBadRequest},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fake := &fakeEntityProjectClient{}
+			h := NewProjectHandler(fake)
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("GET /projects/{id}", h.GetProject)
+
+			req := authedRequest(http.MethodGet, "/projects/"+tc.id, "")
+			rec := httptest.NewRecorder()
+
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.wantStatus != http.StatusOK {
+				if fake.called {
+					t.Errorf("entity-service GetProject was called with a malformed id (%q)", fake.gotID)
+				}
+				return
+			}
+			if fake.gotID != tc.wantSentID {
+				t.Fatalf("entity-service GetProject got id %q, want %q", fake.gotID, tc.wantSentID)
+			}
+		})
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/instances.go
+++ b/apps/customer-portal/backend-v2/internal/handler/instances.go
@@ -79,7 +79,7 @@ func (h *InstanceHandler) searchInstances(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
 		return
 	}
-	if !uuidRe.MatchString(pathID) {
+	if !isEntityID(pathID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -121,20 +121,20 @@ func (h *InstanceHandler) searchInstances(w http.ResponseWriter, r *http.Request
 
 // SearchProjectInstances handles POST /projects/{id}/instances/search.
 func (h *InstanceHandler) SearchProjectInstances(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstances(w, r, projectScope(id), id, "project")
 }
 
 // SearchDeploymentInstances handles POST /deployments/{id}/instances/search.
 func (h *InstanceHandler) SearchDeploymentInstances(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstances(w, r, deploymentScope(id), id, "deployment")
 }
 
 // SearchDeployedProductInstances handles
 // POST /deployments/products/{id}/instances/search.
 func (h *InstanceHandler) SearchDeployedProductInstances(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstances(w, r, deployedProductScope(id), id, "deployed product")
 }
 
@@ -146,7 +146,7 @@ func (h *InstanceHandler) searchInstanceMetrics(w http.ResponseWriter, r *http.R
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
 		return
 	}
-	if !uuidRe.MatchString(pathID) {
+	if !isEntityID(pathID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -181,20 +181,20 @@ func (h *InstanceHandler) searchInstanceMetrics(w http.ResponseWriter, r *http.R
 
 // SearchProjectInstanceMetrics handles POST /projects/{id}/instances/metrics/search.
 func (h *InstanceHandler) SearchProjectInstanceMetrics(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceMetrics(w, r, projectScope(id), id, "project")
 }
 
 // SearchDeploymentInstanceMetrics handles POST /deployments/{id}/instances/metrics/search.
 func (h *InstanceHandler) SearchDeploymentInstanceMetrics(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceMetrics(w, r, deploymentScope(id), id, "deployment")
 }
 
 // SearchDeployedProductInstanceMetrics handles
 // POST /deployments/products/{id}/instances/metrics/search.
 func (h *InstanceHandler) SearchDeployedProductInstanceMetrics(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceMetrics(w, r, deployedProductScope(id), id, "deployed product")
 }
 
@@ -206,7 +206,7 @@ func (h *InstanceHandler) searchInstanceUsage(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
 		return
 	}
-	if !uuidRe.MatchString(pathID) {
+	if !isEntityID(pathID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -241,20 +241,20 @@ func (h *InstanceHandler) searchInstanceUsage(w http.ResponseWriter, r *http.Req
 
 // SearchProjectInstanceUsage handles POST /projects/{id}/instances/usages/search.
 func (h *InstanceHandler) SearchProjectInstanceUsage(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceUsage(w, r, projectScope(id), id, "project")
 }
 
 // SearchDeploymentInstanceUsage handles POST /deployments/{id}/instances/usages/search.
 func (h *InstanceHandler) SearchDeploymentInstanceUsage(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceUsage(w, r, deploymentScope(id), id, "deployment")
 }
 
 // SearchDeployedProductInstanceUsage handles
 // POST /deployments/products/{id}/instances/usages/search.
 func (h *InstanceHandler) SearchDeployedProductInstanceUsage(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceUsage(w, r, deployedProductScope(id), id, "deployed product")
 }
 
@@ -271,7 +271,7 @@ func (h *InstanceHandler) searchInstanceMetricsStats(w http.ResponseWriter, r *h
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
 		return
 	}
-	if !uuidRe.MatchString(pathID) {
+	if !isEntityID(pathID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -306,20 +306,20 @@ func (h *InstanceHandler) searchInstanceMetricsStats(w http.ResponseWriter, r *h
 
 // SearchProjectInstanceMetricsStats handles POST /projects/{id}/instances/stats/metrics/search.
 func (h *InstanceHandler) SearchProjectInstanceMetricsStats(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceMetricsStats(w, r, projectScope(id), id, "project")
 }
 
 // SearchDeploymentInstanceMetricsStats handles POST /deployments/{id}/instances/stats/metrics/search.
 func (h *InstanceHandler) SearchDeploymentInstanceMetricsStats(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceMetricsStats(w, r, deploymentScope(id), id, "deployment")
 }
 
 // SearchDeployedProductInstanceMetricsStats handles
 // POST /deployments/products/{id}/instances/stats/metrics/search.
 func (h *InstanceHandler) SearchDeployedProductInstanceMetricsStats(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceMetricsStats(w, r, deployedProductScope(id), id, "deployed product")
 }
 
@@ -331,7 +331,7 @@ func (h *InstanceHandler) searchInstanceUsageStats(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
 		return
 	}
-	if !uuidRe.MatchString(pathID) {
+	if !isEntityID(pathID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -367,19 +367,19 @@ func (h *InstanceHandler) searchInstanceUsageStats(w http.ResponseWriter, r *htt
 
 // SearchProjectInstanceUsageStats handles POST /projects/{id}/instances/stats/usages/search.
 func (h *InstanceHandler) SearchProjectInstanceUsageStats(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceUsageStats(w, r, projectScope(id), id, "project")
 }
 
 // SearchDeploymentInstanceUsageStats handles POST /deployments/{id}/instances/stats/usages/search.
 func (h *InstanceHandler) SearchDeploymentInstanceUsageStats(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceUsageStats(w, r, deploymentScope(id), id, "deployment")
 }
 
 // SearchDeployedProductInstanceUsageStats handles
 // POST /deployments/products/{id}/instances/stats/usages/search.
 func (h *InstanceHandler) SearchDeployedProductInstanceUsageStats(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := toDashedID(r.PathValue("id"))
 	h.searchInstanceUsageStats(w, r, deployedProductScope(id), id, "deployed product")
 }

--- a/apps/customer-portal/backend-v2/internal/handler/product_consumption.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_consumption.go
@@ -76,9 +76,9 @@ func (h *ProductConsumptionHandler) GetDeploymentLicense(w http.ResponseWriter, 
 	// unrecognized ResponseWriter simply keeps the server's default timeout.
 	_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(licenseProvisioningWriteDeadline))
 
-	projectID := r.PathValue("projectId")
-	deploymentID := r.PathValue("deploymentId")
-	if !uuidRe.MatchString(projectID) || !uuidRe.MatchString(deploymentID) {
+	projectID := toDashedID(r.PathValue("projectId"))
+	deploymentID := toDashedID(r.PathValue("deploymentId"))
+	if !isEntityID(projectID) || !isEntityID(deploymentID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/product_vulnerabilities.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_vulnerabilities.go
@@ -96,8 +96,8 @@ func (h *ProductVulnerabilityHandler) GetProductVulnerability(w http.ResponseWri
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/products.go
+++ b/apps/customer-portal/backend-v2/internal/handler/products.go
@@ -133,8 +133,8 @@ func (h *ProductHandler) SearchProductVersions(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/project_stats.go
+++ b/apps/customer-portal/backend-v2/internal/handler/project_stats.go
@@ -62,8 +62,8 @@ func (h *ProjectStatsHandler) GetProjectFilters(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -86,8 +86,8 @@ func (h *ProjectStatsHandler) GetProjectFeatures(w http.ResponseWriter, r *http.
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -113,8 +113,8 @@ func (h *ProjectStatsHandler) GetProjectDashboardStats(w http.ResponseWriter, r 
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -161,8 +161,8 @@ func (h *ProjectStatsHandler) GetProjectCaseStats(w http.ResponseWriter, r *http
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -185,8 +185,8 @@ func (h *ProjectStatsHandler) GetProjectConversationStats(w http.ResponseWriter,
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -211,8 +211,8 @@ func (h *ProjectStatsHandler) GetProjectSupportStats(w http.ResponseWriter, r *h
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -245,8 +245,8 @@ func (h *ProjectStatsHandler) GetProjectTimeCardStats(w http.ResponseWriter, r *
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -275,8 +275,8 @@ func (h *ProjectStatsHandler) GetProjectChangeRequestStats(w http.ResponseWriter
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -300,8 +300,8 @@ func (h *ProjectStatsHandler) SearchProjectCaseTimeCards(w http.ResponseWriter, 
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -347,8 +347,8 @@ func (h *ProjectStatsHandler) GetProjectUsageStats(w http.ResponseWriter, r *htt
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/projects.go
+++ b/apps/customer-portal/backend-v2/internal/handler/projects.go
@@ -80,8 +80,8 @@ func (h *ProjectHandler) GetProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	id := toDashedID(r.PathValue("id"))
+	if id == "" || !isEntityID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/registry.go
+++ b/apps/customer-portal/backend-v2/internal/handler/registry.go
@@ -106,8 +106,8 @@ func (h *RegistryHandler) CreateRegistryToken(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -192,8 +192,8 @@ func (h *RegistryHandler) SearchRegistryTokens(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -282,7 +282,7 @@ func (h *RegistryHandler) DeleteRegistryToken(w http.ResponseWriter, r *http.Req
 	// tokenID is not UUID-validated: the registry service's own token IDs are
 	// not UUID-shaped, so this route takes a plain `string` path param,
 	// unlike the project-scoped registry routes above.
-	tokenID := r.PathValue("id")
+	tokenID := toDashedID(r.PathValue("id"))
 	if tokenID == "" {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
@@ -310,7 +310,7 @@ func (h *RegistryHandler) RegenerateRegistryToken(w http.ResponseWriter, r *http
 	}
 
 	// tokenID is not UUID-validated — see the matching comment in DeleteRegistryToken.
-	tokenID := r.PathValue("id")
+	tokenID := toDashedID(r.PathValue("id"))
 	if tokenID == "" {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
@@ -338,8 +338,8 @@ func (h *RegistryHandler) GetProjectIntegrationUsers(w http.ResponseWriter, r *h
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/response.go
+++ b/apps/customer-portal/backend-v2/internal/handler/response.go
@@ -45,6 +45,42 @@ var uuidRe = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-
 // sysidRe matches a bare ServiceNow sysid: 32 hex characters, no dashes.
 var sysidRe = regexp.MustCompile(`(?i)^[0-9a-f]{32}$`)
 
+// isEntityID reports whether id is a usable entity identifier — either the
+// dashed UUID entity-service returns or the bare 32-hex ServiceNow sysid the
+// same value has upstream.
+//
+// Both shapes genuinely reach this API. Every id in an entity-service response
+// is already dashed (its own sysidToUUID runs on every response id), but
+// plenty of inbound links carry the dashless form: a bookmarked or shared URL,
+// a value copied out of ServiceNow, or an inline comment image, referenced
+// only as `<img src="…/<sysid>.iix">` and so extracted by the frontend as a
+// bare 32-hex sysid. Accepting only the dashed form failed all of those with a
+// flat 400 before this existed — and unlike the CSM portal, whose webapp
+// repairs a dashless id in its own routes (useNormalizedIdParam), the
+// customer-portal webapp has no such redirect.
+func isEntityID(id string) bool {
+	return uuidRe.MatchString(id) || sysidRe.MatchString(id)
+}
+
+// toDashedID returns id in the canonical dashed-UUID form: hyphens inserted at
+// the 8-4-4-4-12 positions when id is a bare 32-hex sysid, unchanged
+// otherwise (already dashed, or not an identifier at all). Validate the result
+// with isEntityID — normalize first, then check.
+//
+// The dashed form is deliberately what gets forwarded upstream, because it is
+// the only shape BOTH entity-service data sources accept. Its ServiceNow path
+// strips the hyphens itself (uuidToSysid), so either shape works there; its
+// Postgres path runs validateUUIDs and rejects a dashless id outright. So
+// normalizing to a sysid instead — what the call-request and deployed-product
+// routes do, both of which are ServiceNow-only endpoints — would work on a
+// ServiceNow deployment and 400 on a Postgres one.
+func toDashedID(id string) string {
+	if !sysidRe.MatchString(id) {
+		return id
+	}
+	return id[0:8] + "-" + id[8:12] + "-" + id[12:16] + "-" + id[16:20] + "-" + id[20:32]
+}
+
 // isAttachmentID reports whether id is a usable attachment identifier — either a
 // dashed UUID or a bare ServiceNow sysid.
 //
@@ -59,8 +95,13 @@ var sysidRe = regexp.MustCompile(`(?i)^[0-9a-f]{32}$`)
 // `entity:IdString`, a plain string alias with no format constraint. This keeps
 // the same contract while still refusing anything that is neither shape, so the
 // value remains safe to place in an upstream URL path.
+//
+// Same predicate as isEntityID, kept under this name because the attachment
+// routes pass the id upstream verbatim rather than normalizing it: an
+// attachment is fetched straight from ServiceNow by sysid, so there is no
+// Postgres path here to make the dashed form the safer one to forward.
 func isAttachmentID(id string) bool {
-	return uuidRe.MatchString(id) || sysidRe.MatchString(id)
+	return isEntityID(id)
 }
 
 // Error message constants matching the customer-portal error vocabulary.

--- a/apps/customer-portal/backend-v2/internal/handler/time_cards.go
+++ b/apps/customer-portal/backend-v2/internal/handler/time_cards.go
@@ -56,8 +56,8 @@ func (h *TimeCardHandler) SearchTimeCards(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	projectID := r.PathValue("id")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	projectID := toDashedID(r.PathValue("id"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -264,8 +264,11 @@ func (h *WebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	projectID := r.URL.Query().Get("sessionId")
-	if projectID == "" || !uuidRe.MatchString(projectID) {
+	// sessionId carries the project id (see this handler's doc comment), and is
+	// normalized like any other URL-supplied id — the value reaches this
+	// listener from a browser-built URL, so it can be the dashless form too.
+	projectID := toDashedID(r.URL.Query().Get("sessionId"))
+	if projectID == "" || !isEntityID(projectID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -134,7 +134,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -232,7 +232,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -281,7 +281,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -330,7 +330,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -381,7 +381,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: caseTypes
           in: query
           required: false
@@ -444,7 +444,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: caseTypes
           in: query
           required: false
@@ -507,7 +507,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: createdBy
           in: query
           required: false
@@ -563,7 +563,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: caseTypes
           in: query
           required: false
@@ -626,7 +626,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: startDate
           in: query
           required: false
@@ -687,7 +687,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -735,7 +735,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -832,7 +832,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -890,7 +890,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -1003,7 +1003,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -1067,7 +1067,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -1125,7 +1125,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -1184,7 +1184,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -1242,7 +1242,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -1301,7 +1301,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -1363,13 +1363,13 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: id
           in: path
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -1531,7 +1531,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -1584,7 +1584,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -1631,7 +1631,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -1680,7 +1680,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -1855,7 +1855,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -1969,7 +1969,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -2025,7 +2025,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -2077,7 +2077,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -2139,7 +2139,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -2189,7 +2189,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -2251,7 +2251,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -2310,7 +2310,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -2372,13 +2372,13 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: id
           in: path
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -2532,13 +2532,13 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: id
           in: path
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -2750,7 +2750,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -2802,7 +2802,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -2857,13 +2857,13 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: itemId
           in: path
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -2918,7 +2918,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -3078,7 +3078,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -3134,7 +3134,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: limit
           in: query
           required: false
@@ -3199,13 +3199,13 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: conversationId
           in: path
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -3263,13 +3263,13 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: conversationId
           in: path
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -3373,13 +3373,13 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: deploymentId
           in: path
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -3601,7 +3601,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -3652,7 +3652,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -3716,7 +3716,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -3777,7 +3777,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: limit
           in: query
           required: false
@@ -3833,7 +3833,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -3888,7 +3888,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -3935,7 +3935,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -3996,7 +3996,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: limit
           in: query
           schema:
@@ -4051,7 +4051,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         required: true
         content:
@@ -4111,13 +4111,13 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: attachmentId
           in: path
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4181,13 +4181,13 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: attachmentId
           in: path
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4248,13 +4248,13 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: productId
           in: path
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4315,13 +4315,13 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: productId
           in: path
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4385,7 +4385,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4449,7 +4449,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4513,7 +4513,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4581,7 +4581,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4646,7 +4646,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4711,7 +4711,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4779,7 +4779,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4844,7 +4844,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4909,7 +4909,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -4974,7 +4974,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -5039,7 +5039,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -5104,7 +5104,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -5169,7 +5169,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -5234,7 +5234,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -5299,7 +5299,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -5364,7 +5364,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -5429,7 +5429,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -5494,7 +5494,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -5559,7 +5559,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -5623,7 +5623,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -5674,7 +5674,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -5828,7 +5828,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       responses:
         "200":
           description: Ok
@@ -5879,7 +5879,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:
@@ -5940,7 +5940,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: email
           in: path
           required: true
@@ -5994,7 +5994,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
         - name: email
           in: path
           required: true
@@ -6065,7 +6065,7 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+            pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})$'
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
## Purpose
Every id path parameter on `backend-v2` required the dashed UUID form and rejected the dashless one outright, so a URL carrying a bare 32-hex ServiceNow sysid answered `{"message":"Invalid UUID format."}` — reported from staging against `GET /projects/{id}`. The 400 is written by this backend's own handler guard, before entity-service is ever called; entity-service itself would have served the request fine (its ServiceNow path runs `uuidToSysid`, which passes a non-canonical value straight through).

> **Scope note:** path (and the WebSocket `sessionId` query) parameters only — the ids that arrive from a URL a person can bookmark, share, or copy out of ServiceNow. Request-body id fields (`CommentCreateRequest.referenceId`, `CreateCaseRequest.conversationId`, the WebSocket message's own `conversationId`) stay strict-UUID: the app builds those from an entity-service response, which is always dashed, so there is no dashless source to accommodate. `openapi.yaml` keeps `format: uuid` on exactly those, so the spec and the code agree on both sides.

## Goals
- A detail-route URL carrying either id shape resolves instead of 400ing, across all 97 paths — not just the one reported.
- One shared helper for it, rather than the per-endpoint normalization added recently for call requests and deployed products.
- Keep refusing anything that is neither shape, so a malformed value can still never reach an upstream URL path.

## Approach
- `internal/handler/response.go` — two helpers: `isEntityID` (dashed UUID **or** bare 32-hex sysid) and `toDashedID` (inserts the hyphens for a sysid; no-op otherwise). `isAttachmentID` now delegates to `isEntityID` — it was already the identical predicate.
- Every id path parameter is read as `toDashedID(r.PathValue("…"))` and validated with `isEntityID` instead of `uuidRe`, across 18 handler files. The `sessionId` query parameter on `GET /ws` gets the same treatment, since it also carries a project id from a browser-built URL.
- **Normalization is to the dashed form, deliberately, because it is the only shape both entity-service data sources accept:** the ServiceNow path strips the hyphens itself, but the Postgres path runs `validateUUIDs` and rejects a dashless id. Normalizing to a sysid instead — as the ServiceNow-only call-request and deployed-product routes do — would work on a ServiceNow deployment and 400 on a Postgres one. Noted in `CLAUDE.md` so the next endpoint follows the same direction.
- `openapi.yaml` — the 93 id path parameters now declare a two-shape `pattern` in place of `format: uuid`.

## User stories
As a customer-portal user, I can open a project/case/deployment link that carries the dashless form of an id and land on the record, instead of getting a validation error.

## Release note
- [Customer Portal] Accept both the dashed-UUID and ServiceNow sysid form of an id in backend-v2 URLs.

## Documentation
N/A — internal API behaviour; the convention is recorded in `apps/customer-portal/backend-v2/CLAUDE.md`.

## Automation tests
- Unit tests (`internal/handler/entity_id_test.go`): `toDashedID` across both shapes, casing, and every near-miss (31/33 hex, non-hex, path traversal); `isEntityID` accept/refuse sets; and a route-level regression test through a real `http.ServeMux` on `GET /projects/{id}` asserting a dashless id now returns 200 **and** that entity-service receives the dashed form — plus that a malformed id still 400s without the upstream ever being called.
- `gofmt -l` clean, `go vet ./...` clean, `make test` (vet + `go test -race ./...`) green, `gosec -fmt=text ./...` 0 issues across 110 files.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go backend change)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- macOS, Go 1.26, `make test` + `gosec` locally. Needs a staging deploy to confirm the originally reported URL against the live ServiceNow data source.
