### PR TITLE
[CSM Portal] Filter SR deployed products by project's srProductCategories

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -222,6 +222,7 @@ func main() {
 	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
 	mux.HandleFunc("POST /accounts/{id}/contacts/search", accountHandler.SearchAccountContacts)
 	mux.HandleFunc("GET /projects/{id}", projectHandler.GetProject)
+	mux.HandleFunc("GET /projects/{id}/metadata", projectHandler.GetProjectMetadata)
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("POST /projects/{id}/contacts/search", projectHandler.SearchProjectContacts)
 	mux.HandleFunc("GET /projects/{id}/contacts/{contactId}", projectHandler.GetProjectContact)

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -167,6 +167,12 @@ func (c *CustomerEntityClient) GetProject(ctx context.Context, id string) ([]byt
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/projects/%s", url.PathEscape(id)), nil)
 }
 
+// GetProjectMetadata calls GET /projects/{id}/metadata on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) GetProjectMetadata(ctx context.Context, id string) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/projects/%s/metadata", url.PathEscape(id)), nil)
+}
+
 // SearchProjects calls POST /projects/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
 func (c *CustomerEntityClient) SearchProjects(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -481,6 +481,7 @@ func (m *mockEntityAccountClient) SearchAccountContacts(ctx context.Context, acc
 
 type mockEntityProjectClient struct {
 	getProjectFn            func(ctx context.Context, id string) ([]byte, error)
+	getProjectMetadataFn    func(ctx context.Context, id string) ([]byte, error)
 	searchProjectsFn        func(ctx context.Context, body []byte) ([]byte, error)
 	searchProjectContactsFn func(ctx context.Context, projectID string, body []byte) ([]byte, error)
 	getProjectContactFn     func(ctx context.Context, projectID, contactID string) ([]byte, error)
@@ -497,6 +498,13 @@ func (m *mockEntityProjectClient) GetProjectContact(ctx context.Context, project
 func (m *mockEntityProjectClient) GetProject(ctx context.Context, id string) ([]byte, error) {
 	if m.getProjectFn != nil {
 		return m.getProjectFn(ctx, id)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityProjectClient) GetProjectMetadata(ctx context.Context, id string) ([]byte, error) {
+	if m.getProjectMetadataFn != nil {
+		return m.getProjectMetadataFn(ctx, id)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/internal/handler/projects.go
+++ b/apps/csm-portal/backend/internal/handler/projects.go
@@ -29,6 +29,7 @@ import (
 // entityProjectClient abstracts the entity service project operations used by ProjectHandler.
 type entityProjectClient interface {
 	GetProject(ctx context.Context, id string) ([]byte, error)
+	GetProjectMetadata(ctx context.Context, id string) ([]byte, error)
 	SearchProjects(ctx context.Context, body []byte) ([]byte, error)
 	SearchProjectContacts(ctx context.Context, projectID string, body []byte) ([]byte, error)
 	GetProjectContact(ctx context.Context, projectID, contactID string) ([]byte, error)
@@ -64,6 +65,30 @@ func (h *ProjectHandler) GetProject(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity GetProject failed", "userID", user.UserID, "projectID", id, "err", err)
 		mapUpstreamErrorGeneric(w, err, "Failed to retrieve project.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// GetProjectMetadata handles GET /projects/{id}/metadata.
+func (h *ProjectHandler) GetProjectMetadata(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.GetProjectMetadata(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectMetadata failed", "userID", user.UserID, "projectID", id, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to retrieve project metadata.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/projects_test.go
+++ b/apps/csm-portal/backend/internal/handler/projects_test.go
@@ -93,6 +93,76 @@ func TestGetProject(t *testing.T) {
 	})
 }
 
+func TestGetProjectMetadata(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewProjectHandler(&mockEntityProjectClient{})
+		r := httptest.NewRequest(http.MethodGet, "/projects/proj-1/metadata", nil)
+		r.SetPathValue("id", "proj-1")
+		w := httptest.NewRecorder()
+		h.GetProjectMetadata(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty project ID", func(t *testing.T) {
+		h := NewProjectHandler(&mockEntityProjectClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/projects//metadata", nil))
+		w := httptest.NewRecorder()
+		h.GetProjectMetadata(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("passes ID to upstream and returns 200 with response", func(t *testing.T) {
+		var capturedID string
+		client := &mockEntityProjectClient{
+			getProjectMetadataFn: func(_ context.Context, id string) ([]byte, error) {
+				capturedID = id
+				return []byte(`{"srProductCategories":["ms","pc"]}`), nil
+			},
+		}
+		h := NewProjectHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/projects/proj-42/metadata", nil))
+		r.SetPathValue("id", "proj-42")
+		w := httptest.NewRecorder()
+		h.GetProjectMetadata(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedID != "proj-42" {
+			t.Errorf("upstream received id %q, want %q", capturedID, "proj-42")
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		cats, ok := resp["srProductCategories"].([]any)
+		if !ok || len(cats) != 2 {
+			t.Errorf("response srProductCategories = %v, want [ms pc]", resp["srProductCategories"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to retrieve project metadata.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityProjectClient{
+					getProjectMetadataFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewProjectHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/projects/proj-1/metadata", nil))
+				r.SetPathValue("id", "proj-1")
+				w := httptest.NewRecorder()
+				h.GetProjectMetadata(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 func TestSearchProjects(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewProjectHandler(&mockEntityProjectClient{})

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1747,6 +1747,24 @@ export interface BeProjectSearchResponse extends BeSearchResponseBase {
 }
 
 /**
+ * `GET /projects/{id}/metadata` — reference data (choice lists, feature
+ * flags) for building the project's UI, not project-specific field values.
+ * Only the subset this webapp currently reads is typed; the entity service's
+ * response carries more (choice lists for case/change-request states, etc.).
+ */
+export interface BeProjectMetadata {
+  features?: {
+    /**
+     * Plain opaque category-code strings (not a named enum), matching the
+     * entity service's own convention. When present and non-empty, only
+     * deployed products whose `category` is in this list are eligible for a
+     * service request against this project.
+     */
+    srProductCategories?: string[] | null;
+  };
+}
+
+/**
  * A contact's attributes for one project, from `POST /projects/{id}/contacts/search`
  * (also the shape of `GET /projects/{id}/contacts/{contactId}`).
  */

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -132,6 +132,7 @@ export const ApiQueryKeys = {
   CSM_CASE_UPDATE_REQUEST_TEMPLATES: "csm-case-update-request-templates",
   CSM_PROJECTS: "csm-projects",
   CSM_PROJECT_DETAIL: "csm-project-detail",
+  CSM_PROJECT_METADATA: "csm-project-metadata",
   CSM_ACCOUNTS: "csm-accounts",
   CSM_ACCOUNT_DETAIL: "csm-account-detail",
   CSM_ACCOUNT_PROJECTS: "csm-account-projects",

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
@@ -29,6 +29,13 @@ export interface DeployedProductOption {
   id: string;
   /** Human label: "{product name} {version}". */
   label: string;
+  /**
+   * Opaque category code carried straight through from `BeDeployedProduct.category`
+   * (e.g. "ms", "pc"), or `null`/`undefined` when the record has none. Used by
+   * callers (e.g. the service-request create page) that need to narrow the
+   * option list to a project's `srProductCategories`.
+   */
+  category?: string | null;
 }
 
 /**
@@ -59,7 +66,11 @@ export function useDeployedProductOptions(
         // products with missing names stay distinguishable in the selector.
         const name = d.product?.name || d.product?.id || "Product";
         const ver = d.version?.name ?? "";
-        return { id: d.id, label: ver ? `${name} ${ver}` : name };
+        return {
+          id: d.id,
+          label: ver ? `${name} ${ver}` : name,
+          category: d.category,
+        };
       });
     },
     enabled: !!deploymentId,

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.test.tsx
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { BeProjectMetadata } from "@api/backend/types";
+
+const navigateMock = vi.fn();
+const postCaseMutateAsyncMock = vi.fn();
+const showErrorMock = vi.fn();
+
+// Mutable per-test fixture for the project-metadata query, mirroring the
+// getter pattern used for mutation `isPending` flags elsewhere (e.g.
+// CreateChangeRequestPage.test.tsx) so each `it` can set its own shape
+// without a fresh vi.mock per test.
+let projectMetadataResult: {
+  data: BeProjectMetadata | null | undefined;
+  isLoading: boolean;
+  isError: boolean;
+} = { data: undefined, isLoading: false, isError: false };
+
+vi.mock("react-router", () => ({
+  useNavigate: () => navigateMock,
+  useLocation: () => ({ state: undefined }),
+  useSearchParams: () => [new URLSearchParams()],
+}));
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: showErrorMock }),
+}));
+vi.mock("@features/csm-cases/api/usePostCsmCase", () => ({
+  usePostCsmCase: () => ({ mutateAsync: postCaseMutateAsyncMock }),
+}));
+vi.mock("@features/csm-cases/api/useCsmCaseAttachments", () => ({
+  usePostCsmCaseAttachment: () => ({ mutateAsync: vi.fn(), uploadProgress: null }),
+}));
+vi.mock("@hooks/useEngineerDisplayName", () => ({
+  useEngineerDisplayName: () => "Test Engineer",
+}));
+vi.mock("@features/csm-projects/api/useGetProject", () => ({
+  useGetProject: () => ({
+    data: { id: "proj-1", hasSr: true, subscriptionType: "managed_cloud_subscription" },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock("@features/csm-projects/api/useProjectMetadata", () => ({
+  useProjectMetadata: () => projectMetadataResult,
+}));
+vi.mock("@features/csm-cases/api/useSearchDeployments", () => ({
+  useSearchDeployments: () => ({
+    data: [{ id: "dep-1", name: "Production" }],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+// Three fixed deployed-product options spanning: a category matching the
+// project's srProductCategories restriction, a category that doesn't, and no
+// category at all — enough to exercise every branch of the client-side filter.
+vi.mock("@features/csm-cases/api/useDeployedProductOptions", () => ({
+  useDeployedProductOptions: () => ({
+    data: [
+      { id: "dp-ms", label: "API Manager 4.3.0", category: "ms" },
+      { id: "dp-pc", label: "Choreo Connect 1.0", category: "pc" },
+      { id: "dp-none", label: "Unknown Product", category: null },
+    ],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock("@features/csm-operations/api/useSearchCatalogs", () => ({
+  useSearchCatalogs: () => ({ data: [], isLoading: false, isError: false, refetch: vi.fn() }),
+}));
+vi.mock("@features/csm-operations/api/useCatalogItemVariables", () => ({
+  useCatalogItemVariables: () => ({ data: [], isLoading: false, isError: false }),
+}));
+vi.mock("@features/csm-cases/components/ProjectSelectionField", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (next: string) => void;
+  }) => (
+    <input aria-label="Project" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+// CreateServiceRequestPage imports BackendApiError from the real API client
+// module, which reads window.config at module load and throws outside a
+// configured runtime. Mock it with a real class (so `instanceof` still
+// works), mirroring CreateSecurityReportPage.test.tsx.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+// Imported after the mocks above so the module picks them up.
+import CreateServiceRequestPage from "@features/csm-operations/pages/CreateServiceRequestPage";
+
+/** Selects the project and deployment, which is enough to unlock (enable) the
+ * deployed-product dropdown these tests exercise. */
+function selectProjectAndDeployment(): void {
+  fireEvent.change(screen.getByLabelText("Project"), { target: { value: "proj-1" } });
+  fireEvent.mouseDown(screen.getByLabelText(/deployment/i));
+  fireEvent.click(screen.getByRole("option", { name: "Production" }));
+}
+
+describe("CreateServiceRequestPage — deployed-product filtering by srProductCategories", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    postCaseMutateAsyncMock.mockReset();
+    showErrorMock.mockReset();
+    projectMetadataResult = { data: undefined, isLoading: false, isError: false };
+  });
+
+  it("shows only deployed products whose category is in the project's srProductCategories", () => {
+    projectMetadataResult = {
+      data: { features: { srProductCategories: ["ms"] } },
+      isLoading: false,
+      isError: false,
+    };
+    render(<CreateServiceRequestPage />);
+    selectProjectAndDeployment();
+
+    fireEvent.mouseDown(screen.getByLabelText(/deployed product/i));
+    expect(screen.getByRole("option", { name: "API Manager 4.3.0" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Choreo Connect 1.0" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Unknown Product" })).not.toBeInTheDocument();
+  });
+
+  it("shows every deployed product when srProductCategories is absent (no restriction configured)", () => {
+    projectMetadataResult = {
+      data: { features: {} },
+      isLoading: false,
+      isError: false,
+    };
+    render(<CreateServiceRequestPage />);
+    selectProjectAndDeployment();
+
+    fireEvent.mouseDown(screen.getByLabelText(/deployed product/i));
+    expect(screen.getByRole("option", { name: "API Manager 4.3.0" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Choreo Connect 1.0" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Unknown Product" })).toBeInTheDocument();
+  });
+
+  it("shows every deployed product when srProductCategories is an empty array", () => {
+    projectMetadataResult = {
+      data: { features: { srProductCategories: [] } },
+      isLoading: false,
+      isError: false,
+    };
+    render(<CreateServiceRequestPage />);
+    selectProjectAndDeployment();
+
+    fireEvent.mouseDown(screen.getByLabelText(/deployed product/i));
+    expect(screen.getByRole("option", { name: "API Manager 4.3.0" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Choreo Connect 1.0" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Unknown Product" })).toBeInTheDocument();
+  });
+
+  it("fails open (shows every deployed product) when the metadata fetch itself errors", () => {
+    projectMetadataResult = { data: undefined, isLoading: false, isError: true };
+    render(<CreateServiceRequestPage />);
+    selectProjectAndDeployment();
+
+    fireEvent.mouseDown(screen.getByLabelText(/deployed product/i));
+    expect(screen.getByRole("option", { name: "API Manager 4.3.0" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Choreo Connect 1.0" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Unknown Product" })).toBeInTheDocument();
+    // A metadata-fetch failure must never surface as a form-blocking error —
+    // it's a narrowing-only feature, so it fails open silently.
+    expect(screen.queryByText(/failed to load deployed products/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -43,6 +43,7 @@ import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import ProjectSelectionField from "@features/csm-cases/components/ProjectSelectionField";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
+import { useProjectMetadata } from "@features/csm-projects/api/useProjectMetadata";
 import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
 import { usePostCsmCaseAttachment } from "@features/csm-cases/api/useCsmCaseAttachments";
@@ -135,6 +136,23 @@ export default function CreateServiceRequestPage(): JSX.Element {
 
   const deployments = useSearchDeployments(projectId || undefined);
   const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
+  // Service requests are only raisable against a subset of a project's
+  // deployed products, keyed by category — mirrors CP's
+  // CreateServiceRequestPage, which restricts its deployed-product picker the
+  // same way. Fetched independently of deployedProducts (no server-side
+  // filter param exists for this yet) and applied client-side below. A
+  // missing/empty/failed-to-load srProductCategories must never narrow the
+  // list to zero when it would otherwise show options — fail open, not
+  // closed.
+  const projectMetadata = useProjectMetadata(projectId || undefined);
+  const srProductCategories = projectMetadata.data?.features?.srProductCategories;
+  const deployedProductOptions = useMemo(() => {
+    const options = deployedProducts.data ?? [];
+    if (!srProductCategories || srProductCategories.length === 0) return options;
+    return options.filter(
+      (o) => o.category != null && srProductCategories.includes(o.category),
+    );
+  }, [deployedProducts.data, srProductCategories]);
   const catalogs = useSearchCatalogs(deployedProductId || undefined);
   const variables = useCatalogItemVariables(
     catalogId || undefined,
@@ -434,7 +452,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
                 disabled={!deploymentId || deployedProducts.isLoading}
                 notched={deployedProductId !== ""}
               >
-                {(deployedProducts.data ?? []).map((dp) => (
+                {deployedProductOptions.map((dp) => (
                   <MenuItem key={dp.id} value={dp.id}>
                     {dp.label}
                   </MenuItem>
@@ -446,7 +464,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
                 <FormHelperText error>Failed to load deployed products.</FormHelperText>
               ) : deployedProducts.isLoading ? (
                 <FormHelperText>Loading products…</FormHelperText>
-              ) : (deployedProducts.data ?? []).length === 0 ? (
+              ) : deployedProductOptions.length === 0 ? (
                 <FormHelperText>No deployed products found for this deployment.</FormHelperText>
               ) : null}
             </FormControl>

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useProjectMetadata.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useProjectMetadata.test.tsx
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const getMock = vi.fn();
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as useDashboard.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ get: getMock }),
+}));
+
+import { useProjectMetadata } from "@features/csm-projects/api/useProjectMetadata";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useProjectMetadata", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it("fetches a project's metadata via GET /projects/{id}/metadata", async () => {
+    getMock.mockResolvedValue({
+      features: { srProductCategories: ["ms", "pc"] },
+    });
+
+    const { result } = renderHook(() => useProjectMetadata("proj-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(getMock).toHaveBeenCalledWith("/projects/proj-1/metadata");
+    expect(result.current.data?.features?.srProductCategories).toEqual(["ms", "pc"]);
+  });
+
+  it("does not fetch while the project id is undefined", () => {
+    const { result } = renderHook(() => useProjectMetadata(undefined), { wrapper });
+
+    expect(getMock).not.toHaveBeenCalled();
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("resolves to null on a 404 (unknown project) rather than throwing", async () => {
+    getMock.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useProjectMetadata("missing"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("surfaces a query error when the call fails", async () => {
+    getMock.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useProjectMetadata("proj-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("boom");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useProjectMetadata.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useProjectMetadata.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeProjectMetadata } from "@api/backend/types";
+
+/**
+ * Look up a project's reference/feature metadata via `GET /projects/{id}/metadata`
+ * (BFF passthrough to the entity service). Returns `null` when the id is unknown
+ * so callers that only need an optional feature flag (e.g.
+ * `features.srProductCategories`) can fail open rather than treating "not
+ * found" as an error. The query stays disabled until an id is present.
+ */
+export function useProjectMetadata(
+  id: string | undefined,
+): UseQueryResult<BeProjectMetadata | null, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeProjectMetadata | null, Error>({
+    queryKey: [ApiQueryKeys.CSM_PROJECT_METADATA, id ?? ""],
+    queryFn: (): Promise<BeProjectMetadata | null> =>
+      api.get<BeProjectMetadata>(`/projects/${encodeURIComponent(id as string)}/metadata`),
+    enabled: !!id,
+    staleTime: 60_000,
+  });
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

CSM's Service Request creation flow lets a CS engineer pick any deployed product for the deployment, regardless of category. The customer portal (CP) already restricts this to a project's `srProductCategories` (e.g. `ms`/`pc`); CSM had no equivalent, so an engineer could select a product a customer would never be allowed to raise an SR against.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Bring CSM's SR creation deployed-product picker to parity with CP: only show products whose category is in the current project's `srProductCategories`.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- **Backend** (`apps/csm-portal/backend`): added `GET /projects/{id}/metadata` as a pure passthrough proxy to the entity-service's existing endpoint (already consumed by CP's backend today — no entity-service or ServiceNow change).
- **Webapp** (`apps/csm-portal/webapp`): `CreateServiceRequestPage.tsx` fetches that project's metadata and filters the already-fetched deployed-product list client-side by `category ∈ srProductCategories`, before rendering the dropdown.
- Deliberately **not** a server-side search filter (the approach CP appears to use): the entity-service's deployed-products search endpoint has no category-filter support anywhere in its stack (flat request struct, `DisallowUnknownFields()`), so a nested filter param the way CP sends it may be silently dropped server-side already. Client-side filtering avoids that risk entirely and needs no entity-service or SN changes.
- Fail-open: if `srProductCategories` is absent, empty, or the metadata call errors, the full product list is shown unfiltered — matches CP's own behavior and avoids ever showing zero products due to a metadata hiccup.

## User stories
> Summary of user stories addressed by this change

As a CS engineer creating a Service Request in the CSM portal, I only see deployed products eligible for SR creation on that project, consistent with what a customer sees in the customer portal.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

CSM portal: Service Request creation now filters selectable deployed products to the project's SR-eligible product categories, matching the customer portal's existing behavior.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A — this narrows an existing dropdown's contents; no new field, flow, or nav change to document in the CSM portal user guide.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal CS-engineer-facing behavior change, no customer-facing marketing impact.

## Automation tests
 - Unit tests
   > New: `useProjectMetadata.test.tsx` (4 cases: fetch/URL, disabled until project id present, 404→null fail-open, error), `CreateServiceRequestPage.test.tsx` (4 cases: narrows to matching category, shows all when categories absent, shows all when categories empty, fails open silently on metadata error), `TestGetProjectMetadata` on the Go backend (4 subtests: auth required, empty id rejected, upstream passthrough, upstream error mapping).
 - Integration tests
   > None added — no live entity-service/ServiceNow environment was available during implementation. **Manually smoke-tested against a real project before merge is required** (see Test environment).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go/TypeScript change, not applicable to this stack
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Verified locally: Go backend `go build`/`go vet`/`go test ./...` all pass (worktree, no live stack); webapp `tsc -b`, `eslint`, `vitest run` (new + full suite), `vite build` all pass. **Not yet verified against a real project with real ServiceNow-sourced `srProductCategories`** — this PR is opened as a draft pending that manual verification.

## Learning
N/A
