### PR TITLE
[CSM Portal] Fix closing last case tab navigating to listing page instead of prior route

### DIFF
--- a/apps/csm-portal/webapp/src/features/case-tabs/CaseTabsIntegration.test.tsx
+++ b/apps/csm-portal/webapp/src/features/case-tabs/CaseTabsIntegration.test.tsx
@@ -399,6 +399,60 @@ describe("case tabs — real BrowserRouter integration", () => {
     // doesn't close it.
     expect(screen.getByText("CS0001")).toBeInTheDocument();
   });
+
+  // Regression test: closing the LAST open case tab used to always land on
+  // that case type's list view (`basePathForKind`), even when the user had
+  // opened the tab from somewhere else entirely (the dashboard, in this
+  // test) — because `CaseTabsContentHost`'s close effect had no access to
+  // "where the user was before any case tab was opened"; only
+  // `CaseTabStripBar` tracked that (via `useCurrentLocationTab`), and the two
+  // components never shared it. Fixed by having `CaseTabsContentHost` read
+  // the same hook itself (see that component's own doc comment for why the
+  // two instances are always in lockstep) and fall back to its tracked path
+  // instead of `basePathForKind` when no tab remains active.
+  it("closing the last open case tab returns to the route live before any case tab opened, not the case-type list view", async () => {
+    sessionStorage.clear();
+    function AppWithDashboard() {
+      window.history.pushState({}, "", "/dashboard");
+      return (
+        <BrowserRouter>
+          <ErrorBannerProvider>
+            <CaseTabsBehaviorProvider>
+              <CaseTabsProvider>
+                <NavigateButton to="/cases/CS0001" label="go-to-cs0001" />
+                <CaseTabStripBar />
+                <CaseTabsContentHost />
+                <Routes>
+                  <Route path="/dashboard" element={<div>stub-dashboard</div>} />
+                  <Route path="/cases" element={<div>stub-case-list</div>} />
+                  <Route path="/cases/:caseId" element={<CaseDetailRouteSync kind="case" />} />
+                </Routes>
+              </CaseTabsProvider>
+            </CaseTabsBehaviorProvider>
+          </ErrorBannerProvider>
+        </BrowserRouter>
+      );
+    }
+    render(<AppWithDashboard />);
+    expect(screen.getByText("stub-dashboard")).toBeInTheDocument();
+
+    // Open the only case tab from the dashboard — never visiting the case
+    // list at all in this test, so a fallback to it (rather than back to the
+    // dashboard) would be unambiguously wrong, not just "a" plausible page.
+    fireEvent.click(screen.getByText("go-to-cs0001"));
+    await waitFor(() =>
+      expect(screen.getByTestId("stub-page-case-id")).toHaveTextContent("CS0001"),
+    );
+    expect(screen.getAllByRole("tab")).toHaveLength(2);
+
+    // Close that one and only case tab (the pinned "current location" tab
+    // isn't closable, so this is the sole `CancelIcon`).
+    fireEvent.click(screen.getByTestId("CancelIcon"));
+
+    await waitFor(() => expect(window.location.pathname).toBe("/dashboard"));
+    expect(screen.getByText("stub-dashboard")).toBeInTheDocument();
+    expect(screen.queryByText("stub-case-list")).not.toBeInTheDocument();
+  });
 });
 
 /**

--- a/apps/csm-portal/webapp/src/features/case-tabs/components/CaseTabsWorkspace.tsx
+++ b/apps/csm-portal/webapp/src/features/case-tabs/components/CaseTabsWorkspace.tsx
@@ -118,22 +118,35 @@ export function CaseTabStripBar(): JSX.Element | null {
  * route.
  *
  * Also owns closing a tab whose current route is the one just closed:
- * navigates to whatever tab became active, or that case type's list view if
- * none are left open. Deliberately does NOT do this for a case that was
- * simply never opened as a tab at all (the open-tab-cap fallback in
- * `CaseDetailRouteSync`, rendered un-tabbed via the real `<Outlet/>`) — an
- * earlier version of this effect couldn't tell those two situations apart
- * (both look like "no tab backs the current route") and silently redirected
- * a just-clicked, cap-blocked case's URL back to whatever tab happened to be
- * active, which looked like the click had done nothing. Distinguishing them
- * needs the PREVIOUS render's open caseIds, not just tab ids: a genuinely
- * closed tab's caseId was in that set; a never-opened (blocked) one never
- * was.
+ * navigates to whatever tab became active, or — when that was the last open
+ * tab — back to wherever the user was before any case tab was opened (the
+ * dashboard, a listing page, admin, ...), via the SAME `useCurrentLocationTab`
+ * that backs the pinned tab in `CaseTabStripBar`. Falls back to that case
+ * type's list view (`basePathForKind`) only in the (practically unreachable)
+ * case `useCurrentLocationTab` never recorded a prior non-case location at
+ * all — see that hook's own doc comment for why it always has SOME value
+ * (defaulting to `/dashboard`) once mounted. Deliberately does NOT do this
+ * for a case that was simply never opened as a tab at all (the open-tab-cap
+ * fallback in `CaseDetailRouteSync`, rendered un-tabbed via the real
+ * `<Outlet/>`) — an earlier version of this effect couldn't tell those two
+ * situations apart (both look like "no tab backs the current route") and
+ * silently redirected a just-clicked, cap-blocked case's URL back to
+ * whatever tab happened to be active, which looked like the click had done
+ * nothing. Distinguishing them needs the PREVIOUS render's open caseIds, not
+ * just tab ids: a genuinely closed tab's caseId was in that set; a
+ * never-opened (blocked) one never was.
+ *
+ * Reads `useCurrentLocationTab` itself (rather than only `CaseTabStripBar`
+ * doing so) specifically so this effect has access to "the last non-case
+ * location" independent of the tab strip's own render — both components are
+ * mounted for the same lifetime (see `AppLayout`), so the two hook instances
+ * always observe the identical sequence of navigations and stay in lockstep.
  */
 export function CaseTabsContentHost(): JSX.Element | null {
   const location = useLocation();
   const navigate = useNavTransition();
   const { tabs, activeTabId } = useCaseTabsController();
+  const currentLocationTab = useCurrentLocationTab();
 
   const currentMatch = matchCaseLocation(location.pathname);
   // Whether a tab actually backs the CURRENT route's specific case — not
@@ -158,10 +171,17 @@ export function CaseTabsContentHost(): JSX.Element | null {
     const wasOpenForThisCase = prevCaseIds.has(currentMatch.caseId);
     if (!wasOpenForThisCase) return;
     const nextActive = tabs.find((t) => t.id === activeTabId);
-    navigate(nextActive ? nextActive.path : basePathForKind(currentMatch.kind), {
-      replace: true,
-    });
-    // Only re-run when the open tab set or the route changes.
+    navigate(
+      nextActive
+        ? nextActive.path
+        : currentLocationTab.path || basePathForKind(currentMatch.kind),
+      { replace: true },
+    );
+    // Only re-run when the open tab set or the route changes — deliberately
+    // NOT on every `currentLocationTab` change (it updates on every non-case
+    // navigation): this effect only needs its LATEST value at the moment a
+    // tab actually closes, not to re-fire whenever the user is simply
+    // browsing non-case pages with tabs open in the background.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabs, currentMatch?.caseId, activeRouteHasTab]);
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Closing the last open case tab in the CSM portal's tab strip navigated to a hardcoded
listing page for that case type, instead of returning the user to wherever they actually
were before opening any case tab (dashboard, a filtered listing view, etc.).

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Closing the last case tab now returns the user to the route that was live before any case
tab was opened.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

`CaseTabsContentHost`'s close-effect always fell back to `basePathForKind(currentMatch.kind)`
whenever no tab remained active after a close. The value it should have used instead —
`useCurrentLocationTab`'s tracked "last non-case location" — was already being computed, but
only ever read by the sibling `CaseTabStripBar` component; `CaseTabsContentHost` never called
the hook itself.

Fix: have `CaseTabsContentHost` call `useCurrentLocationTab` too. Both components are mounted
for the same lifetime under `CaseTabsProvider`, so the two hook instances observe the identical
navigation history and stay in lockstep, without needing to hoist the tracked state into a
shared context. Falls back to `basePathForKind` only if that hook's own tracked location was
somehow never set.

No UI change — this is a pure navigation-target fix, no visible surface change.

## User stories
> Summary of user stories addressed by this change

As a CS engineer working from the dashboard or a case listing, when I open a case in a new
tab and then close it, I land back on the page I was on, not a case-type listing page.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fix: closing the last open case tab now returns to the page you were on before opening it,
instead of a case-type listing page.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal navigation behavior fix, no user-facing flow, field, or nav item changed.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — bug fix, no marketing impact.

## Automation tests
 - Unit tests
   > Code coverage information

Added a regression test (`CaseTabsIntegration.test.tsx`) exercising the real `BrowserRouter`,
`CaseTabsProvider`, `CaseDetailRouteSync`, `CaseTabStripBar`, and `CaseTabsContentHost`
together: opens a case tab from the dashboard, closes it, asserts the URL returns to
`/dashboard` rather than the case list. Verified the test fails against the pre-fix code
(`Expected "/dashboard", Received "/cases"`) and passes with the fix.

 - Integration tests
   > Details about the test cases and coverage

`npx vitest run src/features/case-tabs src/context/case-tabs` — 9 files, 94/94 tests pass
(93 pre-existing + 1 new).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A — UI navigation logic only, no security-sensitive surface touched
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React project, not applicable
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema or data migration involved

## Test environment
`npm run build` (tsc -b && vite build) and `npx eslint` verified locally; no dedicated
browser/OS/DB matrix run for this change.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing the final open case tab now returns you to the last non-case location, such as the dashboard, instead of always opening the case list.
  * Added regression coverage to verify the updated navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->