### PR TITLE
[Customer Portal v2] backend: fix call-request UUID format and deployed-products search request shape

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/call_request.go
+++ b/apps/customer-portal/backend-v2/internal/dto/call_request.go
@@ -99,11 +99,14 @@ type CallRequestSearchRequest struct {
 	Pagination entity.Pagination        `json:"pagination"`
 }
 
-// toSysID converts an identifier (either a dashed UUID or a 32-hex sysid)
-// to a 32-character lowercase hex string without hyphens, for upstream services
-// that enforce ServiceNow's 32-hex IdString pattern constraint.
-func toSysID(id string) string {
-	return strings.ToLower(strings.ReplaceAll(id, "-", ""))
+// toDashedID converts an identifier (either a dashed UUID or a 32-hex sysid)
+// to a canonical lowercase 8-4-4-4-12 dashed UUID string expected by entity-service.
+func toDashedID(id string) string {
+	clean := strings.ToLower(strings.ReplaceAll(id, "-", ""))
+	if len(clean) == 32 {
+		return clean[0:8] + "-" + clean[8:12] + "-" + clean[12:16] + "-" + clean[16:20] + "-" + clean[20:32]
+	}
+	return strings.ToLower(id)
 }
 
 // BuildEntitySearchCallRequestsRequest translates the portal's request into
@@ -124,7 +127,7 @@ func BuildEntitySearchCallRequestsRequest(caseID string, req CallRequestSearchRe
 		filters = &entity.SearchCallRequestsFilters{States: states}
 	}
 	return entity.SearchCallRequestsRequest{
-		CaseID:     toSysID(caseID),
+		CaseID:     toDashedID(caseID),
 		Filters:    filters,
 		Pagination: req.Pagination,
 	}

--- a/apps/customer-portal/backend-v2/internal/dto/call_request_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/call_request_test.go
@@ -61,8 +61,8 @@ func TestBuildEntitySearchCallRequestsRequest_CaseIDFromPathAndStateKeysTranslat
 
 	got := BuildEntitySearchCallRequestsRequest("case-1", req)
 
-	if got.CaseID != toSysID("case-1") {
-		t.Fatalf("CaseID = %q, want %q", got.CaseID, toSysID("case-1"))
+	if got.CaseID != toDashedID("case-1") {
+		t.Fatalf("CaseID = %q, want %q", got.CaseID, toDashedID("case-1"))
 	}
 	if got.Filters == nil {
 		t.Fatal("expected non-nil Filters")
@@ -76,13 +76,13 @@ func TestBuildEntitySearchCallRequestsRequest_CaseIDFromPathAndStateKeysTranslat
 	}
 }
 
-func TestBuildEntitySearchCallRequestsRequest_CaseIDNormalizedToSysID(t *testing.T) {
+func TestBuildEntitySearchCallRequestsRequest_CaseIDNormalizedToDashedUUID(t *testing.T) {
 	req := CallRequestSearchRequest{
 		Pagination: entity.Pagination{Limit: 10, Offset: 0},
 	}
-	got := BuildEntitySearchCallRequestsRequest("26051dbc-3baa-8f50-9140-4c6aa5e45a1c", req)
-	if got.CaseID != "26051dbc3baa8f5091404c6aa5e45a1c" {
-		t.Fatalf("CaseID = %q, want %q", got.CaseID, "26051dbc3baa8f5091404c6aa5e45a1c")
+	got := BuildEntitySearchCallRequestsRequest("26051dbc3baa8f5091404c6aa5e45a1c", req)
+	if got.CaseID != "26051dbc-3baa-8f50-9140-4c6aa5e45a1c" {
+		t.Fatalf("CaseID = %q, want %q", got.CaseID, "26051dbc-3baa-8f50-9140-4c6aa5e45a1c")
 	}
 }
 

--- a/apps/customer-portal/backend-v2/internal/dto/deployed_product.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployed_product.go
@@ -154,19 +154,12 @@ type DeployedProductSearchRequest struct {
 
 // BuildEntitySearchDeployedProductsRequest translates the portal's search
 // request into entity-service's request shape, always scoping to the
-// deployment in the URL (normalized to a bare sysid) — never a client-settable
+// deployment in the URL (normalized to a canonical dashed UUID) — never a client-settable
 // body field (same reasoning as BuildEntitySearchCasesRequest's projectID parameter).
 func BuildEntitySearchDeployedProductsRequest(deploymentID string, req DeployedProductSearchRequest) entity.SearchDeployedProductsRequest {
-	sysID := ToSysID(deploymentID)
-	filters := &entity.DeployedProductFilters{
-		DeploymentIDs: []string{sysID},
-	}
-	if req.Filters != nil && len(req.Filters.ProductCategories) > 0 {
-		filters.ProductCategories = req.Filters.ProductCategories
-	}
 	return entity.SearchDeployedProductsRequest{
-		Pagination: req.Pagination,
-		Filters:    filters,
+		Pagination:    req.Pagination,
+		DeploymentIDs: []string{toDashedID(deploymentID)},
 	}
 }
 

--- a/apps/customer-portal/backend-v2/internal/dto/deployed_product_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployed_product_test.go
@@ -18,7 +18,6 @@ package dto
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
 	"time"
 
@@ -51,7 +50,7 @@ func TestToSysID(t *testing.T) {
 }
 
 func TestBuildEntitySearchDeployedProductsRequest(t *testing.T) {
-	t.Run("converts dashed UUID to sysid and sets filters", func(t *testing.T) {
+	t.Run("converts dashed UUID to canonical dashed UUID and sets root deploymentIds without filters", func(t *testing.T) {
 		req := DeployedProductSearchRequest{
 			Pagination: entity.Pagination{Limit: 10, Offset: 0},
 			Filters: &DeployedProductSearchFilters{
@@ -60,15 +59,9 @@ func TestBuildEntitySearchDeployedProductsRequest(t *testing.T) {
 		}
 		got := BuildEntitySearchDeployedProductsRequest("4e8431b1-1b8c-0310-0bb3-da47b04bcba6", req)
 
-		if got.Filters == nil {
-			t.Fatal("expected Filters to be non-nil")
-		}
-		expectedSysID := "4e8431b11b8c03100bb3da47b04bcba6"
-		if len(got.Filters.DeploymentIDs) != 1 || got.Filters.DeploymentIDs[0] != expectedSysID {
-			t.Errorf("got DeploymentIDs = %v, want [%s]", got.Filters.DeploymentIDs, expectedSysID)
-		}
-		if !reflect.DeepEqual(got.Filters.ProductCategories, []string{"Integration"}) {
-			t.Errorf("got ProductCategories = %v, want [Integration]", got.Filters.ProductCategories)
+		expectedDashedID := "4e8431b1-1b8c-0310-0bb3-da47b04bcba6"
+		if len(got.DeploymentIDs) != 1 || got.DeploymentIDs[0] != expectedDashedID {
+			t.Errorf("got DeploymentIDs = %v, want [%s]", got.DeploymentIDs, expectedDashedID)
 		}
 
 		data, err := json.Marshal(got)
@@ -79,31 +72,23 @@ func TestBuildEntitySearchDeployedProductsRequest(t *testing.T) {
 		if err := json.Unmarshal(data, &raw); err != nil {
 			t.Fatalf("json.Unmarshal failed: %v", err)
 		}
-		if _, hasRootDepID := raw["deploymentIds"]; hasRootDepID {
-			t.Errorf("expected no deploymentIds at root of serialized request, got: %v", raw)
+		if _, hasFilters := raw["filters"]; hasFilters {
+			t.Errorf("expected no filters object in serialized json, got: %v", raw)
 		}
-		filtersMap, ok := raw["filters"].(map[string]any)
-		if !ok {
-			t.Fatalf("expected filters object in serialized json, got: %v", raw)
-		}
-		if deps, ok := filtersMap["deploymentIds"].([]any); !ok || len(deps) != 1 || deps[0] != expectedSysID {
-			t.Errorf("expected filters.deploymentIds to contain %s, got: %v", expectedSysID, filtersMap["deploymentIds"])
+		deps, ok := raw["deploymentIds"].([]any)
+		if !ok || len(deps) != 1 || deps[0] != expectedDashedID {
+			t.Errorf("expected root deploymentIds to contain %s, got: %v", expectedDashedID, raw["deploymentIds"])
 		}
 	})
 
-	t.Run("bare sysid without category filters", func(t *testing.T) {
+	t.Run("bare sysid normalized to dashed UUID at root", func(t *testing.T) {
 		req := DeployedProductSearchRequest{
 			Pagination: entity.Pagination{Limit: 20, Offset: 10},
 		}
 		got := BuildEntitySearchDeployedProductsRequest("4e8431b11b8c03100bb3da47b04bcba6", req)
-		if got.Filters == nil {
-			t.Fatal("expected Filters to be non-nil")
-		}
-		if len(got.Filters.DeploymentIDs) != 1 || got.Filters.DeploymentIDs[0] != "4e8431b11b8c03100bb3da47b04bcba6" {
-			t.Errorf("got DeploymentIDs = %v", got.Filters.DeploymentIDs)
-		}
-		if len(got.Filters.ProductCategories) != 0 {
-			t.Errorf("expected empty ProductCategories, got %v", got.Filters.ProductCategories)
+		expectedDashedID := "4e8431b1-1b8c-0310-0bb3-da47b04bcba6"
+		if len(got.DeploymentIDs) != 1 || got.DeploymentIDs[0] != expectedDashedID {
+			t.Errorf("got DeploymentIDs = %v, want [%s]", got.DeploymentIDs, expectedDashedID)
 		}
 	})
 }

--- a/apps/customer-portal/backend-v2/internal/entity/call_requests.go
+++ b/apps/customer-portal/backend-v2/internal/entity/call_requests.go
@@ -23,10 +23,14 @@ import (
 	"strings"
 )
 
-// toSysID converts an identifier (either a dashed UUID or a 32-hex sysid)
-// to a 32-character lowercase hex string without hyphens.
-func toSysID(id string) string {
-	return strings.ToLower(strings.ReplaceAll(id, "-", ""))
+// toDashedID converts an identifier (either a dashed UUID or a 32-hex sysid)
+// to a canonical lowercase 8-4-4-4-12 dashed UUID string expected by entity-service.
+func toDashedID(id string) string {
+	clean := strings.ToLower(strings.ReplaceAll(id, "-", ""))
+	if len(clean) == 32 {
+		return clean[0:8] + "-" + clean[8:12] + "-" + clean[12:16] + "-" + clean[16:20] + "-" + clean[20:32]
+	}
+	return strings.ToLower(id)
 }
 
 // CreateCallRequest calls POST /call-requests.
@@ -34,7 +38,7 @@ func toSysID(id string) string {
 // NOTE: entity-service only supports call requests on its ServiceNow data
 // source — a Postgres-mode deployment 404s on every route in this file.
 func (c *Client) CreateCallRequest(ctx context.Context, req CreateCallRequestRequest) (CreateCallRequestResponse, error) {
-	req.CaseID = toSysID(req.CaseID)
+	req.CaseID = toDashedID(req.CaseID)
 	var out CreateCallRequestResponse
 	err := c.postJSON(ctx, "/call-requests", req, &out)
 	return out, err
@@ -42,7 +46,7 @@ func (c *Client) CreateCallRequest(ctx context.Context, req CreateCallRequestReq
 
 // SearchCallRequests calls POST /call-requests/search.
 func (c *Client) SearchCallRequests(ctx context.Context, req SearchCallRequestsRequest) (SearchCallRequestsResponse, error) {
-	req.CaseID = toSysID(req.CaseID)
+	req.CaseID = toDashedID(req.CaseID)
 	var out SearchCallRequestsResponse
 	err := c.postJSON(ctx, "/call-requests/search", req, &out)
 	return out, err
@@ -50,7 +54,7 @@ func (c *Client) SearchCallRequests(ctx context.Context, req SearchCallRequestsR
 
 // UpdateCallRequest calls PATCH /call-requests/{id}.
 func (c *Client) UpdateCallRequest(ctx context.Context, id string, req UpdateCallRequestRequest) (UpdateCallRequestResponse, error) {
-	id = toSysID(id)
+	id = toDashedID(id)
 	req.ID = id // never serialized (json:"-"); set for consistency with the struct's doc comment
 	var out UpdateCallRequestResponse
 	err := c.patchJSON(ctx, fmt.Sprintf("/call-requests/%s", url.PathEscape(id)), req, &out)

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -980,10 +980,10 @@ type DeployedProductFilters struct {
 }
 
 // SearchDeployedProductsRequest is the input for POST /deployed-products/search.
-// Filters is used by upstream services expecting a nested filters object (e.g. Ballerina customer-entity-service).
+// DeploymentIDs scopes results to the given deployments; it is the only filter besides pagination.
 type SearchDeployedProductsRequest struct {
-	Pagination Pagination              `json:"pagination"`
-	Filters    *DeployedProductFilters `json:"filters,omitempty"`
+	Pagination    Pagination `json:"pagination"`
+	DeploymentIDs []string   `json:"deploymentIds,omitempty"`
 }
 
 // DeployedProductVersionRef is the version sub-object in a DeployedProductView.

--- a/apps/customer-portal/backend-v2/internal/handler/attachment_id_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/attachment_id_test.go
@@ -75,6 +75,26 @@ func TestToSysID(t *testing.T) {
 	}
 }
 
+func TestToDashedID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"26051dbc-3baa-8f50-9140-4c6aa5e45a1c", "26051dbc-3baa-8f50-9140-4c6aa5e45a1c"},
+		{"26051DBC-3BAA-8F50-9140-4C6AA5E45A1C", "26051dbc-3baa-8f50-9140-4c6aa5e45a1c"},
+		{"26051dbc3baa8f5091404c6aa5e45a1c", "26051dbc-3baa-8f50-9140-4c6aa5e45a1c"},
+		{"26051DBC3BAA8F5091404C6AA5E45A1C", "26051dbc-3baa-8f50-9140-4c6aa5e45a1c"},
+		{"70d63bca3bd2031091404c6aa5e45a37", "70d63bca-3bd2-0310-9140-4c6aa5e45a37"},
+		{"70d63bca-3bd2-0310-9140-4c6aa5e45a37", "70d63bca-3bd2-0310-9140-4c6aa5e45a37"},
+		{"case-1", "case-1"},
+	}
+	for _, tc := range cases {
+		if got := toDashedID(tc.in); got != tc.want {
+			t.Errorf("toDashedID(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestIsUUIDOrSysID(t *testing.T) {
 	cases := map[string]struct {
 		id   string

--- a/apps/customer-portal/backend-v2/internal/handler/call_requests.go
+++ b/apps/customer-portal/backend-v2/internal/handler/call_requests.go
@@ -75,8 +75,8 @@ func (h *CallRequestHandler) CreateCallRequest(w http.ResponseWriter, r *http.Re
 	// CaseID is always forced to the {caseId} path parameter, never a
 	// client-supplied body field — the frontend's request body carries only
 	// reason/utcTimes/durationInMinutes, no caseId at all. Normalized to a
-	// 32-hex sys_id for entity-service.
-	req.CaseID = toSysID(caseID)
+	// canonical dashed UUID for entity-service.
+	req.CaseID = toDashedID(caseID)
 	if req.Reason == "" || len(req.UTCTimes) == 0 || req.DurationMinutes <= 0 {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
@@ -159,7 +159,7 @@ func (h *CallRequestHandler) PatchCallRequest(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	result, err := h.entity.UpdateCallRequest(r.Context(), toSysID(id), dto.BuildEntityUpdateCallRequestRequest(req))
+	result, err := h.entity.UpdateCallRequest(r.Context(), toDashedID(id), dto.BuildEntityUpdateCallRequestRequest(req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity UpdateCallRequest failed", "userID", user.UserID, "callRequestID", id, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to update call request.")

--- a/apps/customer-portal/backend-v2/internal/handler/case_attachments_call_requests_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/case_attachments_call_requests_test.go
@@ -118,7 +118,7 @@ func TestCreateCallRequest_CaseIDFromPath(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
 	}
-	wantCaseID := toSysID(testCaseID)
+	wantCaseID := toDashedID(testCaseID)
 	if fake.gotCreateReq.CaseID != wantCaseID {
 		t.Fatalf("CaseID = %q, want %q", fake.gotCreateReq.CaseID, wantCaseID)
 	}
@@ -144,7 +144,7 @@ func TestSearchCallRequests_CaseIDFromPath(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	wantCaseID := toSysID(testCaseID)
+	wantCaseID := toDashedID(testCaseID)
 	if fake.gotSearchReq.CaseID != wantCaseID {
 		t.Fatalf("CaseID = %q, want %q", fake.gotSearchReq.CaseID, wantCaseID)
 	}
@@ -189,7 +189,7 @@ func TestPatchCallRequest_ExtraCaseIDPathSegmentDoesNotBreakRouting(t *testing.T
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	wantID := toSysID(callRequestID)
+	wantID := toDashedID(callRequestID)
 	if body.ID != wantID {
 		t.Fatalf("id = %q, want %q (the {id} segment, not {caseId})", body.ID, wantID)
 	}
@@ -211,5 +211,16 @@ func TestPatchCallRequest_BareSysIDSupported(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	wantID := toDashedID(callRequestSysID)
+	if body.ID != wantID {
+		t.Fatalf("id = %q, want %q", body.ID, wantID)
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/handler/deployed_products_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployed_products_test.go
@@ -97,17 +97,17 @@ func TestSearchDeployedProducts_AcceptsUUIDAndBareSysID(t *testing.T) {
 	tests := []struct {
 		name         string
 		deploymentID string
-		wantSysID    string
+		wantDashedID string
 	}{
 		{
 			name:         "dashed UUID",
 			deploymentID: "4e8431b1-1b8c-0310-0bb3-da47b04bcba6",
-			wantSysID:    "4e8431b11b8c03100bb3da47b04bcba6",
+			wantDashedID: "4e8431b1-1b8c-0310-0bb3-da47b04bcba6",
 		},
 		{
 			name:         "bare 32-hex sysid",
 			deploymentID: "4e8431b11b8c03100bb3da47b04bcba6",
-			wantSysID:    "4e8431b11b8c03100bb3da47b04bcba6",
+			wantDashedID: "4e8431b1-1b8c-0310-0bb3-da47b04bcba6",
 		},
 	}
 
@@ -126,11 +126,8 @@ func TestSearchDeployedProducts_AcceptsUUIDAndBareSysID(t *testing.T) {
 				t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
 			}
 
-			if fake.gotSearch.Filters == nil {
-				t.Fatal("expected Filters to be non-nil")
-			}
-			if len(fake.gotSearch.Filters.DeploymentIDs) != 1 || fake.gotSearch.Filters.DeploymentIDs[0] != tc.wantSysID {
-				t.Errorf("got DeploymentIDs = %v, want [%s]", fake.gotSearch.Filters.DeploymentIDs, tc.wantSysID)
+			if len(fake.gotSearch.DeploymentIDs) != 1 || fake.gotSearch.DeploymentIDs[0] != tc.wantDashedID {
+				t.Errorf("got DeploymentIDs = %v, want [%s]", fake.gotSearch.DeploymentIDs, tc.wantDashedID)
 			}
 		})
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/response.go
+++ b/apps/customer-portal/backend-v2/internal/handler/response.go
@@ -53,6 +53,16 @@ func toSysID(id string) string {
 	return strings.ToLower(strings.ReplaceAll(id, "-", ""))
 }
 
+// toDashedID converts an identifier (either a dashed UUID or a 32-hex sysid)
+// to a canonical lowercase 8-4-4-4-12 dashed UUID string expected by entity-service.
+func toDashedID(id string) string {
+	clean := strings.ToLower(strings.ReplaceAll(id, "-", ""))
+	if len(clean) == 32 {
+		return clean[0:8] + "-" + clean[8:12] + "-" + clean[12:16] + "-" + clean[16:20] + "-" + clean[20:32]
+	}
+	return strings.ToLower(id)
+}
+
 // isUUIDOrSysID reports whether id is a valid UUID or bare 32-hex ServiceNow sysid.
 func isUUIDOrSysID(id string) bool {
 	return uuidRe.MatchString(id) || sysidRe.MatchString(id)


### PR DESCRIPTION
## Purpose
Fix runtime 400 Bad Request failures in deployed Customer Portal backend-v2:
1. Call requests fetch (`POST /cases/{caseId}/call-requests/search`) and create (`POST /cases/{caseId}/call-requests`) failed with:
   ```json
   {
     "message": "caseId contains invalid UUID: \"70d63bca3bd2031091404c6aa5e45a37\""
   }
   ```
2. Deployed products search (`POST /deployments/{deploymentId}/products/search`) failed with:
   ```json
   {
     "message": "unknown field \"filters\" in request body"
   }
   ```

## Goals
- Ensure call request search, create, and update requests pass canonical dashed UUID format (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`) to entity-service.
- Ensure deployed products search sends root `deploymentIds` instead of wrapping inside an unsupported `filters` object.
- Maintain compatibility with both dashed UUID and bare 32-hex ServiceNow sysid inputs from webapp routes.

## Approach
- **Call requests UUID normalization:**
  - `entity-service` requires `caseId` as a standard dashed UUID (`format: uuid`), validating it with `validateUUIDs` (`uuidRE`) before converting it internally to a 32-hex sysid for ServiceNow client calls.
  - Previously, backend-v2 called `toSysID` which stripped hyphens from `caseId`, sending 32-character bare hex strings that failed `entity-service`'s UUID regex check.
  - Introduced `toDashedID` to normalize both bare 32-hex sysids and dashed UUIDs into canonical lowercase dashed UUID strings (`clean[0:8] + "-" + clean[8:12] + "-" + clean[12:16] + "-" + clean[16:20] + "-" + clean[20:32]`).
  - Applied `toDashedID` in `internal/entity/call_requests.go`, `internal/dto/call_request.go`, and `internal/handler/call_requests.go`.
- **Deployed products search payload shape:**
  - `entity-service`'s `SearchDeployedProductsRequest` defines `deploymentIds []string` directly at root level alongside `pagination`, without any `filters` object (and `entity-service` decodes with `dec.DisallowUnknownFields()`).
  - Updated `SearchDeployedProductsRequest` in `internal/entity/types.go` and `BuildEntitySearchDeployedProductsRequest` in `internal/dto/deployed_product.go` to send `deploymentIds: []string{toDashedID(deploymentID)}` directly at root level.

## User stories
As a customer portal user, I can fetch and create call requests, and search deployed products on a deployment, without receiving 400 Bad Request errors.

## Release note
Fix call requests UUID normalization and deployed products search request payload shape in Customer Portal backend-v2.

## Documentation
N/A — internal API contract bugfix between Customer Portal backend-v2 and entity-service.

## Automation tests
- Unit tests:
  - `apps/customer-portal/backend-v2/internal/handler/attachment_id_test.go`: `TestToDashedID` and `TestToSysID` verify identifier normalization.
  - `apps/customer-portal/backend-v2/internal/handler/case_attachments_call_requests_test.go`: verifies `CreateCallRequest`, `SearchCallRequests`, and `PatchCallRequest` pass dashed UUIDs.
  - `apps/customer-portal/backend-v2/internal/dto/call_request_test.go`: verifies `BuildEntitySearchCallRequestsRequest` normalizes `CaseID` to dashed UUID.
  - `apps/customer-portal/backend-v2/internal/dto/deployed_product_test.go`: verifies `BuildEntitySearchDeployedProductsRequest` produces root `deploymentIds` without `filters`.
  - `apps/customer-portal/backend-v2/internal/handler/deployed_products_test.go`: verifies `SearchDeployedProducts` receives root `deploymentIds`.
  - `apps/customer-portal/webapp`: `useGetCallRequests` and `usePostCallRequest` vitest test suites passing.
  - `entity-service`: `CallRequestService` unit tests passing.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go service)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `go test -count=1 -race ./...` passing in `apps/customer-portal/backend-v2`
- `go vet ./...` passing in `apps/customer-portal/backend-v2`
