### PR TITLE
[CSM Portal] Fix SRE team filter using wrong team family

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -635,15 +635,14 @@ export default function CasesFilterBar({
   );
   // Same shape, keyed off `sreGroupId` instead — feeds the "Advanced
   // filters" builder's `sreTeam` row (a real multi-select now, not
-  // hand-typed team ids/UUIDs). Scoped to `cre-abt` family per explicit
-  // product instruction, not `sre-abt` -- see the "SRE Team" filter's
-  // family-scoping note in `advancedFilters.ts` for the caveat.
+  // hand-typed team ids/UUIDs). Scoped to the `sre-abt` family, matching
+  // `abtFamilyForDashboardType`, mirroring `teamOptions` above.
   const sreTeamOptions = useMemo(
     () =>
       (teams ?? [])
         .filter(
           (t): t is typeof t & { sreGroupId: string } =>
-            Boolean(t.sreGroupId) && t.family === "cre-abt",
+            Boolean(t.sreGroupId) && t.family === "sre-abt",
         )
         .map((t) => ({ value: t.sreGroupId, label: t.name })),
     [teams],


### PR DESCRIPTION
## Purpose
The CSM Cases page's advanced filter builder has an "SRE team" filter with operator "in", but its value multiselect always showed zero options, so no value could ever be selected. That produced a filter param with no value element (e.g. `af=[["sreTeam","in"]]`), which is a no-op that silently returns unfiltered results instead of filtering by SRE team.

## Goals
Make the SRE team value picker actually list the real SRE-family teams, so the "SRE team" advanced filter works as intended.

## Approach
`sreTeamOptions` in `CasesFilterBar.tsx` filtered teams on `family === "cre-abt"` (the CRE family) instead of `"sre-abt"` (the SRE family). This looks like a copy-paste from the adjacent, correctly-working `teamOptions` memo (CRE team picker), where only `creGroupId` was swapped for `sreGroupId` but the family literal was never updated. A comment above the memo claimed the `cre-abt` scoping was deliberate, citing a "family-scoping note in `advancedFilters.ts`" that does not exist in that file (verified by grep) — removed that stale/incorrect comment along with the fix.

`sre-abt` is confirmed as the correct SRE family value via `abtFamilyForDashboardType` in `csm-dashboard/api/useTeams.ts` and its test coverage, and matches the already-correct pattern used for the equivalent SRE team picker in `IncidentsFilterBar.tsx`.

No UI screenshot included: this only changes which options populate an existing multiselect, not layout or visual design.

## User stories
As a CS engineer building an advanced case filter with Case Type = SR, I can filter by SRE team and get results that are actually scoped to the SRE team I selected.

## Release note
Fixed the CSM Cases advanced filter's "SRE team" field so it shows selectable SRE teams; previously it showed no options and silently filtered nothing.

## Documentation
N/A — internal CSM portal bug fix with no change to documented behavior/contract, only a fix to match already-documented intent.

## Training
N/A — no training content covers this filter.

## Certification
N/A — no certification impact from this internal CSM portal bug fix.

## Marketing
N/A — internal tooling fix, no customer-facing feature.

## Automation tests
 - Unit tests
   > Ran the existing suite covering this component and its filter utilities: `CasesFilterBar.test.tsx` (42 tests), `advancedFilters.test.ts` (13 tests), `CsmIssuesView.advancedFiltersUrl.test.tsx` (2 tests) — all 57 pass. No existing fixture exercised `sreTeamOptions`'s family filtering directly, so this PR does not add new coverage for it (out of scope per the fix's minimal-diff scope), but the corrected family value is independently confirmed by `useTeams.test.tsx`'s coverage of `abtFamilyForDashboardType("sre") === "sre-abt"`.
 - Integration tests
   > N/A — no integration test suite covers this filter.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A — pure client-side filter logic fix, no security-sensitive code touched.
 - Ran FindSecurityBugs plugin and verified report? N/A — Java-only tool, not applicable to this TypeScript project.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes.

## Samples
N/A — no samples affected.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Ran `pnpm exec eslint`, `pnpm exec tsc -b`, and `pnpm exec vitest run` locally on macOS (Darwin) with the project's pinned toolchain (Vite 7 / Vitest 4 / TypeScript 5.9). No browser-level manual test was run since this is a data-filtering logic fix, not a rendering change.

## Learning
Root cause was found via prior read-only code investigation; this PR is the follow-up fix informed by that investigation, cross-checked against the equivalent, already-correct SRE team filter pattern in `IncidentsFilterBar.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
