### PR TITLE
Entity Service - Stop failing entity-service startup when Postgres is unreachable

### DIFF
--- a/entity-service/.env.example
+++ b/entity-service/.env.example
@@ -4,17 +4,11 @@ SERVER_PORT=8080
 # Data source: "postgres" (default) or "servicenow"
 DATA_SOURCE=postgres
 
-# PostgreSQL — required for EVERY DATA_SOURCE, including "servicenow".
-# event_publish_failures (migration 000010), sla_clocks (000011), and
-# scheduled_task_run (000013) have no ServiceNow equivalent and are always
-# Postgres-backed, so routes.go wires their repositories unconditionally and
-# cmd/api/main.go opens (and pings) the pool before the server starts.
-#
-# UPGRADE NOTE: earlier versions skipped the pool entirely when
-# DATA_SOURCE=servicenow (db.NewPoolIfNeeded, since removed). A servicenow-mode
-# deployment that has never had DB credentials will fail to start after this
-# change — provision DB_USER/DB_PASSWORD/DB_NAME and a reachable database, and
-# apply the migrations, before rolling it out.
+# PostgreSQL — required when DATA_SOURCE=postgres. Optional for
+# DATA_SOURCE=servicenow: db.NewPoolIfNeeded skips the pool so a local
+# customer-portal can start without a reachable database. Side tables
+# (event_publish_failures, sla_clocks, scheduled_task_run) are registered
+# only when a pool is available.
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=<YOUR_DB_USER>

--- a/entity-service/cmd/api/main.go
+++ b/entity-service/cmd/api/main.go
@@ -42,11 +42,13 @@ func main() {
 		log.Fatalf("invalid configuration: %v", err)
 	}
 
-	pool, err := db.NewPoolFromConfig(cfg)
+	pool, err := db.NewPoolIfNeeded(cfg)
 	if err != nil {
 		log.Fatalf("connect to database: %v", err)
 	}
-	defer pool.Close()
+	if pool != nil {
+		defer pool.Close()
+	}
 
 	addr := ":" + cfg.ServerPort
 	srv, eventPublisher := server.New(addr, pool, cfg)

--- a/entity-service/internal/config/config.go
+++ b/entity-service/internal/config/config.go
@@ -106,8 +106,8 @@ func getEnvOrDefault(key, defaultVal string) string {
 
 // Validate checks that the configuration is self-consistent. It returns an
 // error if DATA_SOURCE is an unrecognised value, if DB_USER/DB_PASSWORD/DB_NAME
-// are missing (required regardless of DATA_SOURCE — see db.NewPoolFromConfig),
-// if SERVICENOW_INTEGRATION_SERVICE_BASE_URL is missing when
+// are missing when DATA_SOURCE=postgres (see db.NewPoolIfNeeded), if
+// SERVICENOW_INTEGRATION_SERVICE_BASE_URL is missing when
 // DATA_SOURCE=servicenow, or if EVENT_HUB_BROKER/EVENT_HUB_CONNECTION_STRING/
 // EVENT_HUB_TOPIC are only partially set.
 func (c *Config) Validate() error {
@@ -117,25 +117,21 @@ func (c *Config) Validate() error {
 	default:
 		return fmt.Errorf("invalid DATA_SOURCE %q: must be %q or %q", c.DataSource, DataSourcePostgres, DataSourceServiceNow)
 	}
-	// Postgres is required for every DataSource, not just DataSourcePostgres:
-	// event_publish_failures, sla_clocks, and scheduled_task_run have no
-	// ServiceNow equivalent, so routes.go wires their repositories
-	// unconditionally and cmd/api/main.go opens the pool before serving.
-	// Earlier versions skipped the pool in servicenow mode (the removed
-	// db.NewPoolIfNeeded), so a servicenow deployment that never had DB
-	// credentials fails here on upgrade — hence the explicit reason in each
-	// message rather than a bare "X is required".
-	const dbAlwaysRequired = "PostgreSQL is required for every DATA_SOURCE, " +
-		"including servicenow (event_publish_failures, sla_clocks, and " +
-		"scheduled_task_run have no ServiceNow equivalent)"
-	if c.DBUser == "" {
-		return fmt.Errorf("DB_USER is required: %s", dbAlwaysRequired)
-	}
-	if c.DBPassword == "" {
-		return fmt.Errorf("DB_PASSWORD is required: %s", dbAlwaysRequired)
-	}
-	if c.DBName == "" {
-		return fmt.Errorf("DB_NAME is required: %s", dbAlwaysRequired)
+	// Postgres credentials are required only for DATA_SOURCE=postgres.
+	// servicenow mode skips the pool (db.NewPoolIfNeeded) so a local
+	// customer-portal can start without a reachable database. Side tables
+	// that have no ServiceNow equivalent are registered only when a pool
+	// is available — see routes.go.
+	if c.DataSource == DataSourcePostgres {
+		if c.DBUser == "" {
+			return fmt.Errorf("DB_USER is required when DATA_SOURCE=postgres")
+		}
+		if c.DBPassword == "" {
+			return fmt.Errorf("DB_PASSWORD is required when DATA_SOURCE=postgres")
+		}
+		if c.DBName == "" {
+			return fmt.Errorf("DB_NAME is required when DATA_SOURCE=postgres")
+		}
 	}
 	if c.DataSource == DataSourceServiceNow {
 		if c.ServiceNowIntegrationServiceBaseURL == "" {

--- a/entity-service/internal/config/config_test.go
+++ b/entity-service/internal/config/config_test.go
@@ -105,6 +105,19 @@ func TestConfig_Validate_RequiresDBFields(t *testing.T) {
 	}
 }
 
+func TestConfig_Validate_ServiceNowDoesNotRequireDBFields(t *testing.T) {
+	c := Config{
+		DataSource:                               DataSourceServiceNow,
+		ServiceNowIntegrationServiceBaseURL:      "https://example.com",
+		ServiceNowIntegrationServiceTokenURL:     "https://example.com/token",
+		ServiceNowIntegrationServiceClientID:     "client-id",
+		ServiceNowIntegrationServiceClientSecret: "client-secret",
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil when DATA_SOURCE=servicenow has no DB credentials", err)
+	}
+}
+
 func TestConfig_Validate_ServiceNowRequiresIntegrationServiceFields(t *testing.T) {
 	base := func() Config {
 		c := baseValidConfig()

--- a/entity-service/internal/db/postgres.go
+++ b/entity-service/internal/db/postgres.go
@@ -60,13 +60,16 @@ func NewPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	return pool, nil
 }
 
-// NewPoolFromConfig creates a Postgres connection pool from cfg's DSN, with a
-// 10s connect timeout. Always required, regardless of cfg.DataSource: when
-// DATA_SOURCE=servicenow, case/account/etc. entity reads/writes go through
-// the SN integration service instead of this pool, but event_publish_failures
-// (see domain.EventPublishFailure) has no ServiceNow equivalent and is
-// always backed by Postgres, so a pool is always needed.
-func NewPoolFromConfig(cfg *config.Config) (*pgxpool.Pool, error) {
+// NewPoolIfNeeded creates a Postgres connection pool when one is needed.
+// When DATA_SOURCE=servicenow, case/account/etc. reads go through the SN
+// integration service, so no pool is opened and (nil, nil) is returned.
+// Side tables (event_publish_failures, sla_clocks, scheduled_task_run) have
+// no ServiceNow equivalent and are registered in routes.go only when a pool
+// is available — they must not block SN-mode startup (local customer-portal).
+func NewPoolIfNeeded(cfg *config.Config) (*pgxpool.Pool, error) {
+	if cfg.DataSource == config.DataSourceServiceNow {
+		return nil, nil
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	return NewPool(ctx, cfg.DSN())

--- a/entity-service/internal/db/postgres_test.go
+++ b/entity-service/internal/db/postgres_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/License-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package db
+
+import (
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/config"
+)
+
+func TestNewPoolIfNeeded_ServiceNowSkipsPool(t *testing.T) {
+	pool, err := NewPoolIfNeeded(&config.Config{
+		DataSource: config.DataSourceServiceNow,
+		DBHost:     "db-that-must-not-be-dialed.example",
+		DBPort:     "5432",
+		DBUser:     "user",
+		DBPassword: "password",
+		DBName:     "db",
+	})
+	if err != nil {
+		t.Fatalf("NewPoolIfNeeded() = %v, want nil", err)
+	}
+	if pool != nil {
+		t.Fatal("NewPoolIfNeeded() returned a pool for DATA_SOURCE=servicenow")
+	}
+}

--- a/entity-service/internal/server/directory_routes_test.go
+++ b/entity-service/internal/server/directory_routes_test.go
@@ -82,6 +82,21 @@ func TestGroupsSearch_IsStillALiveQuery(t *testing.T) {
 // registry and the role allow-list are the caller's configuration now, and this
 // service no longer reads either. If someone reinstates a route here, the
 // registry has two owners again and they will silently disagree.
+// TestPostgresOnlyRoutesAreAbsentWithoutAPool pins that SN-mode startup
+// without a reachable database must not register the side-table routes.
+func TestPostgresOnlyRoutesAreAbsentWithoutAPool(t *testing.T) {
+	router := newDirectoryRouter(t)
+	for _, path := range []string{
+		"/event-publish-failures/search",
+		"/scheduled-tasks/attempts",
+	} {
+		rec := postDirectory(t, router, path, `{}`)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("POST %s = %d, want 404 when the pool is nil", path, rec.Code)
+		}
+	}
+}
+
 func TestCuratedCataloguesAreNoLongerServedHere(t *testing.T) {
 	router := newDirectoryRouter(t)
 	for _, path := range []string{"/teams/search", "/roles/search"} {

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -63,10 +63,10 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) (http.Handler, service.Even
 	// EventPublishingEnabled, a separate safe-by-default kill switch: Event
 	// Hub can be fully configured and this still stays nil until that's
 	// explicitly turned on. nil when unset; every caller (snCaseService,
-	// snIncidentService) already handles that. A pool is also required so
-	// publish failures can be recorded.
+	// snIncidentService) already handles that. eventPublishFailureSvc is
+	// nil without a pool; Publish then skips durable recording.
 	var eventPublisher service.EventPublisherService
-	if db != nil && cfg.EventHubBroker != "" && cfg.EventPublishingEnabled {
+	if cfg.EventHubBroker != "" && cfg.EventPublishingEnabled {
 		eventPublisher = service.NewEventPublisherService(
 			eventbus.NewProducer(eventbus.Config{
 				Broker:           cfg.EventHubBroker,

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -41,12 +41,20 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) (http.Handler, service.Even
 	userSvc := service.NewUserService(userRepo)
 	userHandler := handler.NewUserHandler(userSvc)
 
-	// event_publish_failures has no ServiceNow equivalent — always backed by
-	// Postgres regardless of cfg.DataSource, same as the pool itself (see
-	// db.NewPool's call site in cmd/api/main.go).
-	eventPublishFailureRepo := repository.NewEventPublishFailureRepository(db)
-	eventPublishFailureSvc := service.NewEventPublishFailureService(eventPublishFailureRepo)
-	eventPublishFailureHandler := handler.NewEventPublishFailureHandler(eventPublishFailureSvc)
+	// event_publish_failures, sla_clocks, and scheduled_task_run have no
+	// ServiceNow equivalent. They are Postgres-backed and registered only
+	// when a pool is available (db.NewPoolIfNeeded returns nil for
+	// DATA_SOURCE=servicenow so local SN-mode startups are not blocked).
+	var eventPublishFailureHandler *handler.EventPublishFailureHandler
+	var eventPublishFailureSvc service.EventPublishFailureService
+	var slaClockHandler *handler.SLAClockHandler
+	var scheduledTaskRunHandler *handler.ScheduledTaskRunHandler
+	if db != nil {
+		eventPublishFailureSvc = service.NewEventPublishFailureService(repository.NewEventPublishFailureRepository(db))
+		eventPublishFailureHandler = handler.NewEventPublishFailureHandler(eventPublishFailureSvc)
+		slaClockHandler = handler.NewSLAClockHandler(service.NewSLAClockService(repository.NewSLAClockRepository(db)))
+		scheduledTaskRunHandler = handler.NewScheduledTaskRunHandler(service.NewScheduledTaskRunService(repository.NewScheduledTaskRunRepository(db)))
+	}
 
 	// EventPublisherService is optional, like every ServiceNow-only
 	// dependency below — gated on EventHubBroker rather than cfg.DataSource,
@@ -55,9 +63,10 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) (http.Handler, service.Even
 	// EventPublishingEnabled, a separate safe-by-default kill switch: Event
 	// Hub can be fully configured and this still stays nil until that's
 	// explicitly turned on. nil when unset; every caller (snCaseService,
-	// snIncidentService) already handles that.
+	// snIncidentService) already handles that. A pool is also required so
+	// publish failures can be recorded.
 	var eventPublisher service.EventPublisherService
-	if cfg.EventHubBroker != "" && cfg.EventPublishingEnabled {
+	if db != nil && cfg.EventHubBroker != "" && cfg.EventPublishingEnabled {
 		eventPublisher = service.NewEventPublisherService(
 			eventbus.NewProducer(eventbus.Config{
 				Broker:           cfg.EventHubBroker,
@@ -67,18 +76,6 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) (http.Handler, service.Even
 			eventPublishFailureSvc,
 		)
 	}
-
-	// sla_clocks has no ServiceNow equivalent either — same reasoning as
-	// event_publish_failures above.
-	slaClockRepo := repository.NewSLAClockRepository(db)
-	slaClockHandler := handler.NewSLAClockHandler(service.NewSLAClockService(slaClockRepo))
-
-	// scheduled_task_run has no ServiceNow equivalent either — same
-	// reasoning as sla_clocks/event_publish_failures above. Backs
-	// operations/csm-scheduled-tasks; see that component's own CLAUDE.md
-	// and this service's CLAUDE.md ("Scheduled task runs").
-	scheduledTaskRunRepo := repository.NewScheduledTaskRunRepository(db)
-	scheduledTaskRunHandler := handler.NewScheduledTaskRunHandler(service.NewScheduledTaskRunService(scheduledTaskRunRepo))
 
 	accountRepo := repository.NewAccountRepository(db)
 	accountHandler := handler.NewAccountHandler(service.NewAccountService(accountRepo))
@@ -324,18 +321,22 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) (http.Handler, service.Even
 
 	mux.HandleFunc("GET /health", handler.HealthCheck)
 
-	// event_publish_failures is not data-source specific, same rationale as
-	// the role catalogue and team registry below — registered unconditionally.
-	mux.HandleFunc("POST /event-publish-failures", eventPublishFailureHandler.CreateEventPublishFailure)
-	mux.HandleFunc("POST /event-publish-failures/search", eventPublishFailureHandler.SearchEventPublishFailures)
-	mux.HandleFunc("POST /event-publish-failures/{id}/resolve", eventPublishFailureHandler.ResolveEventPublishFailure)
-	mux.HandleFunc("POST /cases/{caseId}/sla-clocks", slaClockHandler.RegisterSLAClock)
-	mux.HandleFunc("GET /cases/{caseId}/sla-clocks/{clockType}", slaClockHandler.GetSLAClock)
-	mux.HandleFunc("PATCH /cases/{caseId}/sla-clocks/{clockType}/tiers/{tier}", slaClockHandler.SetSLAClockTierReached)
-	mux.HandleFunc("POST /scheduled-tasks/attempts", scheduledTaskRunHandler.AttemptScheduledTaskRun)
-	mux.HandleFunc("PATCH /scheduled-tasks/attempts/{id}", scheduledTaskRunHandler.UpdateScheduledTaskRunAttempt)
-	mux.HandleFunc("GET /scheduled-tasks/attempts", scheduledTaskRunHandler.ListScheduledTaskRuns)
-	mux.HandleFunc("DELETE /scheduled-tasks/attempts", scheduledTaskRunHandler.DeleteScheduledTaskRuns)
+	if eventPublishFailureHandler != nil {
+		mux.HandleFunc("POST /event-publish-failures", eventPublishFailureHandler.CreateEventPublishFailure)
+		mux.HandleFunc("POST /event-publish-failures/search", eventPublishFailureHandler.SearchEventPublishFailures)
+		mux.HandleFunc("POST /event-publish-failures/{id}/resolve", eventPublishFailureHandler.ResolveEventPublishFailure)
+	}
+	if slaClockHandler != nil {
+		mux.HandleFunc("POST /cases/{caseId}/sla-clocks", slaClockHandler.RegisterSLAClock)
+		mux.HandleFunc("GET /cases/{caseId}/sla-clocks/{clockType}", slaClockHandler.GetSLAClock)
+		mux.HandleFunc("PATCH /cases/{caseId}/sla-clocks/{clockType}/tiers/{tier}", slaClockHandler.SetSLAClockTierReached)
+	}
+	if scheduledTaskRunHandler != nil {
+		mux.HandleFunc("POST /scheduled-tasks/attempts", scheduledTaskRunHandler.AttemptScheduledTaskRun)
+		mux.HandleFunc("PATCH /scheduled-tasks/attempts/{id}", scheduledTaskRunHandler.UpdateScheduledTaskRunAttempt)
+		mux.HandleFunc("GET /scheduled-tasks/attempts", scheduledTaskRunHandler.ListScheduledTaskRuns)
+		mux.HandleFunc("DELETE /scheduled-tasks/attempts", scheduledTaskRunHandler.DeleteScheduledTaskRuns)
+	}
 
 	if snUserHandler != nil {
 		mux.HandleFunc("GET /users/{id}", snUserHandler.GetUser)

--- a/entity-service/internal/service/event_publisher_service.go
+++ b/entity-service/internal/service/event_publisher_service.go
@@ -48,7 +48,8 @@ type eventPublisherService struct {
 // apps/csm-portal/backend's own internal/eventpublisher.Publisher — which
 // has to record a failed publish via an HTTP call to this service's
 // POST /event-publish-failures — failures is called in-process here, since
-// this service is the one that already owns that table.
+// this service is the one that already owns that table. failures may be
+// nil when no Postgres pool is available; Publish then skips recording.
 func NewEventPublisherService(kafka kafkaProducer, failures EventPublishFailureService) EventPublisherService {
 	return &eventPublisherService{kafka: kafka, failures: failures}
 }
@@ -75,15 +76,19 @@ func (s *eventPublisherService) Publish(ctx context.Context, eventType events.Ty
 		return nil
 	}
 
-	recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), recordFailureTimeout)
-	defer cancel()
-	if _, recErr := s.failures.CreateEventPublishFailure(recordCtx, domain.CreateEventPublishFailureRequest{
-		EventType: string(eventType),
-		EntityID:  entityID,
-		Payload:   payload,
-		Error:     pubErr.Error(),
-	}); recErr != nil {
-		slog.ErrorContext(ctx, "eventpublisher: publish failed and recording the failure also failed", "eventType", eventType, "entityId", entityID, "publishErr", pubErr, "recordErr", recErr)
+	if s.failures == nil {
+		slog.ErrorContext(ctx, "eventpublisher: publish failed; skipping failure record (no store)", "eventType", eventType, "entityId", entityID, "publishErr", pubErr)
+	} else {
+		recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), recordFailureTimeout)
+		defer cancel()
+		if _, recErr := s.failures.CreateEventPublishFailure(recordCtx, domain.CreateEventPublishFailureRequest{
+			EventType: string(eventType),
+			EntityID:  entityID,
+			Payload:   payload,
+			Error:     pubErr.Error(),
+		}); recErr != nil {
+			slog.ErrorContext(ctx, "eventpublisher: publish failed and recording the failure also failed", "eventType", eventType, "entityId", entityID, "publishErr", pubErr, "recordErr", recErr)
+		}
 	}
 
 	return fmt.Errorf("eventpublisher: publish %s for entity %s: %w", eventType, entityID, pubErr)

--- a/entity-service/internal/service/event_publisher_service_test.go
+++ b/entity-service/internal/service/event_publisher_service_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/License-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/events"
+)
+
+type failKafka struct{}
+
+func (failKafka) Publish(context.Context, []byte, []byte) error {
+	return errors.New("broker down")
+}
+
+type recordingFailures struct {
+	calls int
+}
+
+func (r *recordingFailures) CreateEventPublishFailure(context.Context, domain.CreateEventPublishFailureRequest) (domain.EventPublishFailure, error) {
+	r.calls++
+	return domain.EventPublishFailure{ID: "f1"}, nil
+}
+
+func (r *recordingFailures) ResolveEventPublishFailure(context.Context, string) (domain.EventPublishFailure, error) {
+	return domain.EventPublishFailure{}, errors.New("unexpected ResolveEventPublishFailure")
+}
+
+func (r *recordingFailures) SearchEventPublishFailures(context.Context, domain.SearchEventPublishFailuresRequest) (domain.SearchEventPublishFailuresResponse, error) {
+	return domain.SearchEventPublishFailuresResponse{}, errors.New("unexpected SearchEventPublishFailures")
+}
+
+func TestPublish_SkipsRecordWhenFailuresNil(t *testing.T) {
+	pub := NewEventPublisherService(failKafka{}, nil)
+	err := pub.Publish(context.Background(), events.TypeCaseCreated, "case-1", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected publish error")
+	}
+}
+
+func TestPublish_RecordsWhenFailuresConfigured(t *testing.T) {
+	store := &recordingFailures{}
+	pub := NewEventPublisherService(failKafka{}, store)
+	err := pub.Publish(context.Background(), events.TypeCaseCreated, "case-1", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected publish error")
+	}
+	if store.calls != 1 {
+		t.Fatalf("CreateEventPublishFailure calls = %d, want 1", store.calls)
+	}
+}


### PR DESCRIPTION
## Summary
- Restore `NewPoolIfNeeded` so `DATA_SOURCE=servicenow` starts without opening or pinging Postgres. Local customer-portal was dying on `connect to database: ping database: context deadline exceeded` after the pool became mandatory.
- `Validate()` requires `DB_*` only for `DATA_SOURCE=postgres`. Side-table routes (`/event-publish-failures`, SLA clocks, scheduled tasks) register only when a pool is available.

## Test plan
- [x] `go test` for `internal/db`, `internal/config`, and `internal/server`
- [x] Local `DATA_SOURCE=servicenow` starts on `:8090` and `GET /health` returns 200 without reaching Azure Postgres
- [x] Postgres-only routes 404 when the pool is nil
- [x] Confirm a `DATA_SOURCE=postgres` deployment still requires credentials and a reachable database


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ServiceNow mode can now start without PostgreSQL credentials or a reachable database.
  - PostgreSQL-backed side-table features are enabled only when a database connection is available.

- **Bug Fixes**
  - Prevented unnecessary database connection attempts in ServiceNow mode.
  - PostgreSQL-only routes are no longer exposed when no database is configured.
  - Updated configuration validation and setup guidance to reflect conditional database requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->