### PR TITLE
[CSM Portal] add Project filter to change requests list

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.test.tsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { ReactNode } from "react";
+import ChangeRequestsFilterBar from "@features/csm-operations/components/ChangeRequestsFilterBar";
+import { DEFAULT_CR_FILTERS } from "@features/csm-operations/utils/changeRequests";
+import { useTeams } from "@features/csm-dashboard/api/useTeams";
+
+const postMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock, get: vi.fn() }),
+}));
+
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
+
+// Mocked directly (same approach as `CasesFilterBar.test.tsx` mocking
+// `useSearchTags`) so tests don't have to drive the real SRE-team network
+// query — this bar's own control, unrelated to the project filter under test.
+vi.mock("@features/csm-dashboard/api/useTeams", () => ({
+  useTeams: vi.fn(),
+}));
+const mockedUseTeams = vi.mocked(useTeams);
+
+beforeEach(() => {
+  postMock.mockReset();
+  postMock.mockResolvedValue({ projects: [] });
+  mockedUseTeams.mockReturnValue({
+    data: [],
+    isLoading: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useTeams>);
+});
+
+function renderBar(
+  filters = DEFAULT_CR_FILTERS,
+  onChange = vi.fn(),
+): { onChange: ReturnType<typeof vi.fn> } {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    (
+      <QueryClientProvider client={queryClient}>
+        <ChangeRequestsFilterBar
+          filters={filters}
+          onChange={onChange}
+          onReset={() => {}}
+          isFiltersOpen
+          onFiltersToggle={() => {}}
+        />
+      </QueryClientProvider>
+    ) as ReactNode,
+  );
+  return { onChange };
+}
+
+describe("ChangeRequestsFilterBar — Project filter", () => {
+  it("renders a Project control alongside the existing filters", () => {
+    renderBar();
+    expect(screen.getByRole("combobox", { name: "Project" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "State" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Impact" })).toBeInTheDocument();
+  });
+
+  it("shows the selected project count in the active-filters badge", () => {
+    renderBar({ ...DEFAULT_CR_FILTERS, projectIds: ["proj-1"] });
+    expect(screen.getByRole("button", { name: "Filters (1)" })).toBeInTheDocument();
+  });
+
+  it("shows a Clear filters action once a project is selected", () => {
+    renderBar({ ...DEFAULT_CR_FILTERS, projectIds: ["proj-1"] });
+    expect(screen.getByRole("button", { name: /Clear filters/i })).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
@@ -51,6 +51,7 @@ import {
 import { changeRequestsSavedViews } from "@features/csm-operations/utils/changeRequestsSavedViews";
 import SavedViewsMenu from "@features/csm-operations/components/SavedViewsMenu";
 import MultiSelectField from "@components/MultiSelectField";
+import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
 
 const { DatePicker, LocalizationProvider } = DatePickers;
 
@@ -250,6 +251,13 @@ export default function ChangeRequestsFilterBar({
                   }}
                 />
               </LocalizationProvider>
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+              <AsyncProjectMultiSelect
+                id="cr-filter-project"
+                values={filters.projectIds}
+                onChange={(next) => onChange({ ...filters, projectIds: next })}
+              />
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <LocalizationProvider dateAdapter={AdapterDateFns}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.test.tsx
@@ -41,6 +41,20 @@ vi.mock("@features/csm-dashboard/api/useTeams", () => ({
   useTeams: () => ({ data: [], isLoading: false }),
 }));
 
+// The filter bar's Project control (`AsyncProjectMultiSelect`) goes through
+// the same shared infinite-query hook the cases list uses — stub it out for
+// the same "no QueryClientProvider" reason as the SRE Team mock above.
+vi.mock("@features/csm-cases/api/useProjectSearch", () => ({
+  useInfiniteProjectSearch: () => ({
+    projects: [],
+    isFetching: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    isError: false,
+    fetchNextPage: vi.fn(),
+  }),
+}));
+
 // Only the column picker's storage key derives from the signed-in user.
 vi.mock("@context/current-user/CurrentUserContext", () => ({
   useCurrentUser: () => ({ user: { id: "user-1" }, isLoading: false, isError: false }),

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/changeRequests.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/changeRequests.test.ts
@@ -234,6 +234,12 @@ describe("countActiveCRFilters", () => {
       countActiveCRFilters({ ...DEFAULT_CR_FILTERS, sreTeamIds: ["team-apollo"] }),
     ).toBe(1);
   });
+
+  it("is 1 when a project filter is set", () => {
+    expect(
+      countActiveCRFilters({ ...DEFAULT_CR_FILTERS, projectIds: ["proj-1"] }),
+    ).toBe(1);
+  });
 });
 
 describe("buildChangeRequestSearchFilters", () => {
@@ -275,5 +281,20 @@ describe("buildChangeRequestSearchFilters", () => {
 
   it("omits the generic filters array entirely when no SRE team is selected", () => {
     expect(buildChangeRequestSearchFilters(DEFAULT_CR_FILTERS, "")).not.toHaveProperty("filters");
+  });
+
+  it("sends selected projects as the named projectIds field", () => {
+    expect(
+      buildChangeRequestSearchFilters(
+        { ...DEFAULT_CR_FILTERS, projectIds: ["proj-1", "proj-2"] },
+        "",
+      ),
+    ).toEqual({ projectIds: ["proj-1", "proj-2"] });
+  });
+
+  it("omits projectIds entirely when no project is selected", () => {
+    expect(buildChangeRequestSearchFilters(DEFAULT_CR_FILTERS, "")).not.toHaveProperty(
+      "projectIds",
+    );
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
@@ -264,6 +264,10 @@ export interface ChangeRequestFilters {
    * `{ field: "assignmentGroupId", op: "in" }` filter entry (see
    * `buildChangeRequestSearchFilters`), not a named payload field. */
   sreTeamIds: string[];
+  /** Selected project ids — sent as the named `projectIds` payload field
+   * (see `buildChangeRequestSearchFilters`), matching the entity-service's
+   * own field name for this search. */
+  projectIds: string[];
 }
 
 export const DEFAULT_CR_FILTERS: ChangeRequestFilters = {
@@ -273,6 +277,7 @@ export const DEFAULT_CR_FILTERS: ChangeRequestFilters = {
   closedStartDate: "",
   closedEndDate: "",
   sreTeamIds: [],
+  projectIds: [],
 };
 
 /** Count non-search active filters (used for the badge on the Filters button). */
@@ -282,7 +287,8 @@ export function countActiveCRFilters(filters: ChangeRequestFilters): number {
     (filters.impacts.length > 0 ? 1 : 0) +
     (filters.closedStartDate ? 1 : 0) +
     (filters.closedEndDate ? 1 : 0) +
-    (filters.sreTeamIds.length > 0 ? 1 : 0)
+    (filters.sreTeamIds.length > 0 ? 1 : 0) +
+    (filters.projectIds.length > 0 ? 1 : 0)
   );
 }
 
@@ -320,6 +326,7 @@ export function buildChangeRequestSearchFilters(
         { field: "assignmentGroupId" as const, op: "in" as const, values: filters.sreTeamIds },
       ],
     }),
+    ...(filters.projectIds.length > 0 && { projectIds: filters.projectIds }),
   };
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestsFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestsFiltersUrl.test.ts
@@ -30,7 +30,7 @@ describe("readChangeRequestFiltersFromUrl", () => {
 
   it("parses a fully-populated query string", () => {
     const params = new URLSearchParams(
-      "crQ=rollback&crStates=implement,review&crImpacts=high,low&crClosedFrom=2026-01-01&crClosedTo=2026-01-31&crSreTeams=team-apollo,team-atlas",
+      "crQ=rollback&crStates=implement,review&crImpacts=high,low&crClosedFrom=2026-01-01&crClosedTo=2026-01-31&crSreTeams=team-apollo,team-atlas&crProjects=proj-1,proj-2",
     );
     expect(readChangeRequestFiltersFromUrl(params)).toEqual({
       search: "rollback",
@@ -39,6 +39,7 @@ describe("readChangeRequestFiltersFromUrl", () => {
       closedStartDate: "2026-01-01",
       closedEndDate: "2026-01-31",
       sreTeamIds: ["team-apollo", "team-atlas"],
+      projectIds: ["proj-1", "proj-2"],
     });
   });
 
@@ -47,6 +48,14 @@ describe("readChangeRequestFiltersFromUrl", () => {
     expect(readChangeRequestFiltersFromUrl(params).sreTeamIds).toEqual([
       "team-apollo",
       "team-atlas",
+    ]);
+  });
+
+  it("drops blank/whitespace project entries", () => {
+    const params = new URLSearchParams("crProjects=proj-1,%20%20,,proj-2");
+    expect(readChangeRequestFiltersFromUrl(params).projectIds).toEqual([
+      "proj-1",
+      "proj-2",
     ]);
   });
 
@@ -89,6 +98,7 @@ describe("writeChangeRequestFiltersToUrl", () => {
       closedStartDate: "2026-01-01",
       closedEndDate: "2026-01-31",
       sreTeamIds: ["team-apollo"],
+      projectIds: ["proj-1"],
     };
     const round = readChangeRequestFiltersFromUrl(
       writeChangeRequestFiltersToUrl(filters),
@@ -102,5 +112,13 @@ describe("writeChangeRequestFiltersToUrl", () => {
       sreTeamIds: [],
     });
     expect(params.has("crSreTeams")).toBe(false);
+  });
+
+  it("omits crProjects when no project is selected", () => {
+    const params = writeChangeRequestFiltersToUrl({
+      ...DEFAULT_CR_FILTERS,
+      projectIds: [],
+    });
+    expect(params.has("crProjects")).toBe(false);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestsFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestsFiltersUrl.ts
@@ -31,6 +31,7 @@ export const CR_FILTER_PARAM_KEYS = [
   "crClosedFrom",
   "crClosedTo",
   "crSreTeams",
+  "crProjects",
 ] as const;
 
 const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
@@ -81,6 +82,15 @@ function parseTeamIdsCsv(raw: string | null): string[] {
 }
 
 /**
+ * Comma-separated project ids — same free-form (non-enum) shape as
+ * `parseTeamIdsCsv` above; kept as its own function so the two filters read
+ * independently even though the parsing logic is identical.
+ */
+function parseProjectIdsCsv(raw: string | null): string[] {
+  return parseTeamIdsCsv(raw);
+}
+
+/**
  * Read change-request filters from the URL. Unknown/malformed values (a
  * hand-edited or stale query string) are dropped rather than passed through,
  * so they fall back to the default (unfiltered) behaviour instead of being
@@ -96,6 +106,7 @@ export function readChangeRequestFiltersFromUrl(
     closedStartDate: parseDateOnly(params.get("crClosedFrom")),
     closedEndDate: parseDateOnly(params.get("crClosedTo")),
     sreTeamIds: parseTeamIdsCsv(params.get("crSreTeams")),
+    projectIds: parseProjectIdsCsv(params.get("crProjects")),
   };
 }
 
@@ -113,5 +124,6 @@ export function writeChangeRequestFiltersToUrl(
   if (f.closedStartDate) out.set("crClosedFrom", f.closedStartDate);
   if (f.closedEndDate) out.set("crClosedTo", f.closedEndDate);
   if (f.sreTeamIds.length) out.set("crSreTeams", f.sreTeamIds.join(","));
+  if (f.projectIds.length) out.set("crProjects", f.projectIds.join(","));
   return out;
 }


### PR DESCRIPTION
## Purpose
> SRE team reported they cannot filter Change Requests by Project in the CSM portal. Root cause: the change-requests filter bar never had a Project field, unlike the Service Request / Cases filter bar, which already has one. The entity-service already accepts `projectIds` in the CR search request — this was a webapp-only gap.

## Goals
> Add a Project filter to the change-requests list so SRE/CS engineers can narrow CRs to a specific project, matching the existing SR/cases filtering experience.

## Approach
> Added a `projectIds: string[]` field to `ChangeRequestFilters`, reused the existing `AsyncProjectMultiSelect` component (the same one `CasesFilterBar` already uses for SR/cases) in `ChangeRequestsFilterBar`, wired it to send `projectIds` in the CR search request (the entity-service field already existed), and added a `crProjects` URL param for persistence, matching the existing `crSreTeams` param pattern.

## User stories
> As an SRE/CS engineer, I can filter the Change Requests list by Project, the same way I already can for Service Requests/Cases.

## Release note
> Added a Project filter to the Change Requests list in the CSM portal.

## Documentation
> N/A — no CSM portal `/help` topic currently documents CR filters in enough detail to need an update; the filter bar is self-explanatory (same UI pattern as the existing SR/cases Project filter).

## Training
N/A — no training content references CR filtering.

## Certification
N/A — no certification impact.

## Marketing
N/A — internal tooling change, not customer-facing.

## Automation tests
 - Unit tests
   > Added/updated tests in `changeRequests.test.ts` (filter counting + search-payload building for `projectIds`), `changeRequestsFiltersUrl.test.ts` (`crProjects` param round-trip), `ChangeRequestsFilterBar.test.tsx` (new — renders the Project control, active-filter badge, clear-filters behavior), and `ChangeRequestsTab.test.tsx` (mocked the project-search hook the filter bar now depends on). `pnpm exec vitest run` — 2692 passed (8 pre-existing unrelated failures needing a local env var, untouched by this change).
 - Integration tests
   > Manually verified against the deployed staging backend (real entity-service, not mocked): selecting a project on the CR list sent `{"filters":{"projectIds":[...]}}` to `/change-requests/search` and the result count correctly dropped to 0 for an unrelated project. Also re-verified the pre-existing SR Project filter still works the same way against `/cases/search`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React change; `pnpm exec eslint` ran clean instead
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
> Local webapp dev server (Vite) against the deployed Choreo staging backend, Chrome, real authenticated session.

## Learning
> N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added project filtering to the change requests view.
  - Project selections now update the active-filter count and provide a clear-filters option.
  - Project filters are preserved in the URL and included in change-request searches.

- **Tests**
  - Added coverage for project filtering, URL parsing and persistence, search payloads, and filter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->