### PR TITLE
[CSM Portal] Incident resolution code dropdown + close-as-duplicate + document specialist-handoff endpoint

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5265,6 +5265,75 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /incidents/{id}/specialist-handoffs:
+    post:
+      summary: Hand an incident off to its specialist group (backing data source only).
+      description: >
+        One atomic call: moves the incident to the specialist group for its business
+        service, clears the assignee, opens a runbook-gap task, and (by default) files
+        an internal issue for the receiving team. The request body is validated at this
+        layer for reasonCode and escalationTeam, then forwarded to the entity service,
+        which performs the handoff; the response is returned to the caller verbatim.
+      operationId: postIncidentsIdSpecialistHandoffs
+      parameters:
+        - name: id
+          in: path
+          description: UUID of the incident.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Specialist handoff payload.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentSpecialistHandoffPayload'
+        required: true
+      responses:
+        "200":
+          description: Specialist handoff result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncidentSpecialistHandoffResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: Incident not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /alerts/{id}:
     get:
       summary: Get a single alert by ID.
@@ -12036,6 +12105,13 @@ components:
         resolutionCode:
           type: string
           nullable: true
+          enum:
+            - "Solved (Work Around)"
+            - "Solved (Permanently)"
+            - "Not Solved (Not Reproducible)"
+            - "False Alarm"
+            - "Duplicate"
+            - "Not Actionable Alert"
         parentId:
           type: string
           format: uuid
@@ -12105,6 +12181,95 @@ components:
           type: string
         incident:
           $ref: '#/components/schemas/IncidentDetail'
+
+    IncidentSpecialistHandoffPayload:
+      type: object
+      description: >-
+        Hands an incident off to its specialist group in one call: moves the incident
+        to the specialist group for its business service, clears the assignee, opens a
+        runbook-gap task, and (by default) files an internal issue for the receiving
+        team. Filing the internal issue is best-effort, not atomic with the rest of the
+        handoff -- a successful response means the handoff itself succeeded even if the
+        issue could not be created; see githubIssueError on the response.
+      required: [reasonCode]
+      properties:
+        reasonCode:
+          type: string
+          enum: [no-runbook, runbook-not-working]
+        escalationTeam:
+          type: string
+          nullable: true
+          description: Only meaningful for a Choreo-routed handoff.
+          enum: [choreo-runtime-team, choreo-apim-team]
+        createGithubIssue:
+          type: boolean
+          default: true
+          description: >-
+            Whether to also file an internal issue for the receiving team. Set false to
+            suppress it, e.g. on a re-handoff or when one already exists.
+
+    IncidentSpecialistHandoffTask:
+      type: object
+      description: The runbook-gap task opened for the specialist team as part of a handoff.
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        subject:
+          type: string
+
+    IncidentSpecialistHandoffGithubIssue:
+      type: object
+      description: >-
+        The internal issue filed for the receiving specialist team, present only when
+        creation was requested and succeeded.
+      properties:
+        url:
+          type: string
+        number:
+          type: integer
+        repo:
+          type: string
+
+    IncidentSpecialistHandoffResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        handoff:
+          type: object
+          properties:
+            assignmentGroup:
+              $ref: '#/components/schemas/EntityRef'
+            previousAssignmentGroup:
+              allOf:
+                - $ref: '#/components/schemas/EntityRef'
+              nullable: true
+            reasonCode:
+              type: string
+              enum: [no-runbook, runbook-not-working]
+            reasonDescription:
+              type: string
+            escalationTeam:
+              type: string
+              nullable: true
+              enum: [choreo-runtime-team, choreo-apim-team]
+            task:
+              $ref: '#/components/schemas/IncidentSpecialistHandoffTask'
+            githubIssue:
+              allOf:
+                - $ref: '#/components/schemas/IncidentSpecialistHandoffGithubIssue'
+              nullable: true
+            githubIssueError:
+              type: string
+              nullable: true
+              description: >-
+                Why the internal issue could not be created, if creation was requested
+                but failed. The handoff itself still succeeds -- callers must surface
+                this rather than report a clean success when it is non-null.
+            incident:
+              $ref: '#/components/schemas/IncidentDetail'
 
     UpdateProblemPayload:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -12073,6 +12073,16 @@ components:
           items:
             $ref: '#/components/schemas/LinkedServiceRequestRef'
           description: Service-request cases whose parent points to this incident.
+        specialistHandoff:
+          allOf:
+            - $ref: '#/components/schemas/IncidentSpecialistHandoffSummary'
+          nullable: true
+          description: >-
+            Derived summary of a specialist-group handoff, null when the incident has
+            never been handed off. Nothing is persisted for it: it is recomputed at
+            read time, so a handoff performed through the backing data source's own
+            native UI reads identically to one performed through
+            POST /incidents/{id}/specialist-handoffs.
 
     UpdateIncidentPayload:
       type: object
@@ -12270,6 +12280,56 @@ components:
                 this rather than report a clean success when it is non-null.
             incident:
               $ref: '#/components/schemas/IncidentDetail'
+
+    IncidentSpecialistHandoffSummaryTask:
+      type: object
+      required: [number, subject]
+      properties:
+        number:
+          type: string
+        subject:
+          type: string
+        state:
+          type: string
+          nullable: true
+
+    IncidentSpecialistHandoffSummary:
+      type: object
+      description: >-
+        Derived summary of a specialist handoff, surfaced on the incident detail
+        response. Nothing is persisted for it -- it is recomputed at read time from
+        the incident's own journal, assignment group, and linked runbook task.
+      required:
+        - reasonCode
+        - reasonDescription
+        - escalationTeam
+        - handedOffAt
+        - handedOffBy
+        - assignmentGroup
+        - task
+        - githubIssueUrl
+      properties:
+        reasonCode:
+          type: string
+          enum: [no-runbook, runbook-not-working]
+        reasonDescription:
+          type: string
+        escalationTeam:
+          type: string
+          nullable: true
+          enum: [choreo-runtime-team, choreo-apim-team]
+        handedOffAt:
+          type: string
+        handedOffBy:
+          type: string
+          nullable: true
+        assignmentGroup:
+          $ref: '#/components/schemas/EntityRef'
+        task:
+          $ref: '#/components/schemas/IncidentSpecialistHandoffSummaryTask'
+        githubIssueUrl:
+          type: string
+          nullable: true
 
     UpdateProblemPayload:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5269,11 +5269,15 @@ paths:
     post:
       summary: Hand an incident off to its specialist group (backing data source only).
       description: >
-        One atomic call: moves the incident to the specialist group for its business
-        service, clears the assignee, opens a runbook-gap task, and (by default) files
-        an internal issue for the receiving team. The request body is validated at this
+        One call moves the incident to the specialist group for its business service,
+        clears the assignee, opens a runbook-gap task, and (by default) files an
+        internal issue for the receiving team. The request body is validated at this
         layer for reasonCode and escalationTeam, then forwarded to the entity service,
         which performs the handoff; the response is returned to the caller verbatim.
+        Internal issue filing is best-effort and non-atomic with the rest of the
+        handoff: a successful response means the handoff itself succeeded even if the
+        issue could not be created -- callers must inspect githubIssueError and must
+        not retry the full handoff as if nothing changed.
       operationId: postIncidentsIdSpecialistHandoffs
       parameters:
         - name: id
@@ -5317,6 +5321,12 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "404":
           description: Incident not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "409":
+          description: Conflict -- the incident is not eligible for a specialist handoff (e.g. wrong service, not In Progress, or already with the specialist group).
           content:
             application/json:
               schema:

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -12116,12 +12116,12 @@ components:
           type: string
           nullable: true
           enum:
-            - "Solved (Work Around)"
-            - "Solved (Permanently)"
-            - "Not Solved (Not Reproducible)"
-            - "False Alarm"
-            - "Duplicate"
-            - "Not Actionable Alert"
+            - SOLVED_WORKAROUND
+            - SOLVED_PERMANENTLY
+            - NOT_SOLVED_NOT_REPRODUCIBLE
+            - FALSE_ALARM
+            - DUPLICATE
+            - NOT_ACTIONABLE
         parentId:
           type: string
           format: uuid

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3084,6 +3084,22 @@ export interface BeCreateIncidentResponse {
 }
 
 /**
+ * Resolution code for an incident moving to `RESOLVED`/`CLOSED`. Only accepted
+ * by `PATCH /incidents/{id}` alongside `state: "RESOLVED"` or `"CLOSED"`.
+ * Closed to the backing data source's real 6-value choice list — "Duplicate"
+ * is this platform's label for the source list's "Duplicate Alert" entry;
+ * this isn't an alerting feature, so the value is used as-is without that
+ * suffix.
+ */
+export type BeIncidentResolutionCode =
+  | "Solved (Work Around)"
+  | "Solved (Permanently)"
+  | "Not Solved (Not Reproducible)"
+  | "False Alarm"
+  | "Duplicate"
+  | "Not Actionable Alert";
+
+/**
  * `PATCH /incidents/{id}` body (ServiceNow data source only,
  * `minProperties: 1`). Covers the in-scope subset the Edit dialog sends —
  * the full `UpdateIncidentPayload` schema also documents `incidentReport` /
@@ -3102,7 +3118,7 @@ export interface BeUpdateIncidentPayload {
   impact?: BeIncidentImpact;
   urgency?: BeIncidentUrgency;
   state?: BeIncidentState;
-  resolutionCode?: string;
+  resolutionCode?: BeIncidentResolutionCode;
   resolutionNotes?: string;
   // Reference/note fields are `nullable: true` on the documented schema — the
   // portal sends an explicit `null` to clear one (e.g. unassign an engineer),

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3086,18 +3086,16 @@ export interface BeCreateIncidentResponse {
 /**
  * Resolution code for an incident moving to `RESOLVED`/`CLOSED`. Only accepted
  * by `PATCH /incidents/{id}` alongside `state: "RESOLVED"` or `"CLOSED"`.
- * Closed to the backing data source's real 6-value choice list — "Duplicate"
- * is this platform's label for the source list's "Duplicate Alert" entry;
- * this isn't an alerting feature, so the value is used as-is without that
- * suffix.
+ * Closed to the backend's domain keys for the backing data source's real
+ * 6-value choice list (see `INCIDENT_RESOLUTION_CODE_LABELS` for display text).
  */
 export type BeIncidentResolutionCode =
-  | "Solved (Work Around)"
-  | "Solved (Permanently)"
-  | "Not Solved (Not Reproducible)"
-  | "False Alarm"
-  | "Duplicate"
-  | "Not Actionable Alert";
+  | "SOLVED_WORKAROUND"
+  | "SOLVED_PERMANENTLY"
+  | "NOT_SOLVED_NOT_REPRODUCIBLE"
+  | "FALSE_ALARM"
+  | "DUPLICATE"
+  | "NOT_ACTIONABLE";
 
 /**
  * `PATCH /incidents/{id}` body (ServiceNow data source only,

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.tsx
@@ -57,6 +57,10 @@ import {
   getLegalNextIncidentStates,
   incidentStateLabel,
 } from "@features/csm-operations/utils/incidents";
+import {
+  INCIDENT_RESOLUTION_CODES,
+  INCIDENT_RESOLUTION_CODE_LABELS,
+} from "@features/csm-operations/utils/incidentResolution";
 import type {
   BeChangeRequestSearchView,
   BeIncident,
@@ -64,6 +68,7 @@ import type {
   BeIncidentContactType,
   BeIncidentDetail,
   BeIncidentImpact,
+  BeIncidentResolutionCode,
   BeIncidentState,
   BeIncidentSubcategory,
   BeIncidentUrgency,
@@ -112,7 +117,7 @@ interface EditState {
   /** Write-only (see `BeUpdateIncidentPayload`) — `IncidentDetail` never
    * echoes these back, so they always start blank, unlike every other field
    * here. Required by ServiceNow to move `state` to `RESOLVED`/`CLOSED`. */
-  resolutionCode: string;
+  resolutionCode: BeIncidentResolutionCode | "";
   resolutionNotes: string;
   serviceId: string;
   serviceOfferingId: string;
@@ -168,7 +173,7 @@ function buildPatch(initial: EditState, next: EditState): BeUpdateIncidentPayloa
   if (next.impact !== initial.impact && next.impact) patch.impact = next.impact;
   if (next.urgency !== initial.urgency && next.urgency) patch.urgency = next.urgency;
   if (next.state !== initial.state && next.state) patch.state = next.state;
-  if (next.resolutionCode.trim()) patch.resolutionCode = next.resolutionCode.trim();
+  if (next.resolutionCode) patch.resolutionCode = next.resolutionCode;
   if (next.resolutionNotes.trim()) patch.resolutionNotes = next.resolutionNotes.trim();
   if (next.serviceId !== initial.serviceId) patch.serviceId = next.serviceId || null;
   if (next.serviceOfferingId !== initial.serviceOfferingId) patch.serviceOfferingId = next.serviceOfferingId || null;
@@ -256,7 +261,7 @@ export default function EditIncidentDialog({
     !!state.urgency &&
     !!state.state &&
     (!isTransitioningToResolved ||
-      (!!state.resolutionCode.trim() && !!state.resolutionNotes.trim()));
+      (!!state.resolutionCode && !!state.resolutionNotes.trim()));
 
   const set = <K extends keyof EditState>(key: K, value: EditState[K]): void =>
     setState((prev) => ({ ...prev, [key]: value }));
@@ -382,14 +387,31 @@ export default function EditIncidentDialog({
               <Typography variant="caption" color="text.secondary">
                 ServiceNow requires a resolution to move this incident to {incidentStateLabel(state.state)}.
               </Typography>
-              <TextField
-                label="Resolution code"
-                value={state.resolutionCode}
-                onChange={(e) => set("resolutionCode", e.target.value)}
-                disabled={isSaving}
-                fullWidth
-                size="small"
-              />
+              <FormControl fullWidth size="small">
+                <InputLabel
+                  id="edit-incident-resolution-code-label"
+                  shrink={state.resolutionCode !== ""}
+                  sx={{ top: "0px !important" }}
+                >
+                  Resolution code
+                </InputLabel>
+                <Select
+                  labelId="edit-incident-resolution-code-label"
+                  label="Resolution code"
+                  value={state.resolutionCode}
+                  notched={state.resolutionCode !== ""}
+                  disabled={isSaving}
+                  onChange={(e) =>
+                    set("resolutionCode", e.target.value as BeIncidentResolutionCode)
+                  }
+                >
+                  {INCIDENT_RESOLUTION_CODES.map((code) => (
+                    <MenuItem key={code} value={code}>
+                      {INCIDENT_RESOLUTION_CODE_LABELS[code]}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
               <TextField
                 label="Resolution notes"
                 value={state.resolutionNotes}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentResolutionDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentResolutionDialog.test.tsx
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import IncidentResolutionDialog from "@features/csm-operations/components/IncidentResolutionDialog";
+
+/** Opens a Select and picks the option by visible text. */
+function chooseOption(labelId: string, optionText: RegExp): void {
+  fireEvent.mouseDown(document.getElementById(labelId)!.parentElement!.querySelector('[role="combobox"]')!);
+  const listbox = screen.getByRole("listbox");
+  fireEvent.click(within(listbox).getByText(optionText));
+}
+
+describe("IncidentResolutionDialog", () => {
+  it("disables submit until a resolution code and resolution notes are both provided", () => {
+    render(
+      <IncidentResolutionDialog
+        target="RESOLVED"
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /move to resolved/i })).toBeDisabled();
+
+    chooseOption("incident-resolution-code-label", /^solved \(work around\)$/i);
+    expect(screen.getByRole("button", { name: /move to resolved/i })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/resolution notes/i), {
+      target: { value: "Restarted the affected node." },
+    });
+    expect(screen.getByRole("button", { name: /move to resolved/i })).not.toBeDisabled();
+  });
+
+  it("submits the chosen resolution code and notes", () => {
+    const onSubmit = vi.fn();
+    render(
+      <IncidentResolutionDialog
+        target="CLOSED"
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+    chooseOption("incident-resolution-code-label", /^duplicate$/i);
+    fireEvent.change(screen.getByLabelText(/resolution notes/i), {
+      target: { value: "Duplicate of INC0012345." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /move to closed/i }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      resolutionCode: "Duplicate",
+      resolutionNotes: "Duplicate of INC0012345.",
+    });
+  });
+
+  it("calls onClose when cancelled", () => {
+    const onClose = vi.fn();
+    render(
+      <IncidentResolutionDialog
+        target="RESOLVED"
+        isSubmitting={false}
+        onClose={onClose}
+        onSubmit={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentResolutionDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentResolutionDialog.test.tsx
@@ -63,7 +63,7 @@ describe("IncidentResolutionDialog", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /move to closed/i }));
     expect(onSubmit).toHaveBeenCalledWith({
-      resolutionCode: "Duplicate",
+      resolutionCode: "DUPLICATE",
       resolutionNotes: "Duplicate of INC0012345.",
     });
   });

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentResolutionDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentResolutionDialog.tsx
@@ -20,19 +20,30 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
 import { useState, type JSX } from "react";
 import { incidentStateLabel } from "@features/csm-operations/utils/incidents";
-import type { BeIncidentState } from "@api/backend/types";
+import {
+  INCIDENT_RESOLUTION_CODES,
+  INCIDENT_RESOLUTION_CODE_LABELS,
+} from "@features/csm-operations/utils/incidentResolution";
+import type { BeIncidentResolutionCode, BeIncidentState } from "@api/backend/types";
 
 interface IncidentResolutionDialogProps {
   /** The transition this dialog is confirming — always RESOLVED or CLOSED. */
   target: Extract<BeIncidentState, "RESOLVED" | "CLOSED">;
   isSubmitting: boolean;
   onClose: () => void;
-  onSubmit: (fields: { resolutionCode: string; resolutionNotes: string }) => void;
+  onSubmit: (fields: {
+    resolutionCode: BeIncidentResolutionCode;
+    resolutionNotes: string;
+  }) => void;
 }
 
 /**
@@ -49,11 +60,11 @@ export default function IncidentResolutionDialog({
   onClose,
   onSubmit,
 }: IncidentResolutionDialogProps): JSX.Element {
-  const [resolutionCode, setResolutionCode] = useState("");
+  const [resolutionCode, setResolutionCode] = useState<BeIncidentResolutionCode | "">("");
   const [resolutionNotes, setResolutionNotes] = useState("");
   const [touched, setTouched] = useState(false);
 
-  const hasCode = resolutionCode.trim().length > 0;
+  const hasCode = resolutionCode !== "";
   const hasNotes = resolutionNotes.trim().length > 0;
   const canSubmit = hasCode && hasNotes && !isSubmitting;
 
@@ -65,18 +76,32 @@ export default function IncidentResolutionDialog({
           ServiceNow requires a resolution to move this incident to{" "}
           {incidentStateLabel(target)}.
         </Typography>
-        <TextField
-          label="Resolution code"
-          required
-          size="small"
-          fullWidth
-          value={resolutionCode}
-          onChange={(e) => setResolutionCode(e.target.value)}
-          onBlur={() => setTouched(true)}
-          error={touched && !hasCode}
-          helperText={touched && !hasCode ? "Resolution code is required." : undefined}
-          disabled={isSubmitting}
-        />
+        <FormControl fullWidth size="small" required error={touched && !hasCode}>
+          <InputLabel
+            id="incident-resolution-code-label"
+            shrink={resolutionCode !== ""}
+            sx={{ top: "0px !important" }}
+          >
+            Resolution code
+          </InputLabel>
+          <Select
+            labelId="incident-resolution-code-label"
+            label="Resolution code"
+            value={resolutionCode}
+            notched={resolutionCode !== ""}
+            disabled={isSubmitting}
+            onChange={(e) =>
+              setResolutionCode(e.target.value as BeIncidentResolutionCode)
+            }
+            onBlur={() => setTouched(true)}
+          >
+            {INCIDENT_RESOLUTION_CODES.map((code) => (
+              <MenuItem key={code} value={code}>
+                {INCIDENT_RESOLUTION_CODE_LABELS[code]}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
         <TextField
           label="Resolution notes"
           required
@@ -104,12 +129,12 @@ export default function IncidentResolutionDialog({
           color="success"
           disabled={!canSubmit}
           onClick={() => {
-            if (!hasCode || !hasNotes) {
+            if (resolutionCode === "" || !hasNotes) {
               setTouched(true);
               return;
             }
             onSubmit({
-              resolutionCode: resolutionCode.trim(),
+              resolutionCode,
               resolutionNotes: resolutionNotes.trim(),
             });
           }}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { JSX } from "react";
@@ -507,9 +507,12 @@ describe("CsmIncidentDetailPage — state-transition action bar", () => {
     openChangeState();
     fireEvent.click(screen.getByRole("menuitem", { name: /resolved/i }));
 
-    fireEvent.change(screen.getByLabelText(/resolution code/i), {
-      target: { value: "Solved" },
-    });
+    fireEvent.mouseDown(
+      document
+        .getElementById("incident-resolution-code-label")!
+        .parentElement!.querySelector('[role="combobox"]')!,
+    );
+    fireEvent.click(within(screen.getByRole("listbox")).getByText(/^solved \(permanently\)$/i));
     fireEvent.change(screen.getByLabelText(/resolution notes/i), {
       target: { value: "Restarted the service." },
     });
@@ -520,7 +523,7 @@ describe("CsmIncidentDetailPage — state-transition action bar", () => {
         id: "inc-1",
         patch: {
           state: "RESOLVED",
-          resolutionCode: "Solved",
+          resolutionCode: "Solved (Permanently)",
           resolutionNotes: "Restarted the service.",
         },
       },

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
@@ -523,7 +523,7 @@ describe("CsmIncidentDetailPage — state-transition action bar", () => {
         id: "inc-1",
         patch: {
           state: "RESOLVED",
-          resolutionCode: "Solved (Permanently)",
+          resolutionCode: "SOLVED_PERMANENTLY",
           resolutionNotes: "Restarted the service.",
         },
       },

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -83,6 +83,7 @@ import type {
   BeHandoffReasonCode,
   BeIncidentDetail,
   BeIncidentHandoffResult,
+  BeIncidentResolutionCode,
   BeIncidentState,
   BeUpdateIncidentPayload,
 } from "@api/backend/types";
@@ -363,7 +364,7 @@ export default function CsmIncidentDetailPage(): JSX.Element {
   );
 
   const onResolutionSubmit = useCallback(
-    (fields: { resolutionCode: string; resolutionNotes: string }) => {
+    (fields: { resolutionCode: BeIncidentResolutionCode; resolutionNotes: string }) => {
       if (!id || !resolutionTarget) return;
       patchIncident.mutate(
         { id, patch: { state: resolutionTarget, ...fields } },

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentResolution.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentResolution.ts
@@ -18,25 +18,24 @@ import type { BeIncidentResolutionCode } from "@api/backend/types";
 
 /** All backend incident resolution codes, in the order declared in openapi.yaml. */
 export const INCIDENT_RESOLUTION_CODES: BeIncidentResolutionCode[] = [
-  "Solved (Work Around)",
-  "Solved (Permanently)",
-  "Not Solved (Not Reproducible)",
-  "False Alarm",
-  "Duplicate",
-  "Not Actionable Alert",
+  "SOLVED_WORKAROUND",
+  "SOLVED_PERMANENTLY",
+  "NOT_SOLVED_NOT_REPRODUCIBLE",
+  "FALSE_ALARM",
+  "DUPLICATE",
+  "NOT_ACTIONABLE",
 ];
 
 /**
- * Display text for each incident resolution code. Matches the backing data
- * source's choice-list values verbatim, except "Duplicate" — the source's UI
- * label for that choice is "Duplicate Alert", but this platform isn't an
- * alerting feature, so it's shown here as just "Duplicate".
+ * Display text for each incident resolution code. "Duplicate" is deliberately
+ * not "Duplicate Alert" (the backing data source's own UI label for that
+ * choice) — this platform isn't an alerting feature.
  */
 export const INCIDENT_RESOLUTION_CODE_LABELS: Record<BeIncidentResolutionCode, string> = {
-  "Solved (Work Around)": "Solved (Work Around)",
-  "Solved (Permanently)": "Solved (Permanently)",
-  "Not Solved (Not Reproducible)": "Not Solved (Not Reproducible)",
-  "False Alarm": "False Alarm",
-  Duplicate: "Duplicate",
-  "Not Actionable Alert": "Not Actionable Alert",
+  SOLVED_WORKAROUND: "Solved (Work Around)",
+  SOLVED_PERMANENTLY: "Solved (Permanently)",
+  NOT_SOLVED_NOT_REPRODUCIBLE: "Not Solved (Not Reproducible)",
+  FALSE_ALARM: "False Alarm",
+  DUPLICATE: "Duplicate",
+  NOT_ACTIONABLE: "Not Actionable Alert",
 };

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentResolution.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentResolution.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeIncidentResolutionCode } from "@api/backend/types";
+
+/** All backend incident resolution codes, in the order declared in openapi.yaml. */
+export const INCIDENT_RESOLUTION_CODES: BeIncidentResolutionCode[] = [
+  "Solved (Work Around)",
+  "Solved (Permanently)",
+  "Not Solved (Not Reproducible)",
+  "False Alarm",
+  "Duplicate",
+  "Not Actionable Alert",
+];
+
+/**
+ * Display text for each incident resolution code. Matches the backing data
+ * source's choice-list values verbatim, except "Duplicate" — the source's UI
+ * label for that choice is "Duplicate Alert", but this platform isn't an
+ * alerting feature, so it's shown here as just "Duplicate".
+ */
+export const INCIDENT_RESOLUTION_CODE_LABELS: Record<BeIncidentResolutionCode, string> = {
+  "Solved (Work Around)": "Solved (Work Around)",
+  "Solved (Permanently)": "Solved (Permanently)",
+  "Not Solved (Not Reproducible)": "Not Solved (Not Reproducible)",
+  "False Alarm": "False Alarm",
+  Duplicate: "Duplicate",
+  "Not Actionable Alert": "Not Actionable Alert",
+};

--- a/apps/csm-portal/webapp/src/features/help/content/operations.md
+++ b/apps/csm-portal/webapp/src/features/help/content/operations.md
@@ -107,7 +107,11 @@ From the detail page a CS engineer can:
 - **Change state**: again driven by the incident's own legal next states.
   Moving to Resolved or Closed opens a dialog to collect a resolution code
   and notes, since those are required by the backing system for those two
-  transitions.
+  transitions. Resolution code is picked from a fixed list rather than typed
+  freely: **Solved (Work Around)**, **Solved (Permanently)**, **Not Solved
+  (Not Reproducible)**, **False Alarm**, **Duplicate**, and **Not Actionable
+  Alert** — use **Duplicate** when closing an incident as a duplicate of
+  another one.
 - **Escalate to specialist team**: reproduces the backing system's own
   "Escalate to Special Ops" action. Pick a reason (runbook unavailable, or
   the runbook didn't solve the incident) and, for a Choreo incident

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -4266,18 +4266,18 @@ const (
 )
 
 // IncidentResolutionCode represents the resolution code recorded when closing an incident.
-// Values are the data source's own close-code values, sent straight through with no
-// translation step (unlike IncidentCategory/IncidentImpact/etc., which map a friendly domain
-// value to a separate backing key).
+// A friendly domain key, mapped to the data source's own close-code value via
+// snIncidentResolutionCodeKeyMap before being sent downstream -- same convention as
+// IncidentCategory/IncidentImpact/etc.
 type IncidentResolutionCode string
 
 const (
-	IncidentResolutionCodeSolvedWorkaround         IncidentResolutionCode = "Solved (Work Around)"
-	IncidentResolutionCodeSolvedPermanently        IncidentResolutionCode = "Solved (Permanently)"
-	IncidentResolutionCodeNotSolvedNotReproducible IncidentResolutionCode = "Not Solved (Not Reproducible)"
-	IncidentResolutionCodeFalseAlarm               IncidentResolutionCode = "False Alarm"
-	IncidentResolutionCodeDuplicateAlert           IncidentResolutionCode = "Duplicate"
-	IncidentResolutionCodeNotActionableAlert       IncidentResolutionCode = "Not Actionable Alert"
+	IncidentResolutionCodeSolvedWorkaround         IncidentResolutionCode = "SOLVED_WORKAROUND"
+	IncidentResolutionCodeSolvedPermanently        IncidentResolutionCode = "SOLVED_PERMANENTLY"
+	IncidentResolutionCodeNotSolvedNotReproducible IncidentResolutionCode = "NOT_SOLVED_NOT_REPRODUCIBLE"
+	IncidentResolutionCodeFalseAlarm               IncidentResolutionCode = "FALSE_ALARM"
+	IncidentResolutionCodeDuplicate                IncidentResolutionCode = "DUPLICATE"
+	IncidentResolutionCodeNotActionable            IncidentResolutionCode = "NOT_ACTIONABLE"
 )
 
 // CreateIncidentRequest is the input for POST /incidents.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -4265,6 +4265,21 @@ const (
 	IncidentUrgencyLow    IncidentUrgency = "LOW"
 )
 
+// IncidentResolutionCode represents the resolution code recorded when closing an incident.
+// Values are the data source's own close-code values, sent straight through with no
+// translation step (unlike IncidentCategory/IncidentImpact/etc., which map a friendly domain
+// value to a separate backing key).
+type IncidentResolutionCode string
+
+const (
+	IncidentResolutionCodeSolvedWorkaround         IncidentResolutionCode = "Solved (Work Around)"
+	IncidentResolutionCodeSolvedPermanently        IncidentResolutionCode = "Solved (Permanently)"
+	IncidentResolutionCodeNotSolvedNotReproducible IncidentResolutionCode = "Not Solved (Not Reproducible)"
+	IncidentResolutionCodeFalseAlarm               IncidentResolutionCode = "False Alarm"
+	IncidentResolutionCodeDuplicateAlert           IncidentResolutionCode = "Duplicate"
+	IncidentResolutionCodeNotActionableAlert       IncidentResolutionCode = "Not Actionable Alert"
+)
+
 // CreateIncidentRequest is the input for POST /incidents.
 type CreateIncidentRequest struct {
 	CallerID            string               `json:"callerId"`
@@ -4303,32 +4318,32 @@ type CreateIncidentResponse struct {
 // UpdateIncidentRequest is the input for PATCH /incidents/{id}. All fields are optional,
 // but at least one must be provided.
 type UpdateIncidentRequest struct {
-	ID                  string               `json:"-"`
-	Subject             *string              `json:"subject,omitempty"`
-	Priority            *IncidentPriority    `json:"priority,omitempty"`
-	State               *IncidentState       `json:"state,omitempty"`
-	Category            *IncidentCategory    `json:"category,omitempty"`
-	Subcategory         *IncidentSubcategory `json:"subcategory,omitempty"`
-	ContactType         *IncidentContactType `json:"contactType,omitempty"`
-	Impact              *IncidentImpact      `json:"impact,omitempty"`
-	Urgency             *IncidentUrgency     `json:"urgency,omitempty"`
-	ResolutionCode      *string              `json:"resolutionCode,omitempty"`
-	ParentID            *string              `json:"parentId,omitempty"`
-	ParentIncidentID    *string              `json:"parentIncidentId,omitempty"`
-	AssignmentGroupID   *string              `json:"assignmentGroupId,omitempty"`
-	AssignedEngineerID  *string              `json:"assignedEngineerId,omitempty"`
-	ServiceID           *string              `json:"serviceId,omitempty"`
-	ServiceOfferingID   *string              `json:"serviceOfferingId,omitempty"`
-	ConfigurationItemID *string              `json:"configurationItemId,omitempty"`
-	ChangeRequestID     *string              `json:"changeRequestId,omitempty"`
-	ProblemID           *string              `json:"problemId,omitempty"`
-	CausedByID          *string              `json:"causedById,omitempty"`
-	ResolvedByID        *string              `json:"resolvedById,omitempty"`
-	ResolutionNotes     *string              `json:"resolutionNotes,omitempty"`
-	IncidentReport      *string              `json:"incidentReport,omitempty"`
-	AdditionalComments  *string              `json:"additionalComments,omitempty"`
-	WorkNotes           *string              `json:"workNotes,omitempty"`
-	WatchList           *[]string            `json:"watchList,omitempty"`
+	ID                  string                  `json:"-"`
+	Subject             *string                 `json:"subject,omitempty"`
+	Priority            *IncidentPriority       `json:"priority,omitempty"`
+	State               *IncidentState          `json:"state,omitempty"`
+	Category            *IncidentCategory       `json:"category,omitempty"`
+	Subcategory         *IncidentSubcategory    `json:"subcategory,omitempty"`
+	ContactType         *IncidentContactType    `json:"contactType,omitempty"`
+	Impact              *IncidentImpact         `json:"impact,omitempty"`
+	Urgency             *IncidentUrgency        `json:"urgency,omitempty"`
+	ResolutionCode      *IncidentResolutionCode `json:"resolutionCode,omitempty"`
+	ParentID            *string                 `json:"parentId,omitempty"`
+	ParentIncidentID    *string                 `json:"parentIncidentId,omitempty"`
+	AssignmentGroupID   *string                 `json:"assignmentGroupId,omitempty"`
+	AssignedEngineerID  *string                 `json:"assignedEngineerId,omitempty"`
+	ServiceID           *string                 `json:"serviceId,omitempty"`
+	ServiceOfferingID   *string                 `json:"serviceOfferingId,omitempty"`
+	ConfigurationItemID *string                 `json:"configurationItemId,omitempty"`
+	ChangeRequestID     *string                 `json:"changeRequestId,omitempty"`
+	ProblemID           *string                 `json:"problemId,omitempty"`
+	CausedByID          *string                 `json:"causedById,omitempty"`
+	ResolvedByID        *string                 `json:"resolvedById,omitempty"`
+	ResolutionNotes     *string                 `json:"resolutionNotes,omitempty"`
+	IncidentReport      *string                 `json:"incidentReport,omitempty"`
+	AdditionalComments  *string                 `json:"additionalComments,omitempty"`
+	WorkNotes           *string                 `json:"workNotes,omitempty"`
+	WatchList           *[]string               `json:"watchList,omitempty"`
 }
 
 // UpdateIncidentResponse is the output for PATCH /incidents/{id}.

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -600,13 +600,15 @@ var validIncidentUrgency = map[domain.IncidentUrgency]bool{
 	domain.IncidentUrgencyLow:    true,
 }
 
-var validIncidentResolutionCode = map[domain.IncidentResolutionCode]bool{
-	domain.IncidentResolutionCodeSolvedWorkaround:         true,
-	domain.IncidentResolutionCodeSolvedPermanently:        true,
-	domain.IncidentResolutionCodeNotSolvedNotReproducible: true,
-	domain.IncidentResolutionCodeFalseAlarm:               true,
-	domain.IncidentResolutionCodeDuplicateAlert:           true,
-	domain.IncidentResolutionCodeNotActionableAlert:       true,
+// snIncidentResolutionCodeKeyMap maps domain IncidentResolutionCode enums to SN close_code
+// string values -- same convention as snIncidentCategoryKeyMap.
+var snIncidentResolutionCodeKeyMap = map[domain.IncidentResolutionCode]string{
+	domain.IncidentResolutionCodeSolvedWorkaround:         "Solved (Work Around)",
+	domain.IncidentResolutionCodeSolvedPermanently:        "Solved (Permanently)",
+	domain.IncidentResolutionCodeNotSolvedNotReproducible: "Not Solved (Not Reproducible)",
+	domain.IncidentResolutionCodeFalseAlarm:               "False Alarm",
+	domain.IncidentResolutionCodeDuplicate:                "Duplicate",
+	domain.IncidentResolutionCodeNotActionable:            "Not Actionable Alert",
 }
 
 // snCreateIncidentPayload is the Choreo POST /incidents request body.
@@ -1223,8 +1225,10 @@ func (s *snIncidentService) UpdateIncident(ctx context.Context, req domain.Updat
 	if req.Urgency != nil && !validIncidentUrgency[*req.Urgency] {
 		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid urgency: " + string(*req.Urgency)}
 	}
-	if req.ResolutionCode != nil && !validIncidentResolutionCode[*req.ResolutionCode] {
-		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid resolutionCode: " + string(*req.ResolutionCode)}
+	if req.ResolutionCode != nil {
+		if _, ok := snIncidentResolutionCodeKeyMap[*req.ResolutionCode]; !ok {
+			return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid resolutionCode: " + string(*req.ResolutionCode)}
+		}
 	}
 
 	optionalUUIDs := map[string]*string{
@@ -1302,7 +1306,7 @@ func (s *snIncidentService) UpdateIncident(ctx context.Context, req domain.Updat
 		payload.UrgencyKey = &v
 	}
 	if req.ResolutionCode != nil {
-		v := string(*req.ResolutionCode)
+		v := snIncidentResolutionCodeKeyMap[*req.ResolutionCode]
 		payload.ResolutionCodeKey = &v
 	}
 	if req.ParentID != nil {

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -600,6 +600,15 @@ var validIncidentUrgency = map[domain.IncidentUrgency]bool{
 	domain.IncidentUrgencyLow:    true,
 }
 
+var validIncidentResolutionCode = map[domain.IncidentResolutionCode]bool{
+	domain.IncidentResolutionCodeSolvedWorkaround:         true,
+	domain.IncidentResolutionCodeSolvedPermanently:        true,
+	domain.IncidentResolutionCodeNotSolvedNotReproducible: true,
+	domain.IncidentResolutionCodeFalseAlarm:               true,
+	domain.IncidentResolutionCodeDuplicateAlert:           true,
+	domain.IncidentResolutionCodeNotActionableAlert:       true,
+}
+
 // snCreateIncidentPayload is the Choreo POST /incidents request body.
 type snCreateIncidentPayload struct {
 	CallerID            string   `json:"callerId"`
@@ -1214,6 +1223,9 @@ func (s *snIncidentService) UpdateIncident(ctx context.Context, req domain.Updat
 	if req.Urgency != nil && !validIncidentUrgency[*req.Urgency] {
 		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid urgency: " + string(*req.Urgency)}
 	}
+	if req.ResolutionCode != nil && !validIncidentResolutionCode[*req.ResolutionCode] {
+		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid resolutionCode: " + string(*req.ResolutionCode)}
+	}
 
 	optionalUUIDs := map[string]*string{
 		"parentId":            req.ParentID,
@@ -1290,7 +1302,8 @@ func (s *snIncidentService) UpdateIncident(ctx context.Context, req domain.Updat
 		payload.UrgencyKey = &v
 	}
 	if req.ResolutionCode != nil {
-		payload.ResolutionCodeKey = req.ResolutionCode
+		v := string(*req.ResolutionCode)
+		payload.ResolutionCodeKey = &v
 	}
 	if req.ParentID != nil {
 		v := uuidToSysid(*req.ParentID)

--- a/entity-service/internal/service/sn_incident_service_test.go
+++ b/entity-service/internal/service/sn_incident_service_test.go
@@ -175,6 +175,57 @@ func TestSNIncidentService_UpdateIncident_WatchList_InvalidUUID(t *testing.T) {
 	}
 }
 
+// TestSNIncidentService_UpdateIncident_ResolutionCodePassedThrough verifies a valid closed
+// enum resolution code is sent straight through as the payload's resolutionCodeKey string,
+// with no translation step.
+func TestSNIncidentService_UpdateIncident_ResolutionCodePassedThrough(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/incidents/"+testIncidentSysid, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"message": "Incident updated successfully.",
+			"incident": {"id": "` + testIncidentSysid + `", "number": "INC0001", "createdOn": "2026-01-01 00:00:00", "createdBy": "engineer@example.com"}
+		}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowIncidentService(client, nil)
+
+	code := domain.IncidentResolutionCodeSolvedWorkaround
+	_, err := svc.UpdateIncident(contextWithUserIDToken("token"), domain.UpdateIncidentRequest{
+		ID:             testIncidentUUID,
+		ResolutionCode: &code,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, _ := gotBody["resolutionCodeKey"].(string)
+	if got != "Solved (Work Around)" {
+		t.Fatalf("resolutionCodeKey: got %q, want %q", got, "Solved (Work Around)")
+	}
+}
+
+// TestSNIncidentService_UpdateIncident_ResolutionCode_Invalid verifies a resolution code
+// outside the closed enum is rejected with a clean validation error before any SN call.
+func TestSNIncidentService_UpdateIncident_ResolutionCode_Invalid(t *testing.T) {
+	// client is intentionally nil: validation must fail before touching it.
+	svc := NewServiceNowIncidentService(nil, nil)
+
+	code := domain.IncidentResolutionCode("Not A Real Code")
+	_, err := svc.UpdateIncident(contextWithUserIDToken("token"), domain.UpdateIncidentRequest{
+		ID:             testIncidentUUID,
+		ResolutionCode: &code,
+	})
+	if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
 // TestSNIncidentService_SearchIncidents_NumberFilterPassedThrough verifies the
 // exact-match Number filter reaches the outgoing payload under the "number" key
 // unchanged, alongside the untouched free-text searchQuery.

--- a/entity-service/internal/service/sn_incident_service_test.go
+++ b/entity-service/internal/service/sn_incident_service_test.go
@@ -176,8 +176,8 @@ func TestSNIncidentService_UpdateIncident_WatchList_InvalidUUID(t *testing.T) {
 }
 
 // TestSNIncidentService_UpdateIncident_ResolutionCodePassedThrough verifies a valid closed
-// enum resolution code is sent straight through as the payload's resolutionCodeKey string,
-// with no translation step.
+// enum resolution code is mapped to the SN close_code string value in the payload's
+// resolutionCodeKey field, same convention as category/impact/urgency.
 func TestSNIncidentService_UpdateIncident_ResolutionCodePassedThrough(t *testing.T) {
 	var gotBody map[string]any
 	mux := http.NewServeMux()

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -12539,6 +12539,13 @@ components:
         resolutionCode:
           type: string
           nullable: true
+          enum:
+            - "Solved (Work Around)"
+            - "Solved (Permanently)"
+            - "Not Solved (Not Reproducible)"
+            - "False Alarm"
+            - "Duplicate"
+            - "Not Actionable Alert"
         parentId:
           type: string
           format: uuid

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -12540,12 +12540,12 @@ components:
           type: string
           nullable: true
           enum:
-            - "Solved (Work Around)"
-            - "Solved (Permanently)"
-            - "Not Solved (Not Reproducible)"
-            - "False Alarm"
-            - "Duplicate"
-            - "Not Actionable Alert"
+            - SOLVED_WORKAROUND
+            - SOLVED_PERMANENTLY
+            - NOT_SOLVED_NOT_REPRODUCIBLE
+            - FALSE_ALARM
+            - DUPLICATE
+            - NOT_ACTIONABLE
         parentId:
           type: string
           format: uuid


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Three incident-workflow gaps in the CSM portal: resolution code was free text
instead of a fixed choice list, and closing an incident as a duplicate had no
dedicated path even though the backing data source already lists "Duplicate" as
a valid resolution.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Close the incident resolution code to the real 6-value choice list, enforced
  end-to-end (entity service, BFF, webapp).
- Make "close as duplicate" possible by exposing "Duplicate" as a pickable
  resolution code (no new field or endpoint needed).
- Document the incident specialist-handoff ("Escalate to Special Ops") endpoint
  and its derived summary field in both services' OpenAPI contracts — the
  underlying feature already existed in code but was undocumented.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- **entity-service**: added a closed `IncidentResolutionCode` enum (mirroring the
  existing `IncidentCategory`/`IncidentImpact`/`IncidentUrgency` pattern), switched
  `UpdateIncidentRequest.ResolutionCode` to it, added server-side validation.
- **CSM backend (BFF)**: documented the same enum in its own OpenAPI contract, and
  documented the `POST /incidents/{id}/specialist-handoffs` endpoint plus the
  `specialistHandoff` summary field on `IncidentDetail` — both already implemented
  in code from prior work, just undocumented.
- **CSM webapp**: replaced the free-text resolution-code field with a dropdown in
  both places it's set (the resolve/close confirmation dialog and the edit
  dialog), sourced from the closed enum, mirroring the existing case-resolution
  dropdown pattern. Updated the in-app user guide's incident-ops topic to match.

## User stories
> Summary of user stories addressed by this change>

As a CS engineer, I can pick an incident's resolution code from a fixed list
instead of typing it freely, and I can close an incident as a duplicate by
picking that option.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Incident resolution code is now a dropdown with a fixed set of options,
including "Duplicate" for closing duplicate incidents.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

Updated the CSM portal's in-app `/help` incident-ops topic as part of this PR.

## Training
N/A — no training content repo impact for this change.

## Certification
N/A — no certification exam impact for this change.

## Marketing
N/A — internal workflow fix, no marketing impact.

## Automation tests
 - Unit tests
   > Code coverage information

   entity-service: added tests covering valid resolution-code passthrough and
   invalid-code rejection. CSM webapp: added a test file for the resolution
   dialog's dropdown, updated existing tests for the edit dialog and incident
   detail page to exercise the new `Select` instead of free text.
 - Integration tests
   > Details about the test cases and coverage

   None added; existing suite exercised end-to-end (`go test ./...`,
   `npx vitest run`) with no regressions.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go/TypeScript change, no Java code touched
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema/data migration involved.

## Test environment
Verified with `go build`/`go vet`/`go test` (entity-service, Go toolchain per
go.mod) and `tsc -b --noEmit`/`vitest run`/`eslint` (CSM webapp, Node per
package.json). No browser-specific testing performed.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to hand incidents off to a specialist group, clear the current assignee, create a runbook-gap task, and optionally file an internal issue.
  - Incident details now display specialist handoff information when available.
  - Added a dropdown for selecting incident resolution codes.

- **Bug Fixes**
  - Resolution codes are now validated against six supported options, preventing invalid values from being submitted.

- **Documentation**
  - Updated Operations help content with resolution-code guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->