### PR TITLE
[CSM Portal] Fix native print truncating detail pages to one page

### DIFF
--- a/apps/csm-portal/webapp/src/features/case-tabs/components/CaseTabIsolatedRouter.tsx
+++ b/apps/csm-portal/webapp/src/features/case-tabs/components/CaseTabIsolatedRouter.tsx
@@ -282,6 +282,17 @@ export default function CaseTabIsolatedRouter({
       aria-labelledby={tabElementId(tab.id)}
       data-testid={tabPanelElementId(tab.id)}
       onScroll={handleScroll}
+      // Only the currently-visible tab's panel gets `csm-print-expand` — see
+      // that class's own doc comment in `print.css`. It forces
+      // `display: block` under `@media print`, so applying it unconditionally
+      // (relying on the sibling `hidden` attribute alone to keep the other,
+      // backgrounded tabs off-screen) would fight that attribute: `hidden`'s
+      // `display: none` comes from the UA stylesheet with no `!important`,
+      // and this class's print rule — which does carry `!important`, by
+      // necessity, to win over this element's own inline `display: none` —
+      // would override it and print every open-but-inactive case tab's
+      // content at once instead of just the one on screen.
+      className={isVisible ? "csm-print-expand" : undefined}
       style={{
         display: isVisible ? "flex" : "none",
         flexDirection: "column",

--- a/apps/csm-portal/webapp/src/features/case-tabs/components/CaseTabsWorkspace.tsx
+++ b/apps/csm-portal/webapp/src/features/case-tabs/components/CaseTabsWorkspace.tsx
@@ -175,6 +175,12 @@ export function CaseTabsContentHost(): JSX.Element | null {
   // un-tabbed real content.
   return (
     <div
+      // Only applied while this host is actually the visible content (see
+      // `CaseTabIsolatedRouter`'s own note on the same pattern, and
+      // `print.css`) — otherwise this print-only rule would force an
+      // otherwise `display: none` host visible on a printed page that isn't
+      // showing any case tab at all.
+      className={activeRouteHasTab ? "csm-print-expand" : undefined}
       style={{
         display: activeRouteHasTab ? "flex" : "none",
         flexDirection: "column",

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
@@ -91,6 +91,7 @@ function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
     <Button
       variant="text"
       size="small"
+      className="csm-print-hide"
       startIcon={<ArrowLeft size={16} />}
       onClick={onClick}
       sx={{ alignSelf: "flex-start" }}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -2096,6 +2096,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
       <Button
         variant="text"
         size="small"
+        className="csm-print-hide"
         startIcon={<ArrowLeft size={16} />}
         onClick={() => navigate(resolvedBackPath)}
         sx={{ alignSelf: "flex-start" }}
@@ -2219,7 +2220,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
           <Typography variant="h5">{c.subject}</Typography>
         </Box>
         {!isAnnouncement && (
-          <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
+          <Box
+            className="csm-print-hide"
+            sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}
+          >
             <CaseActionBar
               caseDetail={c}
               onAction={onAction}
@@ -2267,7 +2271,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
         </Box>
       )}
 
-      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+      <Box className="csm-print-hide" sx={{ borderBottom: 1, borderColor: "divider" }}>
         <Tabs
           value={activeTab}
           onChange={(_, v) => setActiveTab(v as CaseTabId)}
@@ -2337,7 +2341,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
               that hides case-lifecycle patch actions, which don't apply to an
               announcement, not the ability to reply to one. */}
           {composerOpen ? (
-            <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+            <Card
+              className="csm-print-hide"
+              sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}
+            >
               <Box
                 sx={{
                   display: "flex",
@@ -2416,6 +2423,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               fullWidth
               variant="outlined"
               color="inherit"
+              className="csm-print-hide"
               disabled={isClosed}
               startIcon={<MessageSquarePlus size={18} />}
               onClick={() => setComposerOpen(true)}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -2010,6 +2010,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         <Button
+          className="csm-print-hide"
           variant="text"
           size="small"
           startIcon={<ArrowLeft size={16} />}
@@ -2030,6 +2031,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         <Button
+          className="csm-print-hide"
           variant="text"
           size="small"
           startIcon={<ArrowLeft size={16} />}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -334,6 +334,7 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
     <Button
       variant="text"
       size="small"
+      className="csm-print-hide"
       startIcon={<ArrowLeft size={16} />}
       onClick={back}
       sx={{ alignSelf: "flex-start" }}
@@ -548,7 +549,7 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
           <ChangeRequestLifecycleStepper state={cr.state} />
         </Box>
         <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Box className="csm-print-hide" sx={{ display: "flex", alignItems: "center", gap: 1 }}>
             <ChangeRequestActionBar
               cr={cr}
               isPending={transitionPending}
@@ -638,7 +639,7 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
         </Box>
       </Card>
 
-      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+      <Box className="csm-print-hide" sx={{ borderBottom: 1, borderColor: "divider" }}>
         <Tabs
           value={activeTab}
           onChange={(_, v) => setActiveTab(v as ChangeRequestTabId)}
@@ -879,7 +880,7 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
       {activeTab === "comments" && (
         <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
           {composerOpen ? (
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+            <Box className="csm-print-hide" sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
               <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
                 <Typography variant="subtitle2">Reply</Typography>
                 <Button
@@ -924,6 +925,7 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
               fullWidth
               variant="outlined"
               color="inherit"
+              className="csm-print-hide"
               startIcon={<MessageSquarePlus size={18} />}
               onClick={() => setComposerOpen(true)}
               sx={{ justifyContent: "flex-start", textTransform: "none", py: 1.5, px: 2 }}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -417,6 +417,7 @@ export default function CsmIncidentDetailPage(): JSX.Element {
     <Button
       variant="text"
       size="small"
+      className="csm-print-hide"
       startIcon={<ArrowLeft size={16} />}
       onClick={back}
       sx={{ alignSelf: "flex-start" }}
@@ -524,7 +525,7 @@ export default function CsmIncidentDetailPage(): JSX.Element {
           <Typography variant="h5">{incident.subject || "Incident"}</Typography>
         </Box>
         <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Box className="csm-print-hide" sx={{ display: "flex", alignItems: "center", gap: 1 }}>
             <IncidentActionBar
               incident={incident}
               isPending={patchIncident.isPending}
@@ -606,7 +607,7 @@ export default function CsmIncidentDetailPage(): JSX.Element {
         </Box>
       </Card>
 
-      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+      <Box className="csm-print-hide" sx={{ borderBottom: 1, borderColor: "divider" }}>
         <Tabs
           value={activeTab}
           onChange={(_, v) => setActiveTab(v as IncidentTabId)}
@@ -637,7 +638,7 @@ export default function CsmIncidentDetailPage(): JSX.Element {
       {activeTab === "activities" && (
         <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
           {composerOpen ? (
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+            <Box className="csm-print-hide" sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
               <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
                 <Typography variant="subtitle2">Reply</Typography>
                 <Button
@@ -682,6 +683,7 @@ export default function CsmIncidentDetailPage(): JSX.Element {
               fullWidth
               variant="outlined"
               color="inherit"
+              className="csm-print-hide"
               startIcon={<MessageSquarePlus size={18} />}
               onClick={() => setComposerOpen(true)}
               sx={{ justifyContent: "flex-start", textTransform: "none", py: 1.5, px: 2 }}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
@@ -200,6 +200,7 @@ export default function ProblemDetailPage(): JSX.Element {
     <Button
       variant="text"
       size="small"
+      className="csm-print-hide"
       startIcon={<ArrowLeft size={16} />}
       onClick={back}
       sx={{ alignSelf: "flex-start" }}
@@ -302,7 +303,7 @@ export default function ProblemDetailPage(): JSX.Element {
           <Typography variant="h5">{problem.subject || "Problem"}</Typography>
         </Box>
         <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Box className="csm-print-hide" sx={{ display: "flex", alignItems: "center", gap: 1 }}>
             <ProblemActionBar
               problem={problem}
               isPending={patchProblem.isPending}

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/ConversationDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/ConversationDetailPage.tsx
@@ -85,6 +85,7 @@ export default function ConversationDetailPage(): JSX.Element {
     <Button
       variant="text"
       size="small"
+      className="csm-print-hide"
       startIcon={<ArrowLeft size={16} />}
       onClick={() => navigate(backTarget)}
       sx={{ alignSelf: "flex-start" }}

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
@@ -134,6 +134,7 @@ function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
     <Button
       variant="text"
       size="small"
+      className="csm-print-hide"
       startIcon={<ArrowLeft size={16} />}
       onClick={onClick}
       sx={{ alignSelf: "flex-start" }}
@@ -237,6 +238,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
             the wrong one. */}
         <Button
           variant="contained"
+          className="csm-print-hide"
           startIcon={<Plus size={16} />}
           endIcon={<ChevronDown size={16} />}
           onClick={(e: MouseEvent<HTMLElement>) => setCreateMenuAnchor(e.currentTarget)}
@@ -296,7 +298,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
         </Menu>
       </Box>
 
-      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+      <Box className="csm-print-hide" sx={{ borderBottom: 1, borderColor: "divider" }}>
         <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v as ProjectTabId)}>
           <Tab value="overview" label="Overview" />
           <Tab value="deployments" label="Deployments" />

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.tsx
@@ -100,6 +100,7 @@ export default function ProductVulnerabilityDetailPage(): JSX.Element {
     <Button
       variant="text"
       size="small"
+      className="csm-print-hide"
       startIcon={<ArrowLeft size={16} />}
       onClick={back}
       sx={{ alignSelf: "flex-start" }}

--- a/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
@@ -157,6 +157,7 @@ export default function AppLayout({
     <IdleTimeoutProvider>
       <CaseTabsProvider>
         <Box
+          className="csm-print-expand"
           sx={{
             display: "flex",
             flexDirection: "column",
@@ -164,10 +165,12 @@ export default function AppLayout({
             overflow: "hidden",
           }}
         >
-          <TopBanner />
-          <MobileAppBanner />
-          <GlobalNotificationBanner visible={notificationBannerConfig.visible} />
-          <HtmlAnnouncementBanner />
+          <Box className="csm-print-hide">
+            <TopBanner />
+            <MobileAppBanner />
+            <GlobalNotificationBanner visible={notificationBannerConfig.visible} />
+            <HtmlAnnouncementBanner />
+          </Box>
           <AppShellLayout
             header={
               <Header
@@ -188,6 +191,7 @@ export default function AppLayout({
             }
           >
             <Box
+              className="csm-print-expand"
               sx={{
                 display: "flex",
                 flexDirection: "column",
@@ -202,6 +206,7 @@ export default function AppLayout({
               {isVisible && (
                 <LinearProgress
                   color="inherit"
+                  className="csm-print-hide"
                   sx={{
                     color: "primary.main",
                     position: "absolute",
@@ -219,9 +224,14 @@ export default function AppLayout({
                   strip. Renders nothing when no tabs are open. Held off
                   until hasInitialized for the same reason the sidebar is:
                   nothing meaningful to show before auth settles. */}
-              {hasInitialized && <CaseTabStripBar />}
+              {hasInitialized && (
+                <Box className="csm-print-hide">
+                  <CaseTabStripBar />
+                </Box>
+              )}
               <Box
                 ref={mainContentRef}
+                className="csm-print-expand"
                 sx={{
                   flex: 1,
                   minHeight: 0,

--- a/apps/csm-portal/webapp/src/layouts/AppShellLayout.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppShellLayout.tsx
@@ -45,6 +45,7 @@ export default function AppShellLayout({
   return (
     <Box
       data-testid="app-shell"
+      className="csm-print-expand"
       sx={{
         display: "flex",
         flexDirection: "column",
@@ -59,6 +60,7 @@ export default function AppShellLayout({
       <Box
         component="header"
         data-testid="app-navbar"
+        className="csm-print-hide"
         sx={{
           flexShrink: 0,
           width: "100%",
@@ -70,6 +72,7 @@ export default function AppShellLayout({
       </Box>
 
       <Box
+        className="csm-print-expand"
         sx={{
           display: "flex",
           flex: 1,
@@ -85,6 +88,7 @@ export default function AppShellLayout({
           <Box
             component="aside"
             data-testid="app-sidebar"
+            className="csm-print-hide"
             sx={{ flexShrink: 0, minWidth: 0 }}
           >
             {sidebar}
@@ -94,6 +98,7 @@ export default function AppShellLayout({
         <Box
           component="main"
           data-testid="app-main"
+          className="csm-print-expand"
           sx={{
             display: "flex",
             flexDirection: "column",

--- a/apps/csm-portal/webapp/src/main.tsx
+++ b/apps/csm-portal/webapp/src/main.tsx
@@ -17,6 +17,7 @@
 import Prism from "prismjs";
 import React from "react";
 import { createRoot } from "react-dom/client";
+import "./styles/print.css";
 import AppWithConfig from "./AppWithConfig";
 import { POST_LOGIN_REDIRECT_KEY } from "@layouts/postLoginRedirect";
 import { isTopLevelWindow } from "@utils/isTopLevelWindow";

--- a/apps/csm-portal/webapp/src/styles/print.css
+++ b/apps/csm-portal/webapp/src/styles/print.css
@@ -1,0 +1,63 @@
+/* Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Native browser print (Ctrl+P) support for the app's scrollable regions.
+ *
+ * `AppLayout` builds a fixed-viewport shell out of several nested
+ * `height: 100dvh` / `overflow: hidden` / `overflow: auto` containers (the
+ * shell root, `AppShellLayout`'s main column, the shared scrollable content
+ * region, and — for a case/incident/change-request opened as an in-app tab —
+ * that tab's own private scroll container, see `CaseTabIsolatedRouter`). That
+ * nesting is exactly what a screen needs, but a browser's print engine does
+ * NOT paginate an `overflow: auto`/`hidden` box's content across multiple
+ * printed pages — it clips to that box's own on-screen height, so anything
+ * below the first screenful (most of a case's comment trail, for a case with
+ * more than a handful of comments) is silently dropped from the printed
+ * output/PDF.
+ *
+ * The classes below are applied (see `AppLayout.tsx`, `AppShellLayout.tsx`,
+ * `CaseTabIsolatedRouter.tsx`, `CaseTabsWorkspace.tsx`) to exactly that chain
+ * of containers, and only take effect for `@media print`: on screen they are
+ * inert (no rule outside `@media print` below), so normal in-app scrolling,
+ * the kept-alive-in-background case tabs mechanism, and every other on-screen
+ * behavior are unaffected.
+ */
+@media print {
+  .csm-print-expand {
+    height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
+    /* `100dvh`/flex-basis sizing on these containers is meaningless once
+       content is allowed to flow across pages instead of a single fixed
+       viewport height. */
+    min-height: 0 !important;
+    flex: none !important;
+    display: block !important;
+  }
+
+  /* Chrome that has no place in a printed page/PDF: top nav, side nav, the
+     in-app case-tab strip, banners, and page-level controls (Back button,
+     lifecycle/action bars, refresh buttons, the reply composer) that only
+     make sense as interactive, on-screen affordances. Content marked
+     `hidden` (e.g. a background case tab not currently active) already stays
+     hidden regardless of this rule — this only ever hides currently-visible
+     chrome. */
+  .csm-print-hide {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Case, incident, change request, problem, project, conversation (SR), account, and product vulnerability detail pages all render inside a chain of fixed-height `overflow: auto`/`overflow: hidden` containers (the app shell, the shared scrollable content region, and — when opened as an in-app tab — that tab's own private scroll container). Browsers clip an `overflow: auto`/`hidden` box to its on-screen height when printing rather than paginating its content across pages, so using the browser's native print (Ctrl+P → Save as PDF) only ever captured whatever fit in the first screenful — silently dropping most of a case's comment trail (or other long content) on any record with more than a handful of entries.

This does not attempt a dedicated "Export as PDF" feature (a separate, larger scope decision) — only native browser print.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Full detail-page content — including the entire comment/activity trail on case, incident, and change request pages — flows across as many printed pages as needed instead of being clipped to one.
- Screen-only chrome (top nav, side nav, the in-app tab strip, action bars, the reply composer, "Create" menus) is hidden from the printed output on every detail page type, so a printout/PDF reads as record content, not app UI.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Added a small `@media print` stylesheet (`src/styles/print.css`) with two marker classes, applied to the exact ancestor chain identified by tracing the case-detail render path (`AppLayout` → `AppShellLayout` → the case-tabs content host → `CaseTabIsolatedRouter`'s per-tab scroll container):
- `csm-print-expand`: under print, resets `overflow`/`height`/`flex` on a container so its content lays out at natural height instead of being clipped to the screen viewport.
- `csm-print-hide`: hides screen-only chrome under print (top/side nav, the case-tab strip, page action bars, the reply composer).

`csm-print-expand` is applied conditionally (not via a plain CSS selector) on the two containers whose visibility is otherwise controlled by inline styles / the `hidden` attribute (the active case-tab panel, the tab-content host), so a backgrounded, currently-inactive case tab stays hidden under print exactly as it does on screen.

Because this fix is applied at the shared shell level, it covers every detail page rendered through it, not just case/incident: change request, problem, project, conversation (SR), account, and product vulnerability detail all pick up the pagination fix automatically. Each of those pages also got the existing `csm-print-hide` class applied to whichever screen-only chrome it actually has (Back button, action bar, "Create" menu, tab strip — varies per page), reusing the same marker and pattern already used on case/incident/CR detail — no new CSS or shell changes needed for the extension.

Out of scope: a dedicated "Export as PDF" feature; any backend/entity-service change (this is pure frontend CSS/markup).

## User stories
> Summary of user stories addressed by this change

As a CS engineer, I can print (or save as PDF) any case, incident, change request, problem, project, conversation, account, or product vulnerability detail page and get the full content — including the entire comment/activity trail where applicable — across as many pages as needed, without the app's own navigation chrome cluttering the printout.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed: printing a case, incident, change request, problem, project, conversation, account, or product vulnerability detail page (Ctrl+P → Save as PDF) now includes the full content across multiple pages instead of truncating to a single page, and hides app navigation/action chrome from the printout.

## Documentation
N/A — no user-facing workflow change beyond print output now being complete; nothing new to document in the in-app help.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — bug fix, not a new feature.

## Automation tests
 - Unit tests
   > No existing component test suite exercises native browser print output (jsdom does not implement print pagination), so this is verified structurally instead — see Test environment below.
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — pure frontend CSS/markup change, no Java/backend code
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
- `tsc -b && vite build` — passes, no type errors (re-run after adding the five extra pages' markers).
- `eslint .` — 0 errors (2 pre-existing warnings in unrelated files/lines).
- Confirmed by grep that `csm-print-hide` is now present on the Back button (and, where applicable, action bar / "Create" menu / tab strip) of case, incident, change request, problem, project, conversation, account, and product vulnerability detail pages.
- Print-clipping mechanism verified with Playwright + Chromium (headless `page.pdf()`) against a minimal static reproduction of the exact nested container chain (same overflow/height/flex properties as `AppLayout`/`AppShellLayout`/`CaseTabIsolatedRouter`) with the actual `print.css` from this PR: without the fix's classes applied, print output is clipped to 1 page; with them applied, the same content (60 sample comments) spans 4 pages. Could not do an interactive, authenticated in-app browser print-preview check (requires the full local stack + a human login step), so this structural/mechanism-level check is what's actually been run.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved print layouts across the CSM portal.
  * Printable pages now expand scrollable content across pages.
  * Navigation, action controls, tabs, banners, loading indicators, and comment composers are hidden from printed output.
  * Only the currently visible case tab is included when printing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->