### PR TITLE
[CSM Portal] Remove closeNotes from customer portal API and UI

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -318,8 +318,10 @@ type CaseWatchListUser struct {
 // Deliberately excludes entity-service's AutoclosureStep/AutoclosureStateTime
 // and BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta — genuinely
 // CSM-engineer-facing only. CsManager and FindingsResolved/FindingsTotal
-// have no entity-service equivalent on CaseView. CloseNotes is on the
-// GET path (Ballerina CaseResponse.closeNotes) as well as PATCH.
+// have no entity-service equivalent on CaseView. CloseNotes is deliberately
+// NOT exposed here even though entity-service's CaseView carries it (GET path)
+// as well as PATCH: it is an internal CS-agent close note, never meant for
+// the customer-facing view.
 type CaseDetails struct {
 	ID                    string                       `json:"id"`
 	InternalID            string                       `json:"internalId"`
@@ -363,7 +365,6 @@ type CaseDetails struct {
 	// no frontend consumer, so per CLAUDE.md they stay trimmed until one exists.
 	SLAResponseTime     *string   `json:"slaResponseTime,omitempty"`
 	ClosedBy            *Ref      `json:"closedBy,omitempty"`
-	CloseNotes          *string   `json:"closeNotes,omitempty"`
 	HasAutoClosed       *bool     `json:"hasAutoClosed,omitempty"`
 	EngagementStartDate *string   `json:"engagementStartDate,omitempty"`
 	EngagementEndDate   *string   `json:"engagementEndDate,omitempty"`
@@ -466,7 +467,6 @@ func MapCaseDetails(c entity.CaseView) CaseDetails {
 		FixEta:                c.FixEta,
 		SLAResponseTime:       c.SLAResponseTime,
 		ClosedBy:              mapRef(c.ClosedBy),
-		CloseNotes:            c.CloseNotes,
 		HasAutoClosed:         c.HasAutoClosed,
 		EngagementStartDate:   c.EngagementStartDate,
 		EngagementEndDate:     c.EngagementEndDate,
@@ -664,7 +664,6 @@ type CaseUpdateResponse struct {
 	AssignedTo     *PersonRef `json:"assignedTo,omitempty"`
 	ResolutionCode *string    `json:"resolutionCode,omitempty"`
 	Cause          *string    `json:"cause,omitempty"`
-	CloseNotes     *string    `json:"closeNotes,omitempty"`
 	ResolvedOn     *time.Time `json:"resolvedOn,omitempty"`
 	ParentCase     *NumberRef `json:"parentCase,omitempty"`
 	FixEta         *time.Time `json:"fixEta,omitempty"`
@@ -701,7 +700,6 @@ func MapCaseUpdate(r entity.UpdateCaseResponse) CaseUpdateResponse {
 		AssignedTo:     assignedTo,
 		ResolutionCode: c.ResolutionCode,
 		Cause:          c.Cause,
-		CloseNotes:     c.CloseNotes,
 		ResolvedOn:     c.ResolvedOn,
 		ParentCase:     mapNumberRef(c.ParentCase),
 		FixEta:         c.FixEta,

--- a/apps/customer-portal/backend-v2/internal/dto/case_detail_fields_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_detail_fields_test.go
@@ -23,10 +23,14 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 )
 
-// TestMapCaseDetails_ExposesFieldsTheFrontendDeclares covers the five fields
-// added because the frontend's CaseDetails type declares them
+// TestMapCaseDetails_ExposesFieldsTheFrontendDeclares covers the fields added
+// because the frontend's CaseDetails type declares them
 // (features/support/types/cases.ts) while this backend never sent them —
 // entity-service was discarding them from the upstream case response.
+// CloseNotes is deliberately excluded from what's asserted present here (see
+// the closeNotes assertion below): it's an internal CS-agent field that must
+// never reach the customer-facing response, even though it's still decoded
+// off the upstream CaseView.
 func TestMapCaseDetails_ExposesFieldsTheFrontendDeclares(t *testing.T) {
 	sla := "4 hours"
 	start, end := "2026-01-01", "2026-06-30"
@@ -66,8 +70,11 @@ func TestMapCaseDetails_ExposesFieldsTheFrontendDeclares(t *testing.T) {
 	if cb["id"] != "user-1" {
 		t.Errorf("closedBy.id = %v, want user-1", cb["id"])
 	}
-	if got["closeNotes"] != notes {
-		t.Errorf("closeNotes = %v, want %q", got["closeNotes"], notes)
+	// CloseNotes is read off the upstream CaseView (it's still decoded above)
+	// but must never reach the customer-facing response: it's an internal
+	// CS-agent close note, not something a customer should see.
+	if _, present := got["closeNotes"]; present {
+		t.Errorf("closeNotes = %v, want omitted from the customer-facing response", got["closeNotes"])
 	}
 }
 

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -6858,8 +6858,6 @@ components:
           type: string
         cause:
           type: string
-        closeNotes:
-          type: string
         resolvedOn:
           type: string
         parentCase:

--- a/apps/customer-portal/microapp/src/types/case.dto.ts
+++ b/apps/customer-portal/microapp/src/types/case.dto.ts
@@ -49,7 +49,6 @@ export interface CaseDto {
   csManager: (EntityReference & { email: string | null }) | null;
   closedOn: string | null;
   closedBy: (EntityReference & { count: number | null }) | null;
-  closeNotes: string | null;
   hasAutoClosed: boolean | null;
   id: string;
   internalId: string;

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -575,12 +575,6 @@ export default function CaseDetailsDetailsPanel({
                 )}
               </Typography>
             </Box>
-            <Box sx={{ gridColumn: { xs: "1", md: "1 / -1" } }}>
-              <Typography {...labelSx}>Close Notes</Typography>
-              <Typography {...valueSx}>
-                {formatValue(data?.closeNotes)}
-              </Typography>
-            </Box>
           </Box>
         </CaseDetailsCard>
       )}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/__tests__/CaseDetailsContent.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/__tests__/CaseDetailsContent.test.tsx
@@ -44,7 +44,6 @@ const mockCaseDetails = {
   status: { id: "1", label: "Open" },
   closedOn: null,
   closedBy: null,
-  closeNotes: null,
   hasAutoClosed: null,
   engineerEmail: null,
   findingsResolved: null,

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/__tests__/CaseDetailsDetailsPanel.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/__tests__/CaseDetailsDetailsPanel.test.tsx
@@ -46,7 +46,6 @@ const mockCaseDetails: Partial<CaseDetails> = {
   status: { id: "1", label: "Open" },
   closedOn: null,
   closedBy: null,
-  closeNotes: null,
   hasAutoClosed: null,
 };
 
@@ -150,15 +149,13 @@ describe("CaseDetailsDetailsPanel", () => {
         status: { id: "3", label: "Closed" },
         closedOn: "2026-02-20 01:34:44",
         closedBy: { id: "bcc4881f", name: "Anuradha Basnayake" },
-        closeNotes: "Resolved successfully",
       },
     });
     expect(screen.getByText("Closed Case Details")).toBeInTheDocument();
     expect(screen.getByText("Closed On")).toBeInTheDocument();
     expect(screen.getByText("Closed By")).toBeInTheDocument();
-    expect(screen.getByText("Close Notes")).toBeInTheDocument();
+    expect(screen.queryByText("Close Notes")).not.toBeInTheDocument();
     expect(screen.getByText("Anuradha Basnayake")).toBeInTheDocument();
-    expect(screen.getByText("Resolved successfully")).toBeInTheDocument();
   });
 
   it("should not render Closed Case Details when case is not closed", () => {

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/__tests__/CaseDetailsTabPanels.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/__tests__/CaseDetailsTabPanels.test.tsx
@@ -51,7 +51,6 @@ const mockCaseDetails = {
   severity: { id: "60", label: "S0" },
   closedOn: null,
   closedBy: null,
-  closeNotes: null,
   hasAutoClosed: null,
 };
 

--- a/apps/customer-portal/webapp/src/features/support/types/cases.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/cases.ts
@@ -294,7 +294,6 @@ export type CaseDetails = AuditMetadata & {
   status: IdLabelRef | null;
   closedOn: string | null;
   closedBy: CaseDetailsClosedBy | null;
-  closeNotes: string | null;
   hasAutoClosed: boolean | null;
   engineerEmail: string | null;
   findingsResolved: number | null;


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

`closeNotes` is an internal CS-agent close note. It was being returned by the customer
portal's backend API and rendered in the customer portal webapp's closed-case details view,
even though customers should never see it.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Stop `closeNotes` from reaching the customer, at both the API and UI layer.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- `backend-v2`: removed `closeNotes` from the outward `CaseDetails` (GET) and
  `CaseUpdateResponse` (PATCH) response DTOs and from `openapi.yaml`. The field is still
  decoded off the upstream entity-service response into internal structs (so unmarshaling
  doesn't break), it's just no longer copied into what gets sent back to the customer.
- `webapp`: removed the "Close Notes" row from the closed-case details panel and the
  `closeNotes` field from the case-detail TS type.
- `microapp`: removed the unused `closeNotes` field from its case DTO type (no render site
  referenced it).

This is a UI change (removes a labeled field from a details panel) but has no visual layout
impact beyond that field disappearing — no screenshot attached since it's a straightforward
removal, not a redesign.

## User stories
> Summary of user stories addressed by this change

As a customer, I should not see internal CS-agent close notes on my closed cases.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Removed the internal "Close Notes" field from customer-visible case details and the
customer portal API response.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — no customer-facing product documentation described this field.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A — no training content references this field.

## Certification
> Type "Sent" when you have provided new/updated certification questions...

N/A — not exam-relevant.

## Marketing
> Link to drafts of marketing content...

N/A — internal field removal, no marketing impact.

## Automation tests
 - Unit tests
   > Code coverage information

Updated `backend-v2/internal/dto/case_detail_fields_test.go` to assert `closeNotes` is
absent from the outward response; `go test ./...` passes. Updated three webapp test files
(`CaseDetailsDetailsPanel.test.tsx`, `CaseDetailsContent.test.tsx`, `CaseDetailsTabPanels.test.tsx`)
to drop the field from mocks, with a new assertion that "Close Notes" does not render.

 - Integration tests
   > Details about the test cases and coverage

None added; this is a field-removal change with existing unit coverage updated in place.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go/TypeScript change, not Java
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

N/A

## Related PRs
> List any other related PRs

None

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A — no data migration; response shape change only removes a field.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Verified locally: `go build`/`go test` (backend-v2), `tsc -b` (webapp, microapp), targeted
`vitest run` on the three updated test files (macOS, Node/Go versions per repo's toolchain).
Three pre-existing test failures in `CaseDetailsTabPanels.test.tsx` were confirmed
unrelated to this change (missing `<Router>`/hook mocks in those test files, reproduced
identically against unmodified `main`).

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

N/A
