### PR TITLE
[Customer Portal] Map closedOn and closeNotes on entity-service 

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -317,13 +317,9 @@ type CaseWatchListUser struct {
 //
 // Deliberately excludes entity-service's AutoclosureStep/AutoclosureStateTime
 // and BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta — genuinely
-// CSM-engineer-facing only. SlaResponseTime, CsManager, ClosedBy,
-// CloseNotes (on this read path — it does exist on the PATCH response),
-// HasAutoClosed, FindingsResolved/FindingsTotal, EscalationLevel/
-// IsEscalated, Duration, EngagementStartDate/EngagementEndDate, and
-// Variables are all present on the frontend's type but have no
-// entity-service equivalent at all on CaseView — not fixable in this dto
-// layer alone.
+// CSM-engineer-facing only. CsManager and FindingsResolved/FindingsTotal
+// have no entity-service equivalent on CaseView. CloseNotes is on the
+// GET path (Ballerina CaseResponse.closeNotes) as well as PATCH.
 type CaseDetails struct {
 	ID                    string                       `json:"id"`
 	InternalID            string                       `json:"internalId"`
@@ -367,6 +363,7 @@ type CaseDetails struct {
 	// no frontend consumer, so per CLAUDE.md they stay trimmed until one exists.
 	SLAResponseTime     *string   `json:"slaResponseTime,omitempty"`
 	ClosedBy            *Ref      `json:"closedBy,omitempty"`
+	CloseNotes          *string   `json:"closeNotes,omitempty"`
 	HasAutoClosed       *bool     `json:"hasAutoClosed,omitempty"`
 	EngagementStartDate *string   `json:"engagementStartDate,omitempty"`
 	EngagementEndDate   *string   `json:"engagementEndDate,omitempty"`
@@ -469,6 +466,7 @@ func MapCaseDetails(c entity.CaseView) CaseDetails {
 		FixEta:                c.FixEta,
 		SLAResponseTime:       c.SLAResponseTime,
 		ClosedBy:              mapRef(c.ClosedBy),
+		CloseNotes:            c.CloseNotes,
 		HasAutoClosed:         c.HasAutoClosed,
 		EngagementStartDate:   c.EngagementStartDate,
 		EngagementEndDate:     c.EngagementEndDate,

--- a/apps/customer-portal/backend-v2/internal/dto/case_detail_fields_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_detail_fields_test.go
@@ -31,10 +31,12 @@ func TestMapCaseDetails_ExposesFieldsTheFrontendDeclares(t *testing.T) {
 	sla := "4 hours"
 	start, end := "2026-01-01", "2026-06-30"
 	auto := true
+	notes := "Resolved successfully"
 
 	raw, err := json.Marshal(MapCaseDetails(entity.CaseView{
 		SLAResponseTime:     &sla,
 		ClosedBy:            &entity.EntityRef{ID: "user-1", Name: "Closer"},
+		CloseNotes:          &notes,
 		HasAutoClosed:       &auto,
 		EngagementStartDate: &start,
 		EngagementEndDate:   &end,
@@ -63,6 +65,9 @@ func TestMapCaseDetails_ExposesFieldsTheFrontendDeclares(t *testing.T) {
 	}
 	if cb["id"] != "user-1" {
 		t.Errorf("closedBy.id = %v, want user-1", cb["id"])
+	}
+	if got["closeNotes"] != notes {
+		t.Errorf("closeNotes = %v, want %q", got["closeNotes"], notes)
 	}
 }
 
@@ -103,7 +108,7 @@ func TestMapCaseDetails_OmitsAbsentFields(t *testing.T) {
 	if err := json.Unmarshal(raw, &got); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
-	for _, k := range []string{"slaResponseTime", "closedBy", "hasAutoClosed", "engagementStartDate", "engagementEndDate"} {
+	for _, k := range []string{"slaResponseTime", "closedBy", "closeNotes", "hasAutoClosed", "engagementStartDate", "engagementEndDate"} {
 		if _, present := got[k]; present {
 			t.Errorf("%q present with no upstream value; want omitted", k)
 		}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -785,6 +785,7 @@ type CaseView struct {
 	// Nullable throughout — nil means the upstream gave no value.
 	SLAResponseTime       *string    `json:"slaResponseTime"`
 	ClosedBy              *EntityRef `json:"closedBy"`
+	CloseNotes            *string    `json:"closeNotes"`
 	HasAutoClosed         *bool      `json:"hasAutoClosed"`
 	EngagementStartDate   *string    `json:"engagementStartDate"`
 	EngagementEndDate     *string    `json:"engagementEndDate"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1510,6 +1510,7 @@ type CaseView struct {
 	// Names mirror the Ballerina entity-service CaseResponse record.
 	SLAResponseTime       *string    `json:"slaResponseTime"`
 	ClosedBy              *EntityRef `json:"closedBy"`
+	CloseNotes            *string    `json:"closeNotes"`
 	HasAutoClosed         *bool      `json:"hasAutoClosed"`
 	EngagementStartDate   *string    `json:"engagementStartDate"`
 	EngagementEndDate     *string    `json:"engagementEndDate"`

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -248,7 +248,9 @@ type snCase struct {
 	// not declared here, so encoding/json discarded them. All nullable: an
 	// absent key stays nil rather than becoming a zero value.
 	SLAResponseTime       *string          `json:"slaResponseTime"`
+	ClosedOn              *string          `json:"closedOn"`
 	ClosedBy              *snCaseEntityRef `json:"closedBy"`
+	CloseNotes            *string          `json:"closeNotes"`
 	HasAutoClosed         *bool            `json:"hasAutoClosed"`
 	EngagementStartDate   *string          `json:"engagementStartDate"`
 	EngagementEndDate     *string          `json:"engagementEndDate"`
@@ -1593,6 +1595,13 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		}
 		cv.ResolvedOn = &resolvedOn
 	}
+	if c.ClosedOn != nil && *c.ClosedOn != "" {
+		closedOn, err := parseSNDateTime(ctx, "sn get case", "closedOn", *c.ClosedOn)
+		if err != nil {
+			return domain.CaseView{}, fmt.Errorf("sn get case: parse closedOn %q: %w", *c.ClosedOn, err)
+		}
+		cv.ClosedOn = &closedOn
+	}
 	if len(c.WatchList) > 0 {
 		wl := make([]domain.WatchListUser, 0, len(c.WatchList))
 		for _, u := range c.WatchList {
@@ -1647,6 +1656,7 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 	if c.ClosedBy != nil {
 		cv.ClosedBy = &domain.EntityRef{ID: sysidToUUID(c.ClosedBy.ID), Name: c.ClosedBy.Name}
 	}
+	cv.CloseNotes = c.CloseNotes
 	if c.EngagementPaymentType != nil && c.EngagementPaymentType.Label != "" {
 		cv.EngagementPaymentType = &c.EngagementPaymentType.Label
 	}

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -424,6 +424,58 @@ func TestSNCaseService_GetCaseByID_BallerinaBlockedFieldsAbsent(t *testing.T) {
 	if len(cv.WatchList) != 0 {
 		t.Fatalf("expected no watchers, got %+v", cv.WatchList)
 	}
+	if cv.ClosedOn != nil {
+		t.Fatalf("expected closedOn nil when the key is absent, got %+v", cv.ClosedOn)
+	}
+	if cv.CloseNotes != nil {
+		t.Fatalf("expected closeNotes nil when the key is absent, got %+v", cv.CloseNotes)
+	}
+}
+
+// TestSNCaseService_GetCaseByID_MapsClosedOn pins that Ballerina/SN closedOn
+// (space-separated UTC) is decoded onto CaseView so the portal can render
+// Closed On. The field used to be undeclared on snCase, so encoding/json
+// discarded it and GetCaseByID left CaseView.ClosedOn nil.
+func TestSNCaseService_GetCaseByID_MapsClosedOn(t *testing.T) {
+	body := `{
+		"id": "` + testWLCaseSysid + `",
+		"internalId": "WSO2-001",
+		"number": "CS0001001",
+		"title": "Case subject",
+		"description": "Case description",
+		"createdOn": "2026-01-01 10:00:00",
+		"updatedOn": "2026-02-20 01:34:44",
+		"closedOn": "2026-02-20 01:34:44",
+		"closeNotes": "Resolved successfully",
+		"createdBy": "reporter@example.com",
+		"project": {"id": "` + testProjectSysid + `", "name": "Project A"},
+		"deployment": {"id": "", "name": ""},
+		"deployedProduct": {"id": "", "name": "", "version": ""},
+		"state": {"id": 3, "label": "Closed"}
+	}`
+
+	client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+
+	svc := NewServiceNowCaseService(client, nil, nil)
+
+	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantClosedOn, err := time.Parse(snCreatedOnLayout, "2026-02-20 01:34:44")
+	if err != nil {
+		t.Fatalf("parse want closedOn: %v", err)
+	}
+	if cv.ClosedOn == nil || !cv.ClosedOn.Equal(wantClosedOn) {
+		t.Fatalf("expected closedOn=%v, got %+v", wantClosedOn, cv.ClosedOn)
+	}
+	if cv.CloseNotes == nil || *cv.CloseNotes != "Resolved successfully" {
+		t.Fatalf("expected closeNotes=%q, got %+v", "Resolved successfully", cv.CloseNotes)
+	}
 }
 
 // TestSNCaseService_UpdateCase_ExactlyOneFieldValidation exercises the exactly-one-field


### PR DESCRIPTION
## Purpose

Resolves https://github.com/wso2-enterprise/digiops-cs/issues/3026

On a closed support case, Ballerina GET /cases/{id} returns closedOn and the portal shows the datetime. On the Go path (customer-portal backend-v2 → entity-service ServiceNow mapper), snCase never declared closedOn, so encoding/json dropped it and Closed On rendered as --.

## Goals

- GET /cases/{id} on the ServiceNow mapper populates closedOn (parsed the same way as resolvedOn).
- closeNotes from the same SN payload is forwarded to the portal, matching Ballerina.

## Approach

Declare closedOn and closeNotes on snCase, parse closedOn with parseSNDateTime, and map both onto CaseView. backend-v2 already forwarded closedOn; add closeNotes on CaseView / CaseDetails so the BFF does not drop it.

## User stories

As a Customer Portal user, I can see Closed On (and close notes when present) on a closed case served by the Go BFF / entity-service SN path.

## Release note

Entity-service ServiceNow GET case now maps closedOn and closeNotes so the Customer Portal no longer shows Closed On as --.

## Documentation

N/A — field already existed on the portal and Ballerina contract.

## Training

N/A — no training content impact.

## Certification

N/A — no certification exam impact.

## Marketing

N/A

## Automation tests

- Unit tests
  - TestSNCaseService_GetCaseByID_MapsClosedOn
  - TestSNCaseService_GetCaseByID_BallerinaBlockedFieldsAbsent (closedOn / closeNotes stay nil when absent)
  - TestMapCaseDetails_ExposesFieldsTheFrontendDeclares (closeNotes)

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

- Go 1.26 locally
- Unit tests against mocked ServiceNow GET case JSON

## Learning

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Case details now display closure notes when available.
  - Case details now include the date a case was closed.
  - Closure information is available when retrieving case details, including cases closed through external systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->