### PR TITLE
[CSM Portal] Fix incident search filters (SLA-violated, created-date, product) using unsupported flat shape

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3111,11 +3111,10 @@ export interface BePatchIncidentResponse {
 /**
  * `field` enum accepted by an incident search's generic `filters` array —
  * mirrors the entity-service's `incidentFilterFieldSet` (see
- * `incident_filters.go`) exactly. Deliberately a superset of what this
- * portal currently builds a control for (only `assignmentGroupId`, for the
- * SRE Team filter, at present) — narrowing the FE type to just that one
- * value would create a stale-type problem the moment another field gets a
- * control.
+ * `incident_filters.go`) exactly. This portal currently builds controls for
+ * `assignmentGroupId` (SRE Team), `slaViolated`, `createdOn`, and
+ * `productName` — the remaining values (`state`, `businessServiceId`,
+ * `madeSla`) are included for completeness/future controls, not dead code.
  */
 export type BeIncidentFieldFilterField =
   | "state"
@@ -3149,35 +3148,21 @@ export interface BeIncidentSearchPayload {
     priorities?: BeIncidentPriority[];
     parentIds?: string[];
     /**
-     * At least one breached SLA record (optional). `false` and omitted are
-     * identical to the backend — it applies no SLA restriction either way,
-     * `false` does NOT mean "SLA met" — so callers should omit this key
-     * entirely rather than send `false`.
-     */
-    slaViolated?: boolean;
-    /** Inclusive UTC bound on the creation timestamp: `YYYY-MM-DDTHH:MM:SSZ`. */
-    startCreatedDate?: string;
-    /** Inclusive UTC bound on the creation timestamp: `YYYY-MM-DDTHH:MM:SSZ`. */
-    endCreatedDate?: string;
-    /**
-     * Union match on the name of the service the incident relates to
-     * (optional). Incidents carry no product dimension of their own, so this
-     * resolves against the related service's name, which is only ~43%
-     * populated and mixes real products with customer names and service
-     * categories — filtering by this misses roughly half of all incidents.
-     */
-    productNames?: string[];
-    /**
      * A single incident number (e.g. "INC0090472"); matches exactly. Routed
      * as a first-class filter rather than through the free-text searchQuery
      * scan.
      */
     number?: string;
     /**
-     * The generic field/op/values filter array (see {@link BeIncidentFieldFilter}) —
-     * additive alongside the named fields above, not a replacement for them.
-     * Only the SRE Team control (`assignmentGroupId`/`"in"`) populates this
-     * today.
+     * The generic field/op/values filter array (see {@link BeIncidentFieldFilter}).
+     * This is the ONLY way to express `state`, `assignmentGroupId`,
+     * `businessServiceId`, `createdOn`, `slaViolated`, `madeSla`, and
+     * `productName` — the backend's `SearchIncidentsRequest.filters` has no
+     * flat named keys for any of these (there used to be `slaViolated`/
+     * `startCreatedDate`/`endCreatedDate`/`productNames` scalars here, but
+     * the backend now rejects them as unknown fields; always route through
+     * this array instead). `searchQuery`/`priorities`/`parentIds`/`number`
+     * above remain flat — only those four.
      */
     filters?: BeIncidentFieldFilter[];
   };

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/incidents.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/incidents.test.ts
@@ -55,16 +55,18 @@ describe("buildIncidentSearchFilters", () => {
   it("omits slaViolated entirely when the toggle is off", () => {
     const filters: IncidentFilters = { ...DEFAULT_INCIDENT_FILTERS, slaViolated: false };
     const built = buildIncidentSearchFilters(filters, "");
-    expect(built).not.toHaveProperty("slaViolated");
+    expect(built).not.toHaveProperty("filters");
     expect(Object.keys(built)).toEqual([]);
   });
 
-  it("sends slaViolated: true, never false, when the toggle is on", () => {
+  it("sends slaViolated as an eq/[\"true\"] generic filter entry, never a flat key or false", () => {
     const filters: IncidentFilters = { ...DEFAULT_INCIDENT_FILTERS, slaViolated: true };
-    expect(buildIncidentSearchFilters(filters, "")).toEqual({ slaViolated: true });
+    expect(buildIncidentSearchFilters(filters, "")).toEqual({
+      filters: [{ field: "slaViolated", op: "eq", values: ["true"] }],
+    });
   });
 
-  it("produces exact inclusive UTC bounds for a whole-day range", () => {
+  it("produces exact inclusive UTC bounds for a whole-day range as gte/lte createdOn entries", () => {
     // Verified against the real data source (see the API description on
     // BeIncidentSearchPayload): an inclusive May 2026 range is
     // 2026-05-01T00:00:00Z .. 2026-05-31T23:59:59Z, not the next midnight —
@@ -76,32 +78,35 @@ describe("buildIncidentSearchFilters", () => {
       createdEndDate: "2026-05-31",
     };
     expect(buildIncidentSearchFilters(filters, "")).toEqual({
-      startCreatedDate: "2026-05-01T00:00:00Z",
-      endCreatedDate: "2026-05-31T23:59:59Z",
+      filters: [
+        { field: "createdOn", op: "gte", values: ["2026-05-01T00:00:00Z"] },
+        { field: "createdOn", op: "lte", values: ["2026-05-31T23:59:59Z"] },
+      ],
     });
   });
 
   it("includes only the start bound when only createdStartDate is set", () => {
     const filters: IncidentFilters = { ...DEFAULT_INCIDENT_FILTERS, createdStartDate: "2026-05-01" };
     const built = buildIncidentSearchFilters(filters, "");
-    expect(built).toEqual({ startCreatedDate: "2026-05-01T00:00:00Z" });
-    expect(built).not.toHaveProperty("endCreatedDate");
+    expect(built).toEqual({
+      filters: [{ field: "createdOn", op: "gte", values: ["2026-05-01T00:00:00Z"] }],
+    });
   });
 
-  it("includes productNames only when at least one product is selected", () => {
+  it("includes a productName/in generic filter entry only when at least one product is selected", () => {
     expect(buildIncidentSearchFilters(DEFAULT_INCIDENT_FILTERS, "")).not.toHaveProperty(
-      "productNames",
+      "filters",
     );
     const filters: IncidentFilters = {
       ...DEFAULT_INCIDENT_FILTERS,
       products: ["Choreo", "Asgardeo"],
     };
     expect(buildIncidentSearchFilters(filters, "")).toEqual({
-      productNames: ["Choreo", "Asgardeo"],
+      filters: [{ field: "productName", op: "in", values: ["Choreo", "Asgardeo"] }],
     });
   });
 
-  it("includes priorities and searchQuery alongside the new filters", () => {
+  it("includes priorities and searchQuery alongside the generic filters array", () => {
     const filters: IncidentFilters = {
       search: "",
       priorities: ["CRITICAL", "HIGH"],
@@ -114,10 +119,12 @@ describe("buildIncidentSearchFilters", () => {
     expect(buildIncidentSearchFilters(filters, "timeout")).toEqual({
       searchQuery: "timeout",
       priorities: ["CRITICAL", "HIGH"],
-      slaViolated: true,
-      startCreatedDate: "2026-05-01T00:00:00Z",
-      endCreatedDate: "2026-05-31T23:59:59Z",
-      productNames: ["Choreo"],
+      filters: [
+        { field: "slaViolated", op: "eq", values: ["true"] },
+        { field: "createdOn", op: "gte", values: ["2026-05-01T00:00:00Z"] },
+        { field: "createdOn", op: "lte", values: ["2026-05-31T23:59:59Z"] },
+        { field: "productName", op: "in", values: ["Choreo"] },
+      ],
     });
   });
 
@@ -131,7 +138,23 @@ describe("buildIncidentSearchFilters", () => {
     });
   });
 
-  it("omits the generic filters array entirely when no SRE team is selected", () => {
+  it("merges slaViolated, createdOn, productName, and assignmentGroupId into one generic filters array", () => {
+    const filters: IncidentFilters = {
+      ...DEFAULT_INCIDENT_FILTERS,
+      slaViolated: true,
+      products: ["Choreo"],
+      sreTeamIds: ["team-apollo"],
+    };
+    expect(buildIncidentSearchFilters(filters, "")).toEqual({
+      filters: [
+        { field: "slaViolated", op: "eq", values: ["true"] },
+        { field: "productName", op: "in", values: ["Choreo"] },
+        { field: "assignmentGroupId", op: "in", values: ["team-apollo"] },
+      ],
+    });
+  });
+
+  it("omits the generic filters array entirely when no field-filter-backed control is set", () => {
     expect(buildIncidentSearchFilters(DEFAULT_INCIDENT_FILTERS, "")).not.toHaveProperty(
       "filters",
     );

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/incidents.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/incidents.ts
@@ -129,10 +129,11 @@ export function incidentPriorityColor(priority?: string | null): ChipColor {
 
 /**
  * Filters for the incidents list. The backend's `IncidentSearchPayload.filters`
- * supports `searchQuery`, `priorities`, `parentIds`, `slaViolated`,
- * `startCreatedDate`/`endCreatedDate`, and `productNames` (see openapi.yaml),
- * plus the generic `filters` array this feeds `sreTeamIds` through as an
- * `assignmentGroupId`/`"in"` entry; there's no server-side state/category
+ * only has flat named keys for `searchQuery`, `priorities`, `parentIds`, and
+ * `number` (see openapi.yaml); `slaViolated`, `createdOn` (date range), and
+ * `productName` all route through the generic `filters` array (see
+ * {@link buildIncidentSearchFilters}), same as `sreTeamIds`' own
+ * `assignmentGroupId`/`"in"` entry — there's no server-side state/category
  * filter to build a control for.
  */
 export interface IncidentFilters {
@@ -193,29 +194,55 @@ export function incidentDateOnlyToUTCEnd(dateOnly: string): string {
 
 /**
  * Build `IncidentSearchPayload.filters` from the UI's {@link IncidentFilters}
- * plus the (separately debounced) search text. `slaViolated` is included only
- * when the toggle is on — the backend treats `false` and "absent" as the same
- * thing, so sending `false` would be meaningless and misleading to read back.
+ * plus the (separately debounced) search text. `searchQuery`/`priorities`
+ * remain flat named keys — the backend's `SearchIncidentsRequest.filters` has
+ * no flat key for `slaViolated`, `createdOn`, `productName`, or
+ * `assignmentGroupId`; each of those is only accepted through the generic
+ * `filters` array (`IncidentFieldFilter`), so they're all merged into one
+ * array here rather than sent as top-level scalars — the entity-service
+ * rejects unknown top-level fields outright (400) rather than ignoring them.
+ * `slaViolated` is included only when the toggle is on — the backend treats
+ * `false` and "absent" as the same thing, so sending `false` would be
+ * meaningless and misleading to read back. `createdOn` becomes up to two
+ * separate `gte`/`lte` entries (one value each), not a single ranged entry.
  */
 export function buildIncidentSearchFilters(
   filters: IncidentFilters,
   debouncedSearch: string,
 ): NonNullable<BeIncidentSearchPayload["filters"]> {
+  const fieldFilters: NonNullable<BeIncidentSearchPayload["filters"]>["filters"] = [
+    ...(filters.slaViolated
+      ? [{ field: "slaViolated" as const, op: "eq" as const, values: ["true"] }]
+      : []),
+    ...(filters.createdStartDate
+      ? [
+          {
+            field: "createdOn" as const,
+            op: "gte" as const,
+            values: [incidentDateOnlyToUTCStart(filters.createdStartDate)],
+          },
+        ]
+      : []),
+    ...(filters.createdEndDate
+      ? [
+          {
+            field: "createdOn" as const,
+            op: "lte" as const,
+            values: [incidentDateOnlyToUTCEnd(filters.createdEndDate)],
+          },
+        ]
+      : []),
+    ...(filters.products.length > 0
+      ? [{ field: "productName" as const, op: "in" as const, values: filters.products }]
+      : []),
+    ...(filters.sreTeamIds.length > 0
+      ? [{ field: "assignmentGroupId" as const, op: "in" as const, values: filters.sreTeamIds }]
+      : []),
+  ];
+
   return {
     ...(debouncedSearch.length > 0 && { searchQuery: debouncedSearch }),
     ...(filters.priorities.length > 0 && { priorities: filters.priorities }),
-    ...(filters.slaViolated && { slaViolated: true }),
-    ...(filters.createdStartDate && {
-      startCreatedDate: incidentDateOnlyToUTCStart(filters.createdStartDate),
-    }),
-    ...(filters.createdEndDate && {
-      endCreatedDate: incidentDateOnlyToUTCEnd(filters.createdEndDate),
-    }),
-    ...(filters.products.length > 0 && { productNames: filters.products }),
-    ...(filters.sreTeamIds.length > 0 && {
-      filters: [
-        { field: "assignmentGroupId" as const, op: "in" as const, values: filters.sreTeamIds },
-      ],
-    }),
+    ...(fieldFilters.length > 0 && { filters: fieldFilters }),
   };
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The CSM webapp's incident search calls `POST /incidents/search` with a flat, per-field request shape for the SLA-violated toggle, created-date range, and product filter (`filters.slaViolated`, `filters.startCreatedDate`/`endCreatedDate`, `filters.productNames`). The entity-service's `SearchIncidentsRequest.filters` schema does not define any of these as flat keys -- they only exist as `field`/`op`/`values` entries in the generic `filters` array (see `openapi.yaml`'s `IncidentFieldFilter`, already used by this same portal's SRE Team control). The backend rejects the unknown flat fields with a 400, which the BFF passes through and the FE surfaces as a generic "Failed to search incidents." message any time one of those three filters is set.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Build all four field-filter-backed incident search predicates (SLA-violated, created-date start/end, product, and the existing SRE Team control) as entries in a single generic `filters` array, matching the entity-service's actual accepted contract. `searchQuery`/`priorities`/`parentIds`/`number` remain flat, since those are genuinely still flat keys on the wire.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

No UI change -- this only changes the internal request-body shape `buildIncidentSearchFilters` produces for the existing Incidents tab filter bar (priority/SLA-violated/date-range/product/SRE-team controls are unchanged). `BeIncidentSearchPayload`'s TypeScript type is updated to drop the stale flat fields and route through `BeIncidentFieldFilter` instead, matching the entity-service's `openapi.yaml`.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, filtering the Incidents tab by SLA-violated status, created-date range, or product returns matching incidents instead of an error.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed a bug where filtering incidents by SLA-violated status, created-date range, or product returned "Failed to search incidents." instead of results.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A -- internal request-shape fix only; the in-app Operations help topic already describes the user-visible filter behavior accurately and doesn't reference the wire format.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A -- no training content covers this internal request shape.

## Certification
> Type "Sent" when you have provided new/updated certification questions...

N/A -- bug fix with no new user-facing feature or workflow.

## Marketing
> Link to drafts of marketing content...

N/A -- internal bug fix, not a marketing-relevant feature.

## Automation tests
 - Unit tests
   > Updated `src/features/csm-operations/utils/__tests__/incidents.test.ts` to assert the new generic-filters-array shape for `buildIncidentSearchFilters` (SLA-violated, created-date bounds, product, SRE team, and a combined case). Full `apps/csm-portal/webapp` suite: 42 files / 455 tests passed (`pnpm exec vitest run`).
 - Integration tests
   > None added -- no live backend was reachable from this worktree to run an end-to-end request against a real entity-service; contract was verified by reading the entity-service's `openapi.yaml` (`SearchIncidentsRequest`/`IncidentFieldFilter`) directly instead.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A -- TypeScript/React project, not a JVM target this plugin applies to
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

N/A -- no sample code affected.

## Related PRs
> List any other related PRs

None in this repo. The backend-side contract this aligns with was already fixed in a prior, separately merged entity-service PR (out of scope here).

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A -- no data or schema migration involved.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

macOS (Darwin), Node v24.5.0, pnpm 11.1.2. Verified via `tsc -b`, `eslint`, `vitest run`, and `vite build` -- no backend/browser environment was reachable from this worktree to exercise the live request end to end.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Confirmed the actual accepted request shape by reading the entity-service's own `openapi.yaml` (`SearchIncidentsRequest`, `IncidentFieldFilter`) rather than assuming the shape from the bug report alone, since the FE's own doc comments describing the old flat contract were themselves stale.
